### PR TITLE
docs: Record PR #14/#15 merge results

### DIFF
--- a/docs/recovery/HANDOFF.md
+++ b/docs/recovery/HANDOFF.md
@@ -8,7 +8,7 @@ Last updated: 2026-07-20 KST
 - Current phase: `P0-A` — 애니메이션 계약과 golden fixture 확립 (P0-D is `DONE`; P0-A is the next `READY` phase per `docs/recovery/ROADMAP.md`)
 - Phase document: `docs/recovery/phases/P0-A-animation-contract.md`
 - Base branch: `main`
-- Handoff delivery: PR pending from `codex/p0d-merge-cleanup`; this section is updated with the PR number once opened
+- Handoff delivery: [PR #16](https://github.com/landfill/ClairKeys/pull/16) from `codex/p0d-merge-cleanup`; consult GitHub and `docs/recovery/reviews/PR-16.md` for its live review state
 - Completed pull request: [#14](https://github.com/landfill/ClairKeys/pull/14) — `MERGED` at `05c70df` (P0-D handoff closeout); [#15](https://github.com/landfill/ClairKeys/pull/15) — `MERGED` at `992615f` (agent contract consolidation, `CLAUDE.md` reduced to a pointer at `AGENTS.md`)
 - Superseded pull request: [#11](https://github.com/landfill/ClairKeys/pull/11) — `CLOSED`
 - Current objective: start P0-A on a fresh `codex/p0-animation-contract` branch; P0-D no longer blocks it.
@@ -54,4 +54,4 @@ P0-A는 파일 범위가 겹치지 않으면 P0-D와 병렬로 시작할 수 있
 2. P0-B: MusicXML 박자/voice/staff/backup 변환 정확도
 3. P0-C: AudioContext 기준 시계와 애니메이션 동기화
 
-새 세션은 `docs/recovery/ROADMAP.md`, 현재 phase 문서(`P0-A-animation-contract.md`), 이 HANDOFF 순서로 읽는다. P0-D는 `DONE`이며 PR #14·#15 모두 병합되어 이 섹션의 "Handoff delivery"가 다음 PR로 갱신되기 전까지는 별도로 확인할 live PR이 없다. `docs/recovery/reviews/PR-12.md`, `PR-14.md`, `PR-15.md`는 품질 게이트·규약 복구의 역사적 근거로만 참조한다.
+새 세션은 `docs/recovery/ROADMAP.md`, 현재 phase 문서(`P0-A-animation-contract.md`), 이 HANDOFF, `docs/recovery/reviews/PR-16.md` 순서로 읽고 GitHub에서 PR #16의 live state를 확인한다. P0-D는 `DONE`이며 PR #14·#15는 이미 병합됐다. PR #16이 이미 병합됐다면 P0-A를 다음 작업으로 진행한다. `docs/recovery/reviews/PR-12.md`, `PR-14.md`, `PR-15.md`는 품질 게이트·규약 복구의 역사적 근거로만 참조한다.

--- a/docs/recovery/HANDOFF.md
+++ b/docs/recovery/HANDOFF.md
@@ -8,24 +8,25 @@ Last updated: 2026-07-20 KST
 - Current phase: `P0-A` — 애니메이션 계약과 golden fixture 확립 (P0-D is `DONE`; P0-A is the next `READY` phase per `docs/recovery/ROADMAP.md`)
 - Phase document: `docs/recovery/phases/P0-A-animation-contract.md`
 - Base branch: `main`
-- Handoff delivery: [PR #14](https://github.com/landfill/ClairKeys/pull/14) from `codex/p0d-handoff-closeout`; consult GitHub and `docs/recovery/reviews/PR-14.md` for its live review state
-- Completed pull request: [#12](https://github.com/landfill/ClairKeys/pull/12) — `MERGED` at `271f4c6` (P0-D quality gates)
+- Handoff delivery: PR pending from `codex/p0d-merge-cleanup`; this section is updated with the PR number once opened
+- Completed pull request: [#14](https://github.com/landfill/ClairKeys/pull/14) — `MERGED` at `05c70df` (P0-D handoff closeout); [#15](https://github.com/landfill/ClairKeys/pull/15) — `MERGED` at `992615f` (agent contract consolidation, `CLAUDE.md` reduced to a pointer at `AGENTS.md`)
 - Superseded pull request: [#11](https://github.com/landfill/ClairKeys/pull/11) — `CLOSED`
 - Current objective: start P0-A on a fresh `codex/p0-animation-contract` branch; P0-D no longer blocks it.
 
 ## Latest verified result
 
 - P0-D is `DONE`. `docs/recovery/phases/P0-D-quality-gates.md` records all four completion criteria met.
-- Issue [#7](https://github.com/landfill/ClairKeys/issues/7) is `CLOSED`: PR #12 replaced the aspirational `piano-player.spec.ts`/`sheet-music-workflow.spec.ts` (dashboard/auth fixtures absent from the product) with `e2e/application-smoke.spec.ts`, 15 cross-browser public-route smoke checks. The `E2E Tests` check passed both on PR #12's own merge commit `271f4c6` and on current `main` HEAD `5ec5e84` (PR #13's merge commit).
+- Issue [#7](https://github.com/landfill/ClairKeys/issues/7) is `CLOSED`: PR #12 replaced the aspirational `piano-player.spec.ts`/`sheet-music-workflow.spec.ts` (dashboard/auth fixtures absent from the product) with `e2e/application-smoke.spec.ts`, 15 cross-browser public-route smoke checks. The `E2E Tests` check has passed on every subsequent `main` HEAD checked, including PR #12's own merge commit `271f4c6`.
 - Issue [#9](https://github.com/landfill/ClairKeys/issues/9) is `CLOSED`: `main` branch protection is configured with required status checks `Lint`, `Security Audit`, `Run Tests`, `E2E Tests` (`strict: false`, `enforce_admins: false`). `gh api repos/landfill/ClairKeys/branches/main/protection` confirms this (previously `404 Branch not protected`). The agent's write attempt was blocked by the local auto-mode classifier as a repository-admin action; the user applied the payload directly via `gh api -X PUT`.
 - Whether to additionally require pull requests / forbid direct pushes to `main` (issue #9's fourth checklist item) remains an explicit open decision, not yet made.
-- On `main` HEAD `5ec5e84` (PR #13's merge commit, distinct from PR #12's `271f4c6`), `Build application`, `E2E Tests`, `Test before deploy`, `Run Tests`, `Lint`, and `Security Audit` passed. `Run database migrations`, `Deploy to production`, and `Notify deployment status` failed and still have no dedicated GitHub issue.
-- Full evidence: `docs/recovery/validation/2026-07-20-p0d-branch-protection-and-issue-closeout.md`.
+- PR #14 (P0-D closeout docs) and PR #15 (agent contract consolidation: sibling-project practices adopted into `AGENTS.md`/`WORKFLOW.md`/`LORE_COMMIT_PROTOCOL.md`, `CLAUDE.md` reduced to a pointer) were both merged with the user's explicit approval, checked out clean at merge time, and had their remote/local work branches deleted only after confirming both tips were included in updated `main`.
+- Full evidence: `docs/recovery/validation/2026-07-20-p0d-branch-protection-and-issue-closeout.md`; PR review logs at `docs/recovery/reviews/PR-14.md` and `docs/recovery/reviews/PR-15.md`.
+- OBSERVED (pre-existing, unrelated to this session's changes): the merge commit's `Run database migrations`, `Deploy to production`, and `Notify deployment status` jobs have been failing since before this session and still have no dedicated GitHub issue.
 
 ## Next actions
 
 1. Start P0-A (`docs/recovery/phases/P0-A-animation-contract.md`) on a new `codex/p0-animation-contract` branch from the latest `main`.
-2. Open a dedicated GitHub issue for the post-merge `Run database migrations` / `Deploy to production` / `Notify deployment status` failures observed on `5ec5e84`.
+2. Open a dedicated GitHub issue for the post-merge `Run database migrations` / `Deploy to production` / `Notify deployment status` failures.
 3. If the direct-push policy for `main` is decided, extend the branch protection payload with `required_pull_request_reviews` / `restrictions` accordingly.
 
 ## Existing user-owned working tree changes
@@ -53,4 +54,4 @@ P0-A는 파일 범위가 겹치지 않으면 P0-D와 병렬로 시작할 수 있
 2. P0-B: MusicXML 박자/voice/staff/backup 변환 정확도
 3. P0-C: AudioContext 기준 시계와 애니메이션 동기화
 
-새 세션은 `docs/recovery/ROADMAP.md`, 현재 phase 문서(`P0-A-animation-contract.md`), 이 HANDOFF, `docs/recovery/reviews/PR-14.md` 순서로 읽고 GitHub에서 PR #14의 live state를 확인한다. P0-D는 `DONE`이므로 더 이상 선행 조건이 아니며, `docs/recovery/reviews/PR-12.md`는 품질 게이트 복구의 역사적 근거로만 참조한다.
+새 세션은 `docs/recovery/ROADMAP.md`, 현재 phase 문서(`P0-A-animation-contract.md`), 이 HANDOFF 순서로 읽는다. P0-D는 `DONE`이며 PR #14·#15 모두 병합되어 이 섹션의 "Handoff delivery"가 다음 PR로 갱신되기 전까지는 별도로 확인할 live PR이 없다. `docs/recovery/reviews/PR-12.md`, `PR-14.md`, `PR-15.md`는 품질 게이트·규약 복구의 역사적 근거로만 참조한다.

--- a/docs/recovery/HANDOFF.md
+++ b/docs/recovery/HANDOFF.md
@@ -9,7 +9,9 @@ Last updated: 2026-07-20 KST
 - Phase document: `docs/recovery/phases/P0-A-animation-contract.md`
 - Base branch: `main`
 - Handoff delivery: [PR #16](https://github.com/landfill/ClairKeys/pull/16) from `codex/p0d-merge-cleanup`; consult GitHub and `docs/recovery/reviews/PR-16.md` for its live review state
-- Completed pull request: [#14](https://github.com/landfill/ClairKeys/pull/14) — `MERGED` at `05c70df` (P0-D handoff closeout); [#15](https://github.com/landfill/ClairKeys/pull/15) — `MERGED` at `992615f` (agent contract consolidation, `CLAUDE.md` reduced to a pointer at `AGENTS.md`)
+- Completed pull requests:
+  - [#14](https://github.com/landfill/ClairKeys/pull/14) — `MERGED` at `05c70df` (P0-D handoff closeout)
+  - [#15](https://github.com/landfill/ClairKeys/pull/15) — `MERGED` at `992615f` (agent contract consolidation, `CLAUDE.md` reduced to a pointer at `AGENTS.md`)
 - Superseded pull request: [#11](https://github.com/landfill/ClairKeys/pull/11) — `CLOSED`
 - Current objective: start P0-A on a fresh `codex/p0-animation-contract` branch; P0-D no longer blocks it.
 

--- a/docs/recovery/reviews/PR-14.md
+++ b/docs/recovery/reviews/PR-14.md
@@ -3,7 +3,7 @@
 PR URL: https://github.com/landfill/ClairKeys/pull/14
 Branch: `codex/p0d-handoff-closeout`
 Base: `main`
-State: `READY_FOR_REVIEW`
+State: `MERGED` at `05c70df`
 Last checked: 2026-07-20 KST
 
 ## Scope
@@ -43,3 +43,10 @@ Last checked: 2026-07-20 KST
 - Codex's automated review comment contained no findings, only its standard "how to use Codex review" boilerplate.
 - Accepted and fixed R1 and R2 in `8387ebf`.
 - Remaining action: confirm hosted checks stay green on `8387ebf` and wait for the user's explicit merge approval before merging to `main`.
+
+### Iteration 3
+
+- User gave explicit merge approval ("병합하라").
+- Re-verified immediately before merging: `mergeStateStatus: CLEAN`, `mergeable: MERGEABLE`, all required checks `SUCCESS` on head `9da1a37`.
+- Merged with `gh pr merge 14 --merge` (merge commit, matching this repo's existing convention) at `05c70df`.
+- After both PR #14 and PR #15 merged, fetched remote refs and confirmed both branches' local and remote tips were fully contained in updated `main` before deleting either; deleted `origin/codex/p0d-handoff-closeout` and the local branch, then fast-forwarded local `main`.

--- a/docs/recovery/reviews/PR-15.md
+++ b/docs/recovery/reviews/PR-15.md
@@ -3,7 +3,7 @@
 PR URL: https://github.com/landfill/ClairKeys/pull/15
 Branch: `codex/p0d-agents-contract-hardening`
 Base: `main`
-State: `READY_FOR_REVIEW`, mergeable, review loop clean
+State: `MERGED` at `992615f`
 Last checked: 2026-07-20 KST
 
 ## Scope
@@ -61,3 +61,10 @@ Last checked: 2026-07-20 KST
 - Codex posted one more automated comment (on `686c98c`) with no findings, only boilerplate.
 - No new Gemini review; R1 is fixed and no other review item is open.
 - PR #15 is `READY_FOR_REVIEW`, mergeable, and its review loop is clean per `docs/recovery/WORKFLOW.md` section 5. Waiting on the user's explicit merge approval.
+
+### Iteration 5
+
+- User gave explicit merge approval ("병합하라").
+- Re-verified immediately before merging: `mergeStateStatus: CLEAN`, `mergeable: MERGEABLE`, all required checks `SUCCESS` on head `5e5b89c`.
+- Merged with `gh pr merge 15 --merge` (merge commit) after PR #14, at `992615f`; no conflict since PR #14 and PR #15 touched disjoint file sets.
+- Fetched remote refs and confirmed both branches' local and remote tips were fully contained in updated `main` before deleting either; deleted `origin/codex/p0d-agents-contract-hardening` and the local branch, then fast-forwarded local `main`.

--- a/docs/recovery/reviews/PR-16.md
+++ b/docs/recovery/reviews/PR-16.md
@@ -3,7 +3,7 @@
 PR URL: https://github.com/landfill/ClairKeys/pull/16
 Branch: `codex/p0d-merge-cleanup`
 Base: `main`
-State: `READY_FOR_REVIEW`
+State: `READY_FOR_REVIEW`, mergeable, review loop clean
 Last checked: 2026-07-20 KST
 
 ## Scope
@@ -39,3 +39,9 @@ Last checked: 2026-07-20 KST
 - Gemini Code Assist commented with R1, a minor but valid readability suggestion.
 - Accepted and fixed R1.
 - Remaining action: confirm hosted checks stay green and wait for the user's explicit merge approval before merging to `main`.
+
+### Iteration 3
+
+- Hosted checks passed on final head `7545397`: `Lint`, `Run Tests`, `Security Audit`, `E2E Tests`, `All Checks Complete`, `PR Summary`, Vercel, CodeRabbit.
+- No new review comments since R1's fix.
+- PR #16 is `READY_FOR_REVIEW`, mergeable, and its review loop is clean per `docs/recovery/WORKFLOW.md` section 5. Waiting on the user's explicit merge approval.

--- a/docs/recovery/reviews/PR-16.md
+++ b/docs/recovery/reviews/PR-16.md
@@ -1,0 +1,32 @@
+# PR Review Log — PR #16
+
+PR URL: https://github.com/landfill/ClairKeys/pull/16
+Branch: `codex/p0d-merge-cleanup`
+Base: `main`
+State: `READY_FOR_REVIEW`
+Last checked: 2026-07-20 KST
+
+## Scope
+
+- Record PR #14 and PR #15's merge SHAs (`05c70df`, `992615f`) in `docs/recovery/HANDOFF.md`, replacing the stale pre-merge delivery reference.
+- Set `docs/recovery/reviews/PR-14.md` and `PR-15.md` `State` to `MERGED` with a final iteration each recording the pre-merge re-verification and branch cleanup.
+- No application code, no phase/ROADMAP changes.
+
+## CI status
+
+| Check | Status | Last evidence |
+|---|---|---|
+| Documentation diff | PASS | `git diff --check` on all three changed files |
+| Hosted PR checks | PENDING | not yet observed |
+
+## Review items
+
+None yet.
+
+## Iteration log
+
+### Iteration 1
+
+- Created PR #16 from `codex/p0d-merge-cleanup` to `main`, ready for review from creation.
+- This branch exists specifically to record PR #14/#15's merge results per `docs/recovery/WORKFLOW.md` step 8 ("병합 결과와 다음 단계를 프로젝트 내부 HANDOFF·phase·validation·review 기록에 남긴 뒤 다음 단계용 새 브랜치를 만든다").
+- Remaining action: refresh hosted checks, update `HANDOFF.md`'s handoff-delivery line with this PR number, and process any review feedback.

--- a/docs/recovery/reviews/PR-16.md
+++ b/docs/recovery/reviews/PR-16.md
@@ -16,12 +16,14 @@ Last checked: 2026-07-20 KST
 
 | Check | Status | Last evidence |
 |---|---|---|
-| Documentation diff | PASS | `git diff --check` on all three changed files |
-| Hosted PR checks | PENDING | not yet observed |
+| Documentation diff | PASS | `git diff --check` on all changed files |
+| Hosted PR checks | PASS | head `34a1eda`: `Lint`, `Run Tests`, `Security Audit`, `E2E Tests`, `All Checks Complete`, `PR Summary`, Vercel, CodeRabbit all passed |
 
 ## Review items
 
-None yet.
+| ID | Source | File/line | Summary | Decision | Status | Commit/evidence |
+|---|---|---|---|---|---|---|
+| R1 | Gemini Code Assist | `docs/recovery/HANDOFF.md`, `Completed pull request` line | listing PR #14 and #15 on one semicolon-joined line reads poorly; suggested a nested list and a pluralized header | accept | FIXED | reformatted as `Completed pull requests:` with one nested bullet per PR |
 
 ## Iteration log
 
@@ -30,3 +32,10 @@ None yet.
 - Created PR #16 from `codex/p0d-merge-cleanup` to `main`, ready for review from creation.
 - This branch exists specifically to record PR #14/#15's merge results per `docs/recovery/WORKFLOW.md` step 8 ("병합 결과와 다음 단계를 프로젝트 내부 HANDOFF·phase·validation·review 기록에 남긴 뒤 다음 단계용 새 브랜치를 만든다").
 - Remaining action: refresh hosted checks, update `HANDOFF.md`'s handoff-delivery line with this PR number, and process any review feedback.
+
+### Iteration 2
+
+- Hosted checks passed on head `34a1eda`: `Lint`, `Run Tests`, `Security Audit`, `E2E Tests`, `All Checks Complete`, `PR Summary`, Vercel, CodeRabbit.
+- Gemini Code Assist commented with R1, a minor but valid readability suggestion.
+- Accepted and fixed R1.
+- Remaining action: confirm hosted checks stay green and wait for the user's explicit merge approval before merging to `main`.


### PR DESCRIPTION
## Purpose

PR #14 (P0-D handoff closeout) and PR #15 (agent contract consolidation) were both merged with the user's explicit approval. This records the merge results in the durable HANDOFF and review logs, since WORKFLOW.md's rule against fixing PR-local transient state (`OPEN`/ready) in HANDOFF meant those files still pointed at PR #14 as pending and both review logs still said `READY_FOR_REVIEW`.

## Scope

- `docs/recovery/HANDOFF.md`: replace the stale PR #14 delivery reference with the actual merge SHAs of PR #14 (`05c70df`) and PR #15 (`992615f`); note both work branches were deleted only after confirming their tips landed in `main`.
- `docs/recovery/reviews/PR-14.md` / `PR-15.md`: `State` → `MERGED`; added a final iteration recording the pre-merge re-verification and branch cleanup.
- No application code, no further phase/ROADMAP state changes.

## Verification

- `gh pr view --json mergeStateStatus,mergeable,statusCheckRollup` was `CLEAN`/`MERGEABLE` with all required checks green on both PRs immediately before merging.
- `git merge-base --is-ancestor` confirmed both local and remote tips of both work branches were contained in updated `main` before either branch was deleted.
- `git diff --check` clean.

## Rollback

Revert; log-only, no functional or application-code impact.