### PR TITLE
Play long scores past the 10-second audio cliff (#18)

### DIFF
--- a/docs/recovery/DECISIONS.md
+++ b/docs/recovery/DECISIONS.md
@@ -46,3 +46,13 @@
 - Reason: GitHub Actions가 이미 `main/develop`을 대상으로 하므로 실제 기본 브랜치 `master`와의 불일치를 제거한다.
 - Constraint: PR #1의 기준선·리뷰 로그에 기록된 `master`는 역사적 사실이므로 소급 수정하지 않는다.
 - Directive: DOC-1 완료 후 `master`에서 새 작업 브랜치를 만들거나 PR base로 사용하지 않는다.
+
+## D-007: P0-C 오디오 스케줄러 버그를 P0-A·P0-B보다 먼저 착수한다
+
+- Date: 2026-07-21
+- Status: Accepted
+- Decision: `ROADMAP.md`상 P0-C는 P0-A·P0-B에 의존하지만, 이슈 [#18](https://github.com/landfill/ClairKeys/issues/18)("긴 곡의 오디오가 앞 10초만 재생됨")의 rolling look-ahead scheduler 작업(P0-C Work stages 1~3)을 선행 착수한다.
+- Reason: 이 결함은 canonical animation contract(P0-A) 정립 여부와 무관하게 현재 `FallingNote[]` 타임라인에서 사용자가 실제로 겪는 재생 버그다. `src/hooks/useFallingNotesAudio.ts:111`의 `relativeStart > 10` 상한과, `scheduleAudio`가 재생 중 재호출되지 않는 one-shot 구조가 원인이며, P0-A/P0-B의 산출물을 기다릴 이유가 없다.
+- Constraint: 스케줄 대상 판단은 AudioContext와 무관한 순수 함수(`src/utils/audioScheduler.ts`의 `selectNotesInWindow`)로 분리해, 10초 이후 음표 선택을 오실레이터 모킹 없이 회귀 테스트한다. 이는 D-002(단일 애니메이션 계약)·D-003(변환/재생 검증 분리)과 충돌하지 않는다 — 스케줄러는 계약 필드명을 바꾸지 않고 기존 `FallingNote` 타임라인을 그대로 소비한다.
+- Directive: 이후 P0-A/P0-B가 계약을 확정하더라도, 스케줄러는 `FallingNote`의 `start`/`duration`/`midi`/`velocity`만 읽으므로 그 필드 의미가 유지되는 한 재작업이 필요 없다. P0-C의 나머지 Work stages(4: 시각화·키 활성화 동일 시계 고정, 5: 장시간 drift 측정)는 이 착수 범위에 포함하지 않으며 별도로 남는다.
+- Related: 이슈 #18, `docs/recovery/phases/P0-C-playback-sync.md`

--- a/src/hooks/useFallingNotesAudio.ts
+++ b/src/hooks/useFallingNotesAudio.ts
@@ -212,7 +212,9 @@ export function useFallingNotesAudio() {
     const win = nextScheduleWindow(songNow, scheduleCursorRef.current, tempoScale)
     if (!win) return
 
-    scheduleWindow(win.from, win.to, false)
+    // On a delayed tick the window skips the overdue range; re-articulate a note
+    // still sounding at the new playhead instead of dropping it silently.
+    scheduleWindow(win.from, win.to, win.skippedStale)
     scheduleCursorRef.current = win.cursor
   }, [scheduleWindow])
 

--- a/src/hooks/useFallingNotesAudio.ts
+++ b/src/hooks/useFallingNotesAudio.ts
@@ -3,6 +3,12 @@
 import { useRef, useCallback, useEffect } from 'react'
 import type { FallingNote } from '@/types/fallingNotes'
 import { midiToFreq } from '@/utils/pianoLayout'
+import {
+  selectNotesInWindow,
+  nextScheduleWindow,
+  TICK_MS,
+  VOICE_LIMIT,
+} from '@/utils/audioScheduler'
 
 /**
  * Audio nodes for a single note
@@ -11,11 +17,20 @@ interface AudioNodes {
   osc: OscillatorNode
   gain: GainNode
   lp: BiquadFilterNode
+  /** AudioContext time at which this voice fully finishes (after release). */
+  end: number
 }
 
 /**
  * Hook for managing audio playback with falling notes visualization
- * Provides precise AudioContext-based timing for synchronization
+ * Provides precise AudioContext-based timing for synchronization.
+ *
+ * Scheduling uses a rolling look-ahead model (see `@/utils/audioScheduler`): a
+ * timer advances a cursor through song time and keeps the next
+ * `SCHEDULE_AHEAD_SEC` of audio queued. This replaces the previous one-shot
+ * scheduler that only ever scheduled notes within 10 seconds of the play point
+ * and never re-filled — the cause of issue #18 (audio stops after ~10s while
+ * notes keep falling).
  */
 export function useFallingNotesAudio() {
   const audioContextRef = useRef<AudioContext | null>(null)
@@ -26,6 +41,13 @@ export function useFallingNotesAudio() {
   const tempoScaleRef = useRef(1)
   const isPlayingRef = useRef(false)
 
+  // Rolling-scheduler state, all reset on every startAudio.
+  const notesRef = useRef<FallingNote[]>([])
+  const muteRef = useRef(false)
+  const scheduleCursorRef = useRef(0)
+  const activeEndsRef = useRef<number[]>([])
+  const tickRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
   /**
    * Initialize audio context
    */
@@ -34,7 +56,7 @@ export function useFallingNotesAudio() {
       // Create audio context with compatibility
       const AudioContextClass = window.AudioContext || (window as Window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
       audioContextRef.current = new AudioContextClass()
-      
+
       // Create master gain node
       masterGainRef.current = audioContextRef.current.createGain()
       masterGainRef.current.gain.value = 0.1 // Reasonable volume level
@@ -72,64 +94,57 @@ export function useFallingNotesAudio() {
     lowPassFilter.connect(gainNode)
     gainNode.connect(masterGain)
 
-    return { osc: oscillator, gain: gainNode, lp: lowPassFilter }
+    return { osc: oscillator, gain: gainNode, lp: lowPassFilter, end: 0 }
   }, [])
 
   /**
-   * Schedule audio for multiple notes with precise timing
+   * Schedule every note in the song-time window `[fromSong, toSong)`.
+   *
+   * Timing is derived from a single anchor (`baseAudioTimeRef` maps
+   * `offsetSecRef` in song time to an AudioContext time), so the audio clock is
+   * computed the same way on every tick. Voice/node bookkeeping persists across
+   * ticks via refs, which is what lets a rolling window stay bounded over a
+   * multi-minute song instead of being re-derived per call.
    */
-  const scheduleAudio = useCallback((
-    notes: FallingNote[],
-    offsetSec: number,
-    tempoScale: number,
-    mute: boolean
+  const scheduleWindow = useCallback((
+    fromSong: number,
+    toSong: number,
+    includeSounding: boolean
   ) => {
-    if (!audioContextRef.current || !masterGainRef.current || mute) return []
-
     const audioContext = audioContextRef.current
     const masterGain = masterGainRef.current
-    const scheduledNodes: AudioNodes[] = []
-    const baseTime = audioContext.currentTime + 0.02 // Small delay for precision
-    const currentAudioTime = audioContext.currentTime
+    const baseAudioTime = baseAudioTimeRef.current
+    if (!audioContext || !masterGain || baseAudioTime === null || muteRef.current) return
 
-    // Voice limiting for performance
-    const VOICE_LIMIT = 24
-    const activeEnds: number[] = []
+    const tempoScale = tempoScaleRef.current
+    const offsetSec = offsetSecRef.current
+    const now = audioContext.currentTime
 
-    // Sort notes by start time
-    const sortedNotes = [...notes].sort((a, b) => a.start - b.start)
+    // Drop voices that have already finished so the polyphony count reflects
+    // only notes still sounding, across the whole song rather than one window.
+    for (let i = activeEndsRef.current.length - 1; i >= 0; i--) {
+      if (activeEndsRef.current[i] <= now) activeEndsRef.current.splice(i, 1)
+    }
 
-    for (const note of sortedNotes) {
-      // Skip notes that have already finished
-      if (note.start + note.duration <= offsetSec) continue
+    const notes = selectNotesInWindow(notesRef.current, fromSong, toSong, includeSounding)
 
-      // Calculate precise timing with tempo scaling
-      const relativeStart = Math.max(0, (note.start - offsetSec) / tempoScale)
-      const relativeEnd = Math.max(0, (note.start + note.duration - offsetSec) / tempoScale)
+    for (const note of notes) {
+      // Map song time to AudioContext time through the single shared anchor.
+      const startTime = baseAudioTime + (note.start - offsetSec) / tempoScale
+      const endTime = baseAudioTime + (note.start + note.duration - offsetSec) / tempoScale
 
-      // Skip notes that are too far in the past or future
-      if (relativeStart > 10 || relativeEnd < 0) continue
+      // A note captured by includeSounding may start slightly in the past;
+      // clamp it just ahead of now so it still articulates without an error.
+      const clampedStart = Math.max(startTime, now + 0.005)
+      if (endTime <= clampedStart) continue
 
-      // Clean up finished voices
-      for (let i = activeEnds.length - 1; i >= 0; i--) {
-        if (activeEnds[i] <= relativeStart) {
-          activeEnds.splice(i, 1)
-        }
+      // Retire voices that end before this note begins, then honour the limit.
+      for (let i = activeEndsRef.current.length - 1; i >= 0; i--) {
+        if (activeEndsRef.current[i] <= clampedStart) activeEndsRef.current.splice(i, 1)
       }
-
-      // Skip if voice limit reached
-      if (activeEnds.length >= VOICE_LIMIT) continue
-      activeEnds.push(relativeEnd)
-
-      // Calculate absolute timing
-      const startTime = baseTime + relativeStart
-      const endTime = baseTime + relativeEnd
-
-      // Ensure valid timing
-      if (startTime < currentAudioTime || endTime <= startTime) continue
+      if (activeEndsRef.current.length >= VOICE_LIMIT) continue
 
       try {
-        // Create audio nodes for this note
         const nodes = createNoteAudio(note.midi, audioContext, masterGain)
 
         // Configure ADSR envelope
@@ -142,37 +157,71 @@ export function useFallingNotesAudio() {
         const peakGain = velocity * 0.3
 
         // Attack
-        nodes.gain.gain.setValueAtTime(0, startTime)
-        nodes.gain.gain.linearRampToValueAtTime(peakGain, startTime + attackTime)
+        nodes.gain.gain.setValueAtTime(0, clampedStart)
+        nodes.gain.gain.linearRampToValueAtTime(peakGain, clampedStart + attackTime)
 
         // Decay to sustain
         nodes.gain.gain.linearRampToValueAtTime(
-          peakGain * sustainLevel, 
-          startTime + attackTime + decayTime
+          peakGain * sustainLevel,
+          clampedStart + attackTime + decayTime
         )
 
         // Release
-        nodes.gain.gain.setValueAtTime(
-          peakGain * sustainLevel, 
-          endTime
-        )
+        nodes.gain.gain.setValueAtTime(peakGain * sustainLevel, endTime)
         nodes.gain.gain.linearRampToValueAtTime(0, endTime + releaseTime)
 
         // Start and stop oscillator
-        nodes.osc.start(startTime)
+        nodes.osc.start(clampedStart)
         nodes.osc.stop(endTime + releaseTime)
 
-        scheduledNodes.push(nodes)
+        nodes.end = endTime + releaseTime
+        activeEndsRef.current.push(endTime)
+        scheduledNodesRef.current.push(nodes)
       } catch (error) {
         console.warn('Failed to schedule note:', error)
       }
     }
 
-    return scheduledNodes
+    // Release handles for voices whose sound has fully completed so the array
+    // does not grow without bound over a long song.
+    scheduledNodesRef.current = scheduledNodesRef.current.filter((n) => n.end > now)
   }, [createNoteAudio])
 
   /**
-   * Start audio playback
+   * Stop the rolling schedule timer.
+   */
+  const stopTick = useCallback(() => {
+    if (tickRef.current !== null) {
+      clearInterval(tickRef.current)
+      tickRef.current = null
+    }
+  }, [])
+
+  /**
+   * One rolling-scheduler tick: top up the queue out to the look-ahead horizon.
+   */
+  const tick = useCallback(() => {
+    const audioContext = audioContextRef.current
+    const baseAudioTime = baseAudioTimeRef.current
+    if (!audioContext || baseAudioTime === null || !isPlayingRef.current) return
+
+    const tempoScale = tempoScaleRef.current
+    const songNow = offsetSecRef.current +
+      Math.max(0, audioContext.currentTime - baseAudioTime) * tempoScale
+
+    const win = nextScheduleWindow(songNow, scheduleCursorRef.current, tempoScale)
+    if (!win) return
+
+    scheduleWindow(win.from, win.to, false)
+    scheduleCursorRef.current = win.cursor
+  }, [scheduleWindow])
+
+  /**
+   * Start audio playback from the given song-time offset.
+   *
+   * seek / tempo / mute changes all funnel through here: the previous schedule
+   * and timer are torn down and a fresh anchor is established, so no stale
+   * future node can double-fire and the cursor restarts from the new position.
    */
   const startAudio = useCallback((
     notes: FallingNote[],
@@ -181,40 +230,57 @@ export function useFallingNotesAudio() {
     mute: boolean
   ) => {
     initializeAudio()
-    
+
     if (!audioContextRef.current || !masterGainRef.current) return
 
-    // Stop any currently playing audio
+    // Tear down any currently playing audio and its timer.
+    stopTick()
     stopAudioNodes(scheduledNodesRef.current)
     scheduledNodesRef.current = []
+    activeEndsRef.current = []
 
     // Store current state
+    notesRef.current = notes
+    muteRef.current = mute
     tempoScaleRef.current = tempoScale
     isPlayingRef.current = true
-    
+
     // Resume audio context if suspended (required by some browsers)
     if (audioContextRef.current.state === 'suspended') {
       audioContextRef.current.resume()
     }
 
-    // Schedule new audio
-    const scheduledNodes = scheduleAudio(notes, offsetSec, tempoScale, mute)
-    scheduledNodesRef.current = scheduledNodes
-
-    // Store timing reference
-    baseAudioTimeRef.current = audioContextRef.current.currentTime + 0.02
+    // Establish the single timing anchor: songTime `offsetSec` maps to this
+    // AudioContext time. A small lead keeps the first notes just in the future.
+    const baseAudioTime = audioContextRef.current.currentTime + 0.05
+    baseAudioTimeRef.current = baseAudioTime
     offsetSecRef.current = offsetSec
-  }, [initializeAudio, scheduleAudio])
+    scheduleCursorRef.current = offsetSec
+
+    // Schedule the first window immediately (including any note already sounding
+    // at the offset), then keep filling ahead on a timer.
+    const first = nextScheduleWindow(offsetSec, offsetSec, tempoScale)
+    if (first) {
+      scheduleWindow(first.from, first.to, true)
+      scheduleCursorRef.current = first.cursor
+    }
+
+    if (!mute) {
+      tickRef.current = setInterval(tick, TICK_MS)
+    }
+  }, [initializeAudio, stopTick, scheduleWindow, tick])
 
   /**
    * Stop all audio playback
    */
   const stopAudio = useCallback(() => {
     isPlayingRef.current = false
+    stopTick()
     stopAudioNodes(scheduledNodesRef.current)
     scheduledNodesRef.current = []
+    activeEndsRef.current = []
     baseAudioTimeRef.current = null
-  }, [])
+  }, [stopTick])
 
   /**
    * Get current playback time with precise synchronization
@@ -301,7 +367,7 @@ function stopAudioNodes(nodes: AudioNodes[]) {
       gain.gain.cancelScheduledValues(now)
       gain.gain.setValueAtTime(gain.gain.value, now)
       gain.gain.linearRampToValueAtTime(0, now + 0.02)
-      
+
       // Stop oscillator after fade out
       osc.stop(now + 0.02)
     } catch {

--- a/src/hooks/useFallingNotesAudio.ts
+++ b/src/hooks/useFallingNotesAudio.ts
@@ -175,7 +175,10 @@ export function useFallingNotesAudio() {
         nodes.osc.stop(endTime + releaseTime)
 
         nodes.end = endTime + releaseTime
-        activeEndsRef.current.push(endTime)
+        // Count the voice as active through its release tail (nodes.end), not
+        // just to endTime — the oscillator is still sounding during release, so
+        // pruning at endTime would let more than VOICE_LIMIT voices overlap.
+        activeEndsRef.current.push(nodes.end)
         scheduledNodesRef.current.push(nodes)
       } catch (error) {
         console.warn('Failed to schedule note:', error)

--- a/src/utils/__tests__/audioScheduler.test.ts
+++ b/src/utils/__tests__/audioScheduler.test.ts
@@ -142,4 +142,21 @@ describe('nextScheduleWindow', () => {
     // Cursor is far ahead of where the look-ahead would reach.
     expect(nextScheduleWindow(10, 20, 1)).toBeNull()
   })
+
+  it('does not flag a normal (caught-up) tick as stale', () => {
+    // Cursor is ahead of the playhead, as it is during steady playback.
+    const win = nextScheduleWindow(10, 11, 1)!
+    expect(win.skippedStale).toBe(false)
+    expect(win.from).toBe(11)
+  })
+
+  it('drops the overdue range when a delayed tick falls behind the playhead', () => {
+    // Tick delayed: playhead at 10s but only scheduled up to 8s. The stale
+    // [8, 10) range must be skipped (from clamps to 10), not scheduled as a
+    // burst, and the caller is told so it can re-articulate a sounding note.
+    const win = nextScheduleWindow(10, 8, 1)!
+    expect(win.from).toBe(10)
+    expect(win.skippedStale).toBe(true)
+    expect(win.to).toBeCloseTo(10 + SCHEDULE_AHEAD_SEC)
+  })
 })

--- a/src/utils/__tests__/audioScheduler.test.ts
+++ b/src/utils/__tests__/audioScheduler.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Regression tests for the rolling look-ahead audio scheduler.
+ *
+ * These reproduce issue #18: the old one-shot scheduler dropped every note
+ * starting more than 10 seconds after the play point. The tests exercise the
+ * pure selection/window helpers so the "note past 10s gets scheduled" guarantee
+ * is verified without an AudioContext.
+ */
+
+import {
+  selectNotesInWindow,
+  nextScheduleWindow,
+  SCHEDULE_AHEAD_SEC,
+} from '../audioScheduler'
+import type { FallingNote } from '@/types/fallingNotes'
+
+/** A 0–30s fixture: one note per second at C4, plus one held note. */
+function makeFixture(): FallingNote[] {
+  const notes: FallingNote[] = []
+  for (let i = 0; i < 30; i++) {
+    notes.push({ midi: 60 + (i % 12), start: i, duration: 0.5 })
+  }
+  return notes
+}
+
+describe('selectNotesInWindow', () => {
+  it('selects notes whose start falls in [from, to)', () => {
+    const notes: FallingNote[] = [
+      { midi: 60, start: 0, duration: 0.5 },
+      { midi: 62, start: 1, duration: 0.5 },
+      { midi: 64, start: 2, duration: 0.5 },
+    ]
+
+    const selected = selectNotesInWindow(notes, 1, 2)
+
+    expect(selected.map((n) => n.start)).toEqual([1])
+  })
+
+  it('is lower-inclusive and upper-exclusive at the window bounds', () => {
+    const notes: FallingNote[] = [
+      { midi: 60, start: 1, duration: 0.5 }, // exactly at `from` → included
+      { midi: 62, start: 2, duration: 0.5 }, // exactly at `to`   → excluded
+    ]
+
+    const selected = selectNotesInWindow(notes, 1, 2)
+
+    expect(selected.map((n) => n.start)).toEqual([1])
+  })
+
+  it('regression (issue #18): schedules a note starting well past 10 seconds', () => {
+    const notes = makeFixture()
+
+    // The old cap made a window past 10s impossible; the pure function must
+    // happily select a note starting at 25s.
+    const selected = selectNotesInWindow(notes, 25, 26)
+
+    expect(selected).toHaveLength(1)
+    expect(selected[0].start).toBe(25)
+  })
+
+  it('returns notes sorted by start regardless of input order', () => {
+    const notes: FallingNote[] = [
+      { midi: 64, start: 2.5, duration: 0.5 },
+      { midi: 60, start: 2.1, duration: 0.5 },
+      { midi: 62, start: 2.3, duration: 0.5 },
+    ]
+
+    const selected = selectNotesInWindow(notes, 2, 3)
+
+    expect(selected.map((n) => n.start)).toEqual([2.1, 2.3, 2.5])
+  })
+
+  it('returns an empty array for a zero-width or inverted window', () => {
+    const notes = makeFixture()
+
+    expect(selectNotesInWindow(notes, 5, 5)).toEqual([])
+    expect(selectNotesInWindow(notes, 6, 5)).toEqual([])
+  })
+
+  it('excludes an already-sounding note by default', () => {
+    const notes: FallingNote[] = [{ midi: 60, start: 4, duration: 3 }] // sounds 4–7s
+
+    // Window starts at 5s: the note started before the window and is not
+    // re-triggered unless includeSounding is set.
+    expect(selectNotesInWindow(notes, 5, 6)).toEqual([])
+  })
+
+  it('includes a note still sounding at `from` when includeSounding is set', () => {
+    const notes: FallingNote[] = [
+      { midi: 60, start: 4, duration: 3 }, // sounds 4–7s, straddles 5s
+      { midi: 62, start: 1, duration: 1 }, // finished by 2s, must stay excluded
+    ]
+
+    const selected = selectNotesInWindow(notes, 5, 6, true)
+
+    expect(selected.map((n) => n.start)).toEqual([4])
+  })
+
+  it('rolls across the whole song scheduling every note exactly once', () => {
+    const notes = makeFixture()
+    const seen = new Map<number, number>() // start → times scheduled
+
+    // Simulate the tick loop: 0.25s cursor steps out to 30s. Each note must be
+    // scheduled once and only once — no gaps (the 10s bug), no duplicates.
+    let cursor = 0
+    const step = 0.25
+    for (let songNow = 0; songNow <= 32; songNow += step) {
+      const win = nextScheduleWindow(songNow, cursor, 1)
+      if (!win) continue
+      for (const note of selectNotesInWindow(notes, win.from, win.to)) {
+        seen.set(note.start, (seen.get(note.start) ?? 0) + 1)
+      }
+      cursor = win.cursor
+    }
+
+    expect(seen.size).toBe(notes.length)
+    for (const note of notes) {
+      expect(seen.get(note.start)).toBe(1)
+    }
+  })
+})
+
+describe('nextScheduleWindow', () => {
+  it('opens a window from the cursor out to the tempo-scaled horizon', () => {
+    const win = nextScheduleWindow(10, 10, 1)
+
+    expect(win).not.toBeNull()
+    expect(win!.from).toBe(10)
+    expect(win!.to).toBeCloseTo(10 + SCHEDULE_AHEAD_SEC)
+    expect(win!.cursor).toBe(win!.to)
+  })
+
+  it('keeps the same real look-ahead as tempo increases (more song time queued)', () => {
+    const normal = nextScheduleWindow(10, 10, 1)!
+    const fast = nextScheduleWindow(10, 10, 2)!
+
+    // At 2x speed the same 0.5s of real audio spans twice the song time.
+    expect(fast.to - fast.from).toBeCloseTo((normal.to - normal.from) * 2)
+  })
+
+  it('returns null when the cursor already covers the horizon', () => {
+    // Cursor is far ahead of where the look-ahead would reach.
+    expect(nextScheduleWindow(10, 20, 1)).toBeNull()
+  })
+})

--- a/src/utils/audioScheduler.ts
+++ b/src/utils/audioScheduler.ts
@@ -1,0 +1,86 @@
+import type { FallingNote } from '@/types/fallingNotes'
+
+/**
+ * Rolling look-ahead audio scheduler helpers.
+ *
+ * The playback engine used to schedule audio exactly once, at play time, and
+ * hard-capped scheduling to notes starting within 10 seconds of that point
+ * (`relativeStart > 10` in the old `useFallingNotesAudio.scheduleAudio`). Since
+ * the scheduler was never re-invoked while playing, every note past that window
+ * was silently dropped even though the visualization kept running — the
+ * "audio stops after ~10s but notes keep falling" defect (issue #18).
+ *
+ * The fix is the standard Web Audio pattern: a timer advances a cursor through
+ * song time and repeatedly schedules the next small window of notes. The
+ * decision of *which* notes belong to a given window is isolated here as a pure
+ * function so it can be unit-tested without an AudioContext — the original bug
+ * lived in code that fused this decision with oscillator creation and therefore
+ * could not be tested in isolation.
+ */
+
+/** Real seconds of audio kept scheduled ahead of the playhead. */
+export const SCHEDULE_AHEAD_SEC = 0.5
+
+/** How often the rolling scheduler tops up the queue, in milliseconds. */
+export const TICK_MS = 100
+
+/** Maximum simultaneous scheduled voices, to bound node allocation. */
+export const VOICE_LIMIT = 24
+
+/**
+ * Select the notes that belong to the schedule window `[fromSec, toSec)`,
+ * expressed in song time (seconds from the start of the song).
+ *
+ * Selection rule:
+ * - A note is selected when its start falls within `[fromSec, toSec)`.
+ * - When `includeSounding` is true — used only for the first window right after
+ *   play or seek — a note that started before `fromSec` but is still sounding at
+ *   `fromSec` (`start + duration > fromSec`) is also selected, so seeking into
+ *   the middle of a held note still articulates it.
+ *
+ * The result is sorted by start time so downstream voice allocation is
+ * deterministic regardless of the caller's note ordering.
+ */
+export function selectNotesInWindow(
+  notes: FallingNote[],
+  fromSec: number,
+  toSec: number,
+  includeSounding = false
+): FallingNote[] {
+  if (toSec <= fromSec) return []
+
+  const selected = notes.filter((note) => {
+    const startsInWindow = note.start >= fromSec && note.start < toSec
+    if (startsInWindow) return true
+
+    if (includeSounding) {
+      return note.start < fromSec && note.start + note.duration > fromSec
+    }
+
+    return false
+  })
+
+  return selected.sort((a, b) => a.start - b.start)
+}
+
+/**
+ * Advance a rolling schedule cursor by one tick and report the window that
+ * should be scheduled next.
+ *
+ * Given the current song time and the cursor (the song time already scheduled
+ * up to), returns the `[from, to)` window still needing notes and the new
+ * cursor. The look-ahead is scaled by tempo so a faster playback rate keeps the
+ * same amount of *real* audio queued. Returns `null` when the cursor already
+ * covers the look-ahead horizon, so the caller can skip an empty pass.
+ */
+export function nextScheduleWindow(
+  songNowSec: number,
+  cursorSec: number,
+  tempoScale: number,
+  scheduleAheadSec: number = SCHEDULE_AHEAD_SEC
+): { from: number; to: number; cursor: number } | null {
+  const target = songNowSec + scheduleAheadSec * Math.max(tempoScale, 0)
+  if (target <= cursorSec) return null
+
+  return { from: cursorSec, to: target, cursor: target }
+}

--- a/src/utils/audioScheduler.ts
+++ b/src/utils/audioScheduler.ts
@@ -18,8 +18,16 @@ import type { FallingNote } from '@/types/fallingNotes'
  * could not be tested in isolation.
  */
 
-/** Real seconds of audio kept scheduled ahead of the playhead. */
-export const SCHEDULE_AHEAD_SEC = 0.5
+/**
+ * Real seconds of audio kept scheduled ahead of the playhead.
+ *
+ * Sized above the ~1000ms floor browsers impose on `setInterval` in background
+ * tabs: with a smaller look-ahead a throttled tick would let the queue drain and
+ * the audio would stutter. 1.5s leaves a buffer even when ticks are delayed to
+ * once per second. `stopAudio` flushes all scheduled nodes, so a larger buffer
+ * has no cost on seek/pause/tempo/mute changes.
+ */
+export const SCHEDULE_AHEAD_SEC = 1.5
 
 /** How often the rolling scheduler tops up the queue, in milliseconds. */
 export const TICK_MS = 100
@@ -72,15 +80,23 @@ export function selectNotesInWindow(
  * cursor. The look-ahead is scaled by tempo so a faster playback rate keeps the
  * same amount of *real* audio queued. Returns `null` when the cursor already
  * covers the look-ahead horizon, so the caller can skip an empty pass.
+ *
+ * If a tick is delayed past the look-ahead (main-thread stall or background-tab
+ * throttling), the playhead can advance beyond the cursor. Scheduling the whole
+ * stale `[cursor, songNow)` range would clamp every overdue note to "now" and
+ * fire them in one audible burst, so `from` is clamped forward to the current
+ * playhead — the missed range is dropped. `skippedStale` reports this so the
+ * caller can re-articulate a note still sounding at the new playhead.
  */
 export function nextScheduleWindow(
   songNowSec: number,
   cursorSec: number,
   tempoScale: number,
   scheduleAheadSec: number = SCHEDULE_AHEAD_SEC
-): { from: number; to: number; cursor: number } | null {
+): { from: number; to: number; cursor: number; skippedStale: boolean } | null {
   const target = songNowSec + scheduleAheadSec * Math.max(tempoScale, 0)
-  if (target <= cursorSec) return null
+  const from = Math.max(cursorSec, songNowSec)
+  if (target <= from) return null
 
-  return { from: cursorSec, to: target, cursor: target }
+  return { from, to: target, cursor: target, skippedStale: from > cursorSec }
 }


### PR DESCRIPTION
## 문제 (issue #18)

`useFallingNotesAudio.scheduleAudio()`가 **재생 시작 시 한 번만** 호출되는 one-shot 스케줄러였고, 그 안의 `relativeStart > 10` 상한이 재생 시작 지점 기준 10초 이후 음표를 예약에서 제외했다. 재생 중 재예약이 없으므로 10초 이후 음표는 영원히 무음이 되고, 시각화(노트 낙하)와 재생바는 곡 전체 길이를 따라 끝까지 진행해 소리와 그림의 종료 시점이 구조적으로 어긋났다. (`/sheet/2` 등 10초 초과 곡에서 재현)

## 접근

Web Audio 표준 **rolling look-ahead scheduler**로 교체:

- 타이머(`TICK_MS=100ms`)가 song-time 커서를 전진시키며 `SCHEDULE_AHEAD_SEC(0.5s, tempo 스케일 적용)`만큼 앞을 계속 예약한다.
- "주어진 시간창에 어떤 음표를 예약할지" 판단을 AudioContext와 무관한 **순수 함수 `selectNotesInWindow`**(`src/utils/audioScheduler.ts`)로 분리 → 10초 이후 음표 선택을 오실레이터 모킹 없이 회귀 테스트.
- song-time ↔ AudioContext-time 변환을 **단일 anchor**(`baseAudioTimeRef`)로 통일 (기존엔 `scheduleAudio`의 `baseTime`과 `startAudio`의 `baseAudioTimeRef`가 따로 계산돼 미세하게 어긋나 있었음).
- 폴리포니(`VOICE_LIMIT=24`) 상태(`activeEndsRef`)와 완료 노드 정리를 틱 간에 유지해 장시간 재생에서도 상태가 bounded.
- seek/tempo/mute 전이는 기존처럼 `startAudio` 전체 재시작으로 처리 — 타이머 teardown + anchor 재설정으로 미래 노드 중복 발화 방지.

공개 API(`startAudio`/`stopAudio`/`getCurrentTime`/…)는 변경 없음 — 유일한 호출부 `useFallingNotesPlayer`는 수정 불필요.

## 범위 (P0-C Work stages 1~3)

이 PR은 P0-C의 Work stage 1(재현 테스트)·2(rolling scheduler + voice cleanup)·3(상태 전이 통합)에 해당한다. Work stage 4(시각화·키 활성화 동일 시계 고정)·5(장시간 drift 측정)는 범위 밖으로 남는다.

P0-C는 로드맵상 P0-A·P0-B에 의존하지만, 이 결함은 계약 정립과 무관하게 사용자가 실제로 겪는 재생 버그이므로 선행 착수했다 — 사유는 **D-007**(`docs/recovery/DECISIONS.md`)에 기록. 스케줄러는 기존 `FallingNote` 타임라인(`start`/`duration`/`midi`/`velocity`)만 소비하므로 계약을 건드리지 않는다.

## 검증

- `npx jest audioScheduler.test.ts visualUtils.test.ts` — 24 passed (0~30s roll이 모든 음표를 정확히 한 번씩 예약하는 회귀 포함)
- `npx tsc --noEmit` — 0
- `npx eslint` (변경 파일) — 0
- **미검증**: 실제 브라우저에서 `/sheet/2` 재생, 장시간 누적 drift(P0-C stage 5), 백그라운드 탭 타이머 스로틀링

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 긴 곡에서 재생이 앞부분 10초에 멈추던 오디오 문제를 수정했습니다.
  * 긴 곡에서도 노트가 순차적으로 안정적으로 예약되도록 개선했습니다.
  * 폴리포니 재생 시 동시에 처리되는 음성 수를 관리해 재생 안정성을 높였습니다.

* **테스트**
  * 노트 선택, 재생 구간 경계, 템포 변화 및 전체 곡 재생에 대한 회귀 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->