### PR TITLE
P0-A: canonical animation contract + golden corpus

### DIFF
--- a/docs/recovery/DECISIONS.md
+++ b/docs/recovery/DECISIONS.md
@@ -88,3 +88,18 @@
   - 호스트를 Fly에서 바꾸면 **완료 조건**에 다음을 포함한다: `src/app/api/omr/upload/route.ts`·`src/app/api/omr/status/[jobId]/route.ts`의 기본 `OMR_SERVICE_URL`(현재 `https://clairkeys-omr.fly.dev`)을 새 호스트로 갱신하고, `/process`·`/status/:jobId` 엔드포인트와 `job_id`·결과 필드 계약이 새 호스트에서 동일하게 동작하는지 검증한다. 환경변수를 갱신하지 않으면 애플리케이션은 계속 Fly로 요청한다.
   - 이 항목을 Accepted로 승격할 때 선택한 호스트와 근거(비용·노력 실측)를 함께 기록한다.
 - Related: 이슈 [#20](https://github.com/landfill/ClairKeys/issues/20)(TS 데모 스텁 `pdfParser.ts` 정리), 서버측 컨테이너 결함(Docker-in-Docker 의존·Dockerfile Audiveris/JVM 미설치·512MB 부족 → Docker 없는 호스트에서 job 실패, 별도 이슈 등록 예정), D-001, D-002, `docs/recovery/phases/P0-B-musicxml-converter.md`
+
+## D-009: canonical 애니메이션 계약은 MIDI 계열로 통일하고 legacy Shape A는 정규화로 흡수한다
+
+- Date: 2026-07-21
+- Status: Accepted
+- Context: `docs/recovery/validation/2026-07-21-p0a-animation-shape-audit.md`가 음표 데이터 shape 4종 공존과 플레이어 경계의 무검증 `as` 캐스트를 확인했다. 실제 OMR 출력(Shape C: `midi`/`start`/`R`/`L`)은 현재 `convertToFallingNotes`(Shape A: `note:"C4"`/`startTime`/`left|right` 기대)로 렌더링되지 않고 모든 음표가 middle C로 무너진다.
+- Decision:
+  - canonical 음표는 **MIDI 계열**: `{ midi, start, duration, hand:"L"|"R", velocity?, finger?:1..5, voice?, staff? }`. 문서는 `version` 필드를 가진 봉투(`CanonicalAnimationData`)로 감싼다. 근거: 4개 shape 중 3개(converter.py·FallingNote·MusicData)가 이미 MIDI 계열이며, Shape A(문자열 pitch)는 데모 `pdfParser.ts`와 lossy 변환이 유지하는 outlier다.
+  - `voice`·`staff`는 현재 모든 shape에 없으므로 **신규 추가**한다. P0-B가 이를 채워 hand 배정이 `converter.py`의 `part_idx==0 ? R : L` 휴리스틱에서 벗어나게 한다.
+  - **기존 저장 악보(Shape A)가 존재하므로 legacy 호환은 필수**다. `normalizeAnimationData`(`src/utils/animationContract.ts`)가 canonical·Shape A·converter.py shape를 모두 받아 canonical로 정규화한다. malformed 입력은 조용한 fallback(middle C) 없이 `AnimationContractError`로 명시적 실패한다 — 이는 D-001("fallback은 명시적 실패/demo 상태") 정신과 일치한다.
+- Directive:
+  - 플레이어 경계(`src/app/sheet/[id]/page.tsx`)의 `as PianoAnimationData` 캐스트는 이 validator 호출로 대체한다.
+  - Shape A(`note:"C4"`/`startTime`/`left|right`)를 저장 계약으로 되살리지 않는다. 신규 저장은 canonical로 쓰고, Shape A는 읽기 시 정규화로만 흡수한다.
+  - legacy→canonical 마이그레이션 경로는 golden fixture로 회귀 검증한다(P0-A 완료 조건).
+- Related: D-002, D-001, 이슈 #20, `docs/recovery/phases/P0-A-animation-contract.md`, `docs/recovery/validation/2026-07-21-p0a-animation-shape-audit.md`

--- a/fixtures/animation-contract/01-monophonic/expected.json
+++ b/fixtures/animation-contract/01-monophonic/expected.json
@@ -1,0 +1,15 @@
+{
+  "version": "1.0",
+  "title": "Monophonic line",
+  "composer": "P0-A Fixtures",
+  "duration": 4.0,
+  "tempo": 60,
+  "timeSignature": "4/4",
+  "keySignature": "C",
+  "notes": [
+    { "midi": 60, "start": 0.0, "duration": 1.0, "hand": "R", "voice": 1, "staff": 1 },
+    { "midi": 62, "start": 1.0, "duration": 1.0, "hand": "R", "voice": 1, "staff": 1 },
+    { "midi": 64, "start": 2.0, "duration": 1.0, "hand": "R", "voice": 1, "staff": 1 },
+    { "midi": 65, "start": 3.0, "duration": 1.0, "hand": "R", "voice": 1, "staff": 1 }
+  ]
+}

--- a/fixtures/animation-contract/01-monophonic/input.musicxml
+++ b/fixtures/animation-contract/01-monophonic/input.musicxml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <work><work-title>Monophonic line</work-title></work>
+  <identification><creator type="composer">P0-A Fixtures</creator></identification>
+  <part-list>
+    <score-part id="P1"><part-name>Piano</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>12</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef number="1"><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction placement="above">
+        <direction-type><metronome><beat-unit>quarter</beat-unit><per-minute>60</per-minute></metronome></direction-type>
+        <sound tempo="60"/>
+      </direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>12</duration><voice>1</voice><type>quarter</type><staff>1</staff></note>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>12</duration><voice>1</voice><type>quarter</type><staff>1</staff></note>
+      <note><pitch><step>E</step><octave>4</octave></pitch><duration>12</duration><voice>1</voice><type>quarter</type><staff>1</staff></note>
+      <note><pitch><step>F</step><octave>4</octave></pitch><duration>12</duration><voice>1</voice><type>quarter</type><staff>1</staff></note>
+    </measure>
+  </part>
+</score-partwise>

--- a/fixtures/animation-contract/02-chord/expected.json
+++ b/fixtures/animation-contract/02-chord/expected.json
@@ -1,0 +1,15 @@
+{
+  "version": "1.0",
+  "title": "Chord",
+  "composer": "P0-A Fixtures",
+  "duration": 4.0,
+  "tempo": 60,
+  "timeSignature": "4/4",
+  "keySignature": "C",
+  "notes": [
+    { "midi": 60, "start": 0.0, "duration": 1.0, "hand": "R", "voice": 1, "staff": 1 },
+    { "midi": 64, "start": 0.0, "duration": 1.0, "hand": "R", "voice": 1, "staff": 1 },
+    { "midi": 67, "start": 0.0, "duration": 1.0, "hand": "R", "voice": 1, "staff": 1 },
+    { "midi": 72, "start": 1.0, "duration": 3.0, "hand": "R", "voice": 1, "staff": 1 }
+  ]
+}

--- a/fixtures/animation-contract/02-chord/input.musicxml
+++ b/fixtures/animation-contract/02-chord/input.musicxml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <work><work-title>Chord</work-title></work>
+  <identification><creator type="composer">P0-A Fixtures</creator></identification>
+  <part-list>
+    <score-part id="P1"><part-name>Piano</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>12</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef number="1"><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction placement="above">
+        <direction-type><metronome><beat-unit>quarter</beat-unit><per-minute>60</per-minute></metronome></direction-type>
+        <sound tempo="60"/>
+      </direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>12</duration><voice>1</voice><type>quarter</type><staff>1</staff></note>
+      <note><chord/><pitch><step>E</step><octave>4</octave></pitch><duration>12</duration><voice>1</voice><type>quarter</type><staff>1</staff></note>
+      <note><chord/><pitch><step>G</step><octave>4</octave></pitch><duration>12</duration><voice>1</voice><type>quarter</type><staff>1</staff></note>
+      <note><pitch><step>C</step><octave>5</octave></pitch><duration>36</duration><voice>1</voice><type>half</type><dot/><staff>1</staff></note>
+    </measure>
+  </part>
+</score-partwise>

--- a/fixtures/animation-contract/03-rests-ties/expected.json
+++ b/fixtures/animation-contract/03-rests-ties/expected.json
@@ -1,0 +1,13 @@
+{
+  "version": "1.0",
+  "title": "Rests and ties",
+  "composer": "P0-A Fixtures",
+  "duration": 4.0,
+  "tempo": 60,
+  "timeSignature": "4/4",
+  "keySignature": "C",
+  "notes": [
+    { "midi": 60, "start": 0.0, "duration": 1.0, "hand": "R", "voice": 1, "staff": 1 },
+    { "midi": 62, "start": 2.0, "duration": 2.0, "hand": "R", "voice": 1, "staff": 1 }
+  ]
+}

--- a/fixtures/animation-contract/03-rests-ties/input.musicxml
+++ b/fixtures/animation-contract/03-rests-ties/input.musicxml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <work><work-title>Rests and ties</work-title></work>
+  <identification><creator type="composer">P0-A Fixtures</creator></identification>
+  <part-list>
+    <score-part id="P1"><part-name>Piano</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>12</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef number="1"><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction placement="above">
+        <direction-type><metronome><beat-unit>quarter</beat-unit><per-minute>60</per-minute></metronome></direction-type>
+        <sound tempo="60"/>
+      </direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>12</duration><voice>1</voice><type>quarter</type><staff>1</staff></note>
+      <note><rest/><duration>12</duration><voice>1</voice><type>quarter</type><staff>1</staff></note>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>12</duration><tie type="start"/><voice>1</voice><type>quarter</type><staff>1</staff><notations><tied type="start"/></notations></note>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>12</duration><tie type="stop"/><voice>1</voice><type>quarter</type><staff>1</staff><notations><tied type="stop"/></notations></note>
+    </measure>
+  </part>
+</score-partwise>

--- a/fixtures/animation-contract/04-grand-staff/expected.json
+++ b/fixtures/animation-contract/04-grand-staff/expected.json
@@ -1,0 +1,14 @@
+{
+  "version": "1.0",
+  "title": "Grand staff",
+  "composer": "P0-A Fixtures",
+  "duration": 2.0,
+  "tempo": 60,
+  "timeSignature": "2/4",
+  "keySignature": "C",
+  "notes": [
+    { "midi": 72, "start": 0.0, "duration": 2.0, "hand": "R", "voice": 1, "staff": 1 },
+    { "midi": 48, "start": 0.0, "duration": 1.0, "hand": "L", "voice": 2, "staff": 2 },
+    { "midi": 55, "start": 1.0, "duration": 1.0, "hand": "L", "voice": 2, "staff": 2 }
+  ]
+}

--- a/fixtures/animation-contract/04-grand-staff/input.musicxml
+++ b/fixtures/animation-contract/04-grand-staff/input.musicxml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <work><work-title>Grand staff</work-title></work>
+  <identification><creator type="composer">P0-A Fixtures</creator></identification>
+  <part-list>
+    <score-part id="P1"><part-name>Piano</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>12</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>2</beats><beat-type>4</beat-type></time>
+        <staves>2</staves>
+        <clef number="1"><sign>G</sign><line>2</line></clef>
+        <clef number="2"><sign>F</sign><line>4</line></clef>
+      </attributes>
+      <direction placement="above">
+        <direction-type><metronome><beat-unit>quarter</beat-unit><per-minute>60</per-minute></metronome></direction-type>
+        <sound tempo="60"/>
+      </direction>
+      <note><pitch><step>C</step><octave>5</octave></pitch><duration>24</duration><voice>1</voice><type>half</type><staff>1</staff></note>
+      <backup><duration>24</duration></backup>
+      <note><pitch><step>C</step><octave>3</octave></pitch><duration>12</duration><voice>2</voice><type>quarter</type><staff>2</staff></note>
+      <note><pitch><step>G</step><octave>3</octave></pitch><duration>12</duration><voice>2</voice><type>quarter</type><staff>2</staff></note>
+    </measure>
+  </part>
+</score-partwise>

--- a/fixtures/animation-contract/05-multivoice/expected.json
+++ b/fixtures/animation-contract/05-multivoice/expected.json
@@ -1,0 +1,14 @@
+{
+  "version": "1.0",
+  "title": "Multi-voice",
+  "composer": "P0-A Fixtures",
+  "duration": 2.0,
+  "tempo": 60,
+  "timeSignature": "2/4",
+  "keySignature": "C",
+  "notes": [
+    { "midi": 72, "start": 0.0, "duration": 2.0, "hand": "R", "voice": 1, "staff": 1 },
+    { "midi": 64, "start": 0.0, "duration": 1.0, "hand": "R", "voice": 2, "staff": 1 },
+    { "midi": 65, "start": 1.0, "duration": 1.0, "hand": "R", "voice": 2, "staff": 1 }
+  ]
+}

--- a/fixtures/animation-contract/05-multivoice/input.musicxml
+++ b/fixtures/animation-contract/05-multivoice/input.musicxml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <work><work-title>Multi-voice</work-title></work>
+  <identification><creator type="composer">P0-A Fixtures</creator></identification>
+  <part-list>
+    <score-part id="P1"><part-name>Piano</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>12</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>2</beats><beat-type>4</beat-type></time>
+        <clef number="1"><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction placement="above">
+        <direction-type><metronome><beat-unit>quarter</beat-unit><per-minute>60</per-minute></metronome></direction-type>
+        <sound tempo="60"/>
+      </direction>
+      <note><pitch><step>C</step><octave>5</octave></pitch><duration>24</duration><voice>1</voice><type>half</type><staff>1</staff></note>
+      <backup><duration>24</duration></backup>
+      <note><pitch><step>E</step><octave>4</octave></pitch><duration>12</duration><voice>2</voice><type>quarter</type><staff>1</staff></note>
+      <note><pitch><step>F</step><octave>4</octave></pitch><duration>12</duration><voice>2</voice><type>quarter</type><staff>1</staff></note>
+    </measure>
+  </part>
+</score-partwise>

--- a/fixtures/animation-contract/06-triplet-dotted/expected.json
+++ b/fixtures/animation-contract/06-triplet-dotted/expected.json
@@ -1,0 +1,17 @@
+{
+  "version": "1.0",
+  "title": "Triplet and dotted",
+  "composer": "P0-A Fixtures",
+  "duration": 4.0,
+  "tempo": 60,
+  "timeSignature": "4/4",
+  "keySignature": "C",
+  "notes": [
+    { "midi": 60, "start": 0.0, "duration": 1.5, "hand": "R", "voice": 1, "staff": 1 },
+    { "midi": 62, "start": 1.5, "duration": 0.5, "hand": "R", "voice": 1, "staff": 1 },
+    { "midi": 64, "start": 2.0, "duration": 0.3333, "hand": "R", "voice": 1, "staff": 1 },
+    { "midi": 65, "start": 2.3333, "duration": 0.3333, "hand": "R", "voice": 1, "staff": 1 },
+    { "midi": 67, "start": 2.6667, "duration": 0.3333, "hand": "R", "voice": 1, "staff": 1 },
+    { "midi": 69, "start": 3.0, "duration": 1.0, "hand": "R", "voice": 1, "staff": 1 }
+  ]
+}

--- a/fixtures/animation-contract/06-triplet-dotted/input.musicxml
+++ b/fixtures/animation-contract/06-triplet-dotted/input.musicxml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <work><work-title>Triplet and dotted</work-title></work>
+  <identification><creator type="composer">P0-A Fixtures</creator></identification>
+  <part-list>
+    <score-part id="P1"><part-name>Piano</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>12</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef number="1"><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction placement="above">
+        <direction-type><metronome><beat-unit>quarter</beat-unit><per-minute>60</per-minute></metronome></direction-type>
+        <sound tempo="60"/>
+      </direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>18</duration><voice>1</voice><type>quarter</type><dot/><staff>1</staff></note>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>6</duration><voice>1</voice><type>eighth</type><staff>1</staff></note>
+      <note><pitch><step>E</step><octave>4</octave></pitch><duration>4</duration><voice>1</voice><type>eighth</type><time-modification><actual-notes>3</actual-notes><normal-notes>2</normal-notes></time-modification><staff>1</staff></note>
+      <note><pitch><step>F</step><octave>4</octave></pitch><duration>4</duration><voice>1</voice><type>eighth</type><time-modification><actual-notes>3</actual-notes><normal-notes>2</normal-notes></time-modification><staff>1</staff></note>
+      <note><pitch><step>G</step><octave>4</octave></pitch><duration>4</duration><voice>1</voice><type>eighth</type><time-modification><actual-notes>3</actual-notes><normal-notes>2</normal-notes></time-modification><staff>1</staff></note>
+      <note><pitch><step>A</step><octave>4</octave></pitch><duration>12</duration><voice>1</voice><type>quarter</type><staff>1</staff></note>
+    </measure>
+  </part>
+</score-partwise>

--- a/fixtures/animation-contract/07-tempo-change/expected.json
+++ b/fixtures/animation-contract/07-tempo-change/expected.json
@@ -1,0 +1,15 @@
+{
+  "version": "1.0",
+  "title": "Tempo change",
+  "composer": "P0-A Fixtures",
+  "duration": 3.0,
+  "tempo": 60,
+  "timeSignature": "2/4",
+  "keySignature": "C",
+  "notes": [
+    { "midi": 60, "start": 0.0, "duration": 1.0, "hand": "R", "voice": 1, "staff": 1 },
+    { "midi": 62, "start": 1.0, "duration": 1.0, "hand": "R", "voice": 1, "staff": 1 },
+    { "midi": 64, "start": 2.0, "duration": 0.5, "hand": "R", "voice": 1, "staff": 1 },
+    { "midi": 65, "start": 2.5, "duration": 0.5, "hand": "R", "voice": 1, "staff": 1 }
+  ]
+}

--- a/fixtures/animation-contract/07-tempo-change/input.musicxml
+++ b/fixtures/animation-contract/07-tempo-change/input.musicxml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <work><work-title>Tempo change</work-title></work>
+  <identification><creator type="composer">P0-A Fixtures</creator></identification>
+  <part-list>
+    <score-part id="P1"><part-name>Piano</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>12</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>2</beats><beat-type>4</beat-type></time>
+        <clef number="1"><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction placement="above">
+        <direction-type><metronome><beat-unit>quarter</beat-unit><per-minute>60</per-minute></metronome></direction-type>
+        <sound tempo="60"/>
+      </direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>12</duration><voice>1</voice><type>quarter</type><staff>1</staff></note>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>12</duration><voice>1</voice><type>quarter</type><staff>1</staff></note>
+    </measure>
+    <measure number="2">
+      <direction placement="above">
+        <direction-type><metronome><beat-unit>quarter</beat-unit><per-minute>120</per-minute></metronome></direction-type>
+        <sound tempo="120"/>
+      </direction>
+      <note><pitch><step>E</step><octave>4</octave></pitch><duration>12</duration><voice>1</voice><type>quarter</type><staff>1</staff></note>
+      <note><pitch><step>F</step><octave>4</octave></pitch><duration>12</duration><voice>1</voice><type>quarter</type><staff>1</staff></note>
+    </measure>
+  </part>
+</score-partwise>

--- a/fixtures/animation-contract/README.md
+++ b/fixtures/animation-contract/README.md
@@ -1,0 +1,53 @@
+# Golden fixtures — canonical animation contract (P0-A)
+
+Each subdirectory is one golden fixture: an input `input.musicxml` and the
+hand-authored `expected.json` (canonical animation contract,
+`src/types/animationContract.ts`).
+
+`expected.json` encodes the **musically correct** interpretation, not what the
+current `omr-service/omr/converter.py` produces — that converter's timing
+(`duration / 4.0`, no `divisions` handling) and hand/voice/staff extraction are
+exactly what P0-B must fix and will be measured against this corpus with
+`src/utils/animationCompare.ts`.
+
+## Timing convention
+
+To keep expected onsets/durations exact, fixtures use **tempo = 60 BPM** with a
+**quarter-note beat**, so one quarter note = **1.0 second**. Seconds are derived
+as:
+
+```
+seconds = (duration_in_divisions / divisions) * (60 / tempo_bpm)
+        = (duration_in_divisions / divisions)          // at 60 BPM
+```
+
+`divisions` is stated per fixture in its MusicXML `<attributes>`. A dotted
+quarter = 1.5s, an eighth = 0.5s, a triplet eighth (three in one beat) = 1/3s.
+
+## Hand / staff / voice convention
+
+- `staff` 1 = treble (right hand), `staff` 2 = bass (left hand).
+- `hand` is derived from staff for grand-staff fixtures: staff 1 → `R`, staff 2 → `L`.
+- `voice` is the MusicXML `<voice>` number, 1-based, used for multi-voice-per-staff.
+
+## Fixtures
+
+| Dir | Case | Exercises |
+|---|---|---|
+| `01-monophonic` | 단선율 | single melodic line, quarter notes |
+| `02-chord` | 동시 코드 | simultaneous notes via `<chord>` (same onset) |
+| `03-rests-ties` | 쉼표와 붙임줄 | `<rest>` advances time; `<tie>` merges durations |
+| `04-grand-staff` | 양손 grand staff | two staves → hand L/R |
+| `05-multivoice` | 한 staff 내 다성부 | `<backup>` + `<voice>` overlapping in one staff |
+| `06-triplet-dotted` | 셋잇단음표·점음표 | `<time-modification>` triplet, dotted duration |
+| `07-tempo-change` | 템포/박자표 변경 | mid-piece tempo change re-scales seconds |
+
+## Comparison
+
+```ts
+import { compareAnimationData } from '@/utils/animationCompare'
+// compareAnimationData(actualFromConverter, expectedJson, { onsetSec, durationSec })
+```
+
+Default tolerance is 10 ms on onset and duration (`DEFAULT_TOLERANCE`). Pitch,
+hand, voice, and staff are matched exactly.

--- a/omr-service/omr/converter.py
+++ b/omr-service/omr/converter.py
@@ -57,8 +57,14 @@ class MusicXMLToClairKeysConverter:
             notes = self._extract_notes(root)
             logger.info(f"Extracted {len(notes)} notes")
             
-            # Build ClairKeys animation data structure
+            # Build ClairKeys animation data structure.
+            # Emit the canonical contract shape explicitly (version + top-level
+            # title/composer) rather than relying on the TS validator's tolerance
+            # for the old metadata-nested layout. See P0-A / D-009.
             animation_data = {
+                "version": "1.0",
+                "title": metadata.get("title", "Untitled"),
+                "composer": metadata.get("composer", "Unknown"),
                 "metadata": metadata,
                 "notes": notes,
                 "duration": self._calculate_duration(notes),

--- a/src/app/sheet/[id]/page.tsx
+++ b/src/app/sheet/[id]/page.tsx
@@ -6,7 +6,8 @@ import { MainLayout, PageHeader, Container } from '@/components/layout'
 import { Card, Loading } from '@/components/ui'
 import AuthGuard from '@/components/auth/AuthGuard'
 import FallingNotesPlayer from '@/components/animation/FallingNotesPlayer'
-import { PianoAnimationData } from '@/services/pdfParser'
+import type { CanonicalAnimationData } from '@/types/animationContract'
+import { normalizeAnimationData, AnimationContractError } from '@/utils/animationContract'
 
 interface SheetMusic {
   id: string
@@ -23,7 +24,7 @@ export default function SheetMusicPage() {
   const id = params.id as string
 
   const [sheetMusic, setSheetMusic] = useState<SheetMusic | null>(null)
-  const [animationData, setAnimationData] = useState<PianoAnimationData | null>(null)
+  const [animationData, setAnimationData] = useState<CanonicalAnimationData | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
@@ -97,12 +98,18 @@ export default function SheetMusicPage() {
           }
 
           try {
-            const parsedAnimationData = JSON.parse(responseText) as PianoAnimationData
-            console.log(`✅ Successfully parsed animation data`, parsedAnimationData)
+            // Validate + normalize against the canonical contract instead of an
+            // unchecked `as` cast. Accepts canonical, legacy Shape A, and
+            // converter.py-style JSON; throws AnimationContractError otherwise.
+            const parsedAnimationData = normalizeAnimationData(JSON.parse(responseText))
+            console.log(`✅ Successfully validated animation data`, parsedAnimationData)
             setAnimationData(parsedAnimationData)
           } catch (jsonError) {
-            console.error('❌ Failed to parse animation JSON:', jsonError)
-            console.error('❌ Response text that failed to parse:', responseText)
+            if (jsonError instanceof AnimationContractError) {
+              console.error('❌ Animation data failed contract validation:', jsonError.message)
+            } else {
+              console.error('❌ Failed to parse animation JSON:', jsonError)
+            }
             setError('애니메이션 데이터 형식이 올바르지 않습니다.')
             return
           }

--- a/src/app/test-finger/page.tsx
+++ b/src/app/test-finger/page.tsx
@@ -42,6 +42,10 @@ const testData: PianoAnimationData = {
   }
 }
 
+// Normalize once at module scope — testData is static, so there is no need to
+// re-run the validator on every render.
+const canonicalTestData = normalizeAnimationData(testData)
+
 export default function TestFingerPage() {
   return (
     <div className="min-h-screen bg-gray-100 p-4">
@@ -82,7 +86,7 @@ export default function TestFingerPage() {
         </div>
         
         <FallingNotesPlayer
-          animationData={normalizeAnimationData(testData)}
+          animationData={canonicalTestData}
           className="bg-white rounded-lg shadow-lg"
         />
         

--- a/src/app/test-finger/page.tsx
+++ b/src/app/test-finger/page.tsx
@@ -3,8 +3,10 @@
 import React from 'react'
 import FallingNotesPlayer from '@/components/animation/FallingNotesPlayer'
 import type { PianoAnimationData } from '@/types/animation'
+import { normalizeAnimationData } from '@/utils/animationContract'
 
-// Test data with finger information
+// Test data authored in the legacy Shape A (string pitch / startTime / left|right);
+// normalized to the canonical contract before use, exercising that path too.
 const testData: PianoAnimationData = {
   version: '1.0',
   title: 'Finger Visualization Test',
@@ -79,8 +81,8 @@ export default function TestFingerPage() {
           </div>
         </div>
         
-        <FallingNotesPlayer 
-          animationData={testData}
+        <FallingNotesPlayer
+          animationData={normalizeAnimationData(testData)}
           className="bg-white rounded-lg shadow-lg"
         />
         

--- a/src/components/animation/FallingNotesPlayer.tsx
+++ b/src/components/animation/FallingNotesPlayer.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 import React, { useState, useEffect, useMemo } from 'react'
-import type { PianoAnimationData } from '@/types/animation'
+import type { CanonicalAnimationData } from '@/types/animationContract'
 import { buildKeyLayout } from '@/utils/pianoLayout'
-import { convertToFallingNotes } from '@/utils/dataConverter'
+import { canonicalToFallingNotes } from '@/utils/dataConverter'
 import { useFallingNotesPlayer } from '@/hooks/useFallingNotesPlayer'
 import FallingNotes from './FallingNotes'
 import SimplePianoKeyboard from '../piano/SimplePianoKeyboard'
@@ -18,11 +18,11 @@ export default function FallingNotesPlayer({
   animationData,
   className = ''
 }: {
-  animationData: PianoAnimationData
+  animationData: CanonicalAnimationData
   className?: string
 }) {
-  // Convert animation data to falling notes format
-  const notes = useMemo(() => convertToFallingNotes(animationData), [animationData])
+  // Convert canonical animation data to falling notes format
+  const notes = useMemo(() => canonicalToFallingNotes(animationData), [animationData])
   
   // Use falling notes player hook for audio-visual synchronization
   const {

--- a/src/hooks/useFallingNotesAudio.ts
+++ b/src/hooks/useFallingNotesAudio.ts
@@ -153,7 +153,9 @@ export function useFallingNotesAudio() {
         const sustainLevel = 0.6
         const releaseTime = 0.3
 
-        const velocity = note.velocity || 0.7
+        // Nullish (not `||`) so an explicit velocity of 0 stays silent rather
+        // than snapping to the default 0.7 — the canonical contract allows 0.
+        const velocity = note.velocity ?? 0.7
         const peakGain = velocity * 0.3
 
         // Attack

--- a/src/types/animationContract.ts
+++ b/src/types/animationContract.ts
@@ -1,0 +1,91 @@
+/**
+ * Canonical Animation Contract (P0-A)
+ *
+ * One versioned shape shared from the OMR converter output through storage to
+ * the player. This replaces the four divergent shapes documented in
+ * `docs/recovery/validation/2026-07-21-p0a-animation-shape-audit.md`:
+ * - Shape A `PianoNote` (`note:"C4"`, `startTime`, `hand:"left"|"right"`)
+ * - Shape B `FallingNote` (`midi`, `start`, `hand:"L"|"R"`)
+ * - Shape C `converter.py` output (`midi`, `start`, `hand:"R"|"L"`)
+ * - Shape D `MusicData` (`midi`, `start`, `hand:"L"|"R"`)
+ *
+ * The canonical shape is the MIDI family (per D-009): pitch is a MIDI number,
+ * onset is `start` (seconds), hand is `"L"|"R"`. `voice` and `staff` are new
+ * fields — absent from every current shape — added so P0-B can populate them and
+ * hand assignment stops relying on the `part_idx == 0 ? R : L` heuristic.
+ *
+ * Legacy Shape A JSON already exists in storage; it is not part of this type but
+ * is accepted and normalized to it by `normalizeAnimationData`
+ * (`src/utils/animationContract.ts`), so existing sheets keep rendering.
+ */
+
+/** Current canonical contract version. Bump on any breaking field change. */
+export const ANIMATION_CONTRACT_VERSION = '1.0'
+
+/** Lowest and highest MIDI numbers on an 88-key piano (A0–C8). */
+export const MIDI_MIN = 21
+export const MIDI_MAX = 108
+
+/** Hand assignment in canonical notation. */
+export type CanonicalHand = 'L' | 'R'
+
+/** Finger number, thumb (1) to pinky (5). */
+export type CanonicalFinger = 1 | 2 | 3 | 4 | 5
+
+/**
+ * A single note in the canonical contract.
+ *
+ * `midi`, `start`, and `duration` are required — they are the minimum a note
+ * needs to be scheduled and drawn (and the only fields the audio scheduler reads,
+ * per D-007). Everything else is optional so partial OMR output still validates.
+ */
+export interface CanonicalNote {
+  /** MIDI note number, 21–108. */
+  midi: number
+  /** Onset in seconds from the start of the piece. */
+  start: number
+  /** Duration in seconds. */
+  duration: number
+  /** Hand assignment, if known. */
+  hand?: CanonicalHand
+  /** Note velocity, 0–1. */
+  velocity?: number
+  /** Finger number, 1–5. */
+  finger?: CanonicalFinger
+  /** 1-based voice within the staff (new in v1; absent in legacy shapes). */
+  voice?: number
+  /** 1-based staff index — typically 1 = treble/RH, 2 = bass/LH (new in v1). */
+  staff?: number
+}
+
+/** Optional descriptive metadata; never required to render. */
+export interface CanonicalAnimationMetadata {
+  originalFileName?: string
+  fileSize?: number
+  processedAt?: string
+  keySignature?: string
+  pagesProcessed?: number
+  notesDetected?: number
+  [key: string]: unknown
+}
+
+/**
+ * The full canonical animation document: a versioned envelope around the note
+ * list plus the timing context needed to play it.
+ */
+export interface CanonicalAnimationData {
+  /** Contract version, e.g. "1.0". */
+  version: string
+  title: string
+  composer: string
+  /** Total duration in seconds. */
+  duration: number
+  /** Tempo in BPM. */
+  tempo: number
+  /** Time signature, e.g. "4/4". */
+  timeSignature: string
+  /** Key signature, e.g. "C" or "G". */
+  keySignature?: string
+  notes: CanonicalNote[]
+  metadata?: CanonicalAnimationMetadata
+}

--- a/src/utils/__tests__/animationContract.test.ts
+++ b/src/utils/__tests__/animationContract.test.ts
@@ -165,6 +165,17 @@ describe('normalizeAnimationData — field guards (PR #23 review)', () => {
     expect(out.notes[0].staff).toBeUndefined()
   })
 
+  it('rejects an unknown declared contract version but allows a missing one', () => {
+    // Declared future version → reject (would otherwise render with v1 semantics).
+    expect(() => normalizeAnimationData({ version: '2.0', notes: [{ midi: 60, start: 0, duration: 1 }] })).toThrow(
+      /unsupported animation contract version/
+    )
+    // Missing version → allowed (legacy / converter.py), filled with current.
+    expect(normalizeAnimationData({ notes: [{ midi: 60, start: 0, duration: 1 }] }).version).toBe(
+      ANIMATION_CONTRACT_VERSION
+    )
+  })
+
   it('falls back to a default tempo when tempo <= 0', () => {
     expect(normalizeAnimationData({ tempo: 0, notes: [{ midi: 60, start: 0, duration: 1 }] }).tempo).toBe(120)
     expect(normalizeAnimationData({ tempo: -60, notes: [{ midi: 60, start: 0, duration: 1 }] }).tempo).toBe(120)

--- a/src/utils/__tests__/animationContract.test.ts
+++ b/src/utils/__tests__/animationContract.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for the canonical animation contract validator/normalizer.
+ *
+ * Covers the P0-A completion criteria: legacy/old JSON validates without a cast,
+ * every supported shape normalizes to the canonical MIDI family, and malformed
+ * input is a hard error rather than a silent collapse to middle C (the failure
+ * documented in the shape audit).
+ */
+
+import {
+  normalizeAnimationData,
+  parsePitchToMidi,
+  isValidAnimationData,
+  AnimationContractError,
+} from '../animationContract'
+import { ANIMATION_CONTRACT_VERSION } from '@/types/animationContract'
+
+describe('parsePitchToMidi', () => {
+  it('parses natural, sharp, and flat pitches', () => {
+    expect(parsePitchToMidi('C4')).toBe(60)
+    expect(parsePitchToMidi('A0')).toBe(21)
+    expect(parsePitchToMidi('C8')).toBe(108)
+    expect(parsePitchToMidi('F#5')).toBe(78)
+    expect(parsePitchToMidi('Bb3')).toBe(58)
+  })
+
+  it('returns null for malformed names (no default-to-60)', () => {
+    expect(parsePitchToMidi('H4')).toBeNull()
+    expect(parsePitchToMidi('C')).toBeNull()
+    expect(parsePitchToMidi('')).toBeNull()
+    expect(parsePitchToMidi('60')).toBeNull()
+  })
+})
+
+describe('normalizeAnimationData — canonical (MIDI family)', () => {
+  it('passes a canonical document through, preserving voice/staff', () => {
+    const canonical = {
+      version: '1.0',
+      title: 'Etude',
+      composer: 'Anon',
+      duration: 1.0,
+      tempo: 90,
+      timeSignature: '3/4',
+      notes: [
+        { midi: 60, start: 0, duration: 0.5, hand: 'R', velocity: 0.7, finger: 1, voice: 1, staff: 1 },
+        { midi: 48, start: 0, duration: 1.0, hand: 'L', voice: 1, staff: 2 },
+      ],
+    }
+
+    const out = normalizeAnimationData(canonical)
+
+    expect(out.title).toBe('Etude')
+    expect(out.timeSignature).toBe('3/4')
+    expect(out.notes).toHaveLength(2)
+    expect(out.notes[0]).toMatchObject({ midi: 60, start: 0, duration: 0.5, hand: 'R', voice: 1, staff: 1 })
+    expect(out.notes[1]).toMatchObject({ midi: 48, hand: 'L', staff: 2 })
+  })
+})
+
+describe('normalizeAnimationData — legacy Shape A (string pitch)', () => {
+  it('converts note/startTime/left-right to midi/start/L-R', () => {
+    const legacy = {
+      version: '1.0',
+      title: 'Old Sheet',
+      composer: 'Someone',
+      duration: 2,
+      tempo: 120,
+      timeSignature: '4/4',
+      notes: [
+        { note: 'C4', startTime: 0, duration: 0.5, velocity: 0.8, hand: 'right', finger: 2 },
+        { note: 'F#3', startTime: 0.5, duration: 0.5, hand: 'left' },
+      ],
+    }
+
+    const out = normalizeAnimationData(legacy)
+
+    expect(out.notes[0]).toMatchObject({ midi: 60, start: 0, duration: 0.5, hand: 'R', velocity: 0.8, finger: 2 })
+    expect(out.notes[1]).toMatchObject({ midi: 54, start: 0.5, hand: 'L' })
+    // The old converter would have collapsed an unreadable field to 60/undefined;
+    // here a real pitch is preserved and the onset comes from startTime.
+  })
+})
+
+describe('normalizeAnimationData — converter.py shape (fields under metadata)', () => {
+  it('pulls title/composer/keySignature from metadata and fills defaults', () => {
+    const shapeC = {
+      metadata: { title: 'OMR Piece', composer: 'Bach', keySignature: 'G' },
+      notes: [{ midi: 67, start: 0, duration: 1.0, hand: 'R', finger: 3 }],
+      duration: 1.0,
+      tempo: 100,
+      timeSignature: '4/4',
+      generated_at: '2026-07-21T00:00:00Z',
+    }
+
+    const out = normalizeAnimationData(shapeC)
+
+    expect(out.title).toBe('OMR Piece')
+    expect(out.composer).toBe('Bach')
+    expect(out.keySignature).toBe('G')
+    expect(out.version).toBe(ANIMATION_CONTRACT_VERSION) // no version in Shape C → filled
+    expect(out.notes[0]).toMatchObject({ midi: 67, hand: 'R', finger: 3 })
+  })
+})
+
+describe('normalizeAnimationData — hard errors (no silent fallback)', () => {
+  it('throws when a pitch is unreadable instead of defaulting to middle C', () => {
+    const bad = { notes: [{ note: 'H9', start: 0, duration: 0.5 }] }
+    expect(() => normalizeAnimationData(bad)).toThrow(AnimationContractError)
+    expect(() => normalizeAnimationData(bad)).toThrow(/not a valid pitch/)
+  })
+
+  it('throws when MIDI is outside the piano range', () => {
+    const bad = { notes: [{ midi: 5, start: 0, duration: 0.5 }] }
+    expect(() => normalizeAnimationData(bad)).toThrow(/outside the piano range/)
+  })
+
+  it('throws when start/duration is missing or non-finite', () => {
+    expect(() => normalizeAnimationData({ notes: [{ midi: 60, duration: 0.5 }] })).toThrow(/start/)
+    expect(() => normalizeAnimationData({ notes: [{ midi: 60, start: 0 }] })).toThrow(/duration/)
+    expect(() => normalizeAnimationData({ notes: [{ midi: 60, start: NaN, duration: 1 }] })).toThrow(/start/)
+  })
+
+  it('throws when there is no notes array', () => {
+    expect(() => normalizeAnimationData({ title: 'x' })).toThrow(/notes/)
+  })
+
+  it('throws for a non-object document', () => {
+    expect(() => normalizeAnimationData(null)).toThrow(AnimationContractError)
+    expect(() => normalizeAnimationData('nope')).toThrow(/must be an object/)
+  })
+})
+
+describe('normalizeAnimationData — defaults', () => {
+  it('derives duration from notes when absent and fills tempo/timeSignature', () => {
+    const out = normalizeAnimationData({
+      notes: [{ midi: 60, start: 1, duration: 0.5 }],
+    })
+    expect(out.duration).toBeCloseTo(1.5)
+    expect(out.tempo).toBe(120)
+    expect(out.timeSignature).toBe('4/4')
+    expect(out.title).toBe('Untitled')
+  })
+})
+
+describe('isValidAnimationData', () => {
+  it('is true for canonical and false for malformed', () => {
+    expect(isValidAnimationData({ notes: [{ midi: 60, start: 0, duration: 1 }] })).toBe(true)
+    expect(isValidAnimationData({ notes: [{ midi: 999, start: 0, duration: 1 }] })).toBe(false)
+    expect(isValidAnimationData(42)).toBe(false)
+  })
+})

--- a/src/utils/__tests__/animationContract.test.ts
+++ b/src/utils/__tests__/animationContract.test.ts
@@ -142,6 +142,40 @@ describe('normalizeAnimationData — defaults', () => {
   })
 })
 
+describe('normalizeAnimationData — field guards (PR #23 review)', () => {
+  it('clamps velocity into 0–1', () => {
+    const out = normalizeAnimationData({
+      notes: [
+        { midi: 60, start: 0, duration: 1, velocity: 5 },
+        { midi: 62, start: 1, duration: 1, velocity: -2 },
+      ],
+    })
+    expect(out.notes[0].velocity).toBe(1)
+    expect(out.notes[1].velocity).toBe(0)
+  })
+
+  it('rejects a non-integer finger string like "3.5"', () => {
+    const out = normalizeAnimationData({ notes: [{ midi: 60, start: 0, duration: 1, finger: '3.5' }] })
+    expect(out.notes[0].finger).toBeUndefined()
+  })
+
+  it('ignores voice/staff below 1', () => {
+    const out = normalizeAnimationData({ notes: [{ midi: 60, start: 0, duration: 1, voice: 0, staff: -1 }] })
+    expect(out.notes[0].voice).toBeUndefined()
+    expect(out.notes[0].staff).toBeUndefined()
+  })
+
+  it('falls back to a default tempo when tempo <= 0', () => {
+    expect(normalizeAnimationData({ tempo: 0, notes: [{ midi: 60, start: 0, duration: 1 }] }).tempo).toBe(120)
+    expect(normalizeAnimationData({ tempo: -60, notes: [{ midi: 60, start: 0, duration: 1 }] }).tempo).toBe(120)
+  })
+
+  it('derives duration from notes when the given duration is negative', () => {
+    const out = normalizeAnimationData({ duration: -5, notes: [{ midi: 60, start: 1, duration: 0.5 }] })
+    expect(out.duration).toBeCloseTo(1.5)
+  })
+})
+
 describe('isValidAnimationData', () => {
   it('is true for canonical and false for malformed', () => {
     expect(isValidAnimationData({ notes: [{ midi: 60, start: 0, duration: 1 }] })).toBe(true)

--- a/src/utils/__tests__/animationFixtures.test.ts
+++ b/src/utils/__tests__/animationFixtures.test.ts
@@ -113,15 +113,38 @@ describe('compareAnimationData', () => {
     expect(result.diffs.some((d) => d.field === 'start')).toBe(true)
   })
 
-  it('flags a wrong pitch (the old middle-C collapse would surface here)', () => {
-    const expected = loadExpected('01-monophonic')
+  it('flags the middle-C collapse as missing expected pitches + extra notes', () => {
+    const expected = loadExpected('01-monophonic') // 60, 62, 64, 65
     const actual: CanonicalAnimationData = {
       ...expected,
       notes: expected.notes.map((n) => ({ ...n, midi: 60 })), // everything collapsed to middle C
     }
     const result = compareAnimationData(actual, expected)
     expect(result.match).toBe(false)
-    expect(result.diffs.filter((d) => d.field === 'midi').length).toBeGreaterThan(0)
+    // 60 matches; 62/64/65 have no pitch partner → missing; extra 60s remain.
+    expect(result.diffs.some((d) => d.field === 'missing')).toBe(true)
+    expect(result.diffs.some((d) => d.field === 'extra')).toBe(true)
+  })
+
+  it('matches by pitch+timing, so a missing middle note does not cascade', () => {
+    const expected = loadExpected('01-monophonic') // 4 notes
+    const actual: CanonicalAnimationData = {
+      ...expected,
+      notes: expected.notes.filter((_, i) => i !== 1), // drop the 2nd note
+    }
+    const result = compareAnimationData(actual, expected)
+    // Exactly one missing, no false diffs on the surrounding notes.
+    expect(result.diffs.filter((d) => d.field === 'missing')).toHaveLength(1)
+    expect(result.diffs.filter((d) => d.field !== 'missing')).toHaveLength(0)
+  })
+
+  it('does not mispair equal-onset chord notes reordered in the actual', () => {
+    const expected = loadExpected('02-chord') // three notes share start 0
+    const actual: CanonicalAnimationData = {
+      ...expected,
+      notes: [...expected.notes].reverse(), // same notes, different order
+    }
+    expect(compareAnimationData(actual, expected).match).toBe(true)
   })
 
   it('flags a wrong hand assignment', () => {

--- a/src/utils/__tests__/animationFixtures.test.ts
+++ b/src/utils/__tests__/animationFixtures.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Golden corpus tests (P0-A).
+ *
+ * 1. Every fixture's `expected.json` is a valid canonical document — the corpus
+ *    itself conforms to the contract it will judge others against.
+ * 2. The comparison tool (`compareAnimationData`) reports clean matches, detects
+ *    real mismatches, and honours the timing tolerance.
+ *
+ * These do NOT run the OMR converter (that is P0-B). They lock the corpus and
+ * the measurement tool so P0-B/P0-C can be scored against them.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import { normalizeAnimationData } from '../animationContract'
+import { compareAnimationData, DEFAULT_TOLERANCE } from '../animationCompare'
+import type { CanonicalAnimationData } from '@/types/animationContract'
+
+const FIXTURES_DIR = path.join(process.cwd(), 'fixtures', 'animation-contract')
+
+function fixtureDirs(): string[] {
+  return fs
+    .readdirSync(FIXTURES_DIR, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name)
+    .sort()
+}
+
+function loadExpected(dir: string): CanonicalAnimationData {
+  const raw = fs.readFileSync(path.join(FIXTURES_DIR, dir, 'expected.json'), 'utf-8')
+  return normalizeAnimationData(JSON.parse(raw))
+}
+
+describe('golden corpus — coverage', () => {
+  it('has at least the 7 required fixtures', () => {
+    expect(fixtureDirs().length).toBeGreaterThanOrEqual(7)
+  })
+
+  it('each fixture has both input.musicxml and expected.json', () => {
+    for (const dir of fixtureDirs()) {
+      expect(fs.existsSync(path.join(FIXTURES_DIR, dir, 'input.musicxml'))).toBe(true)
+      expect(fs.existsSync(path.join(FIXTURES_DIR, dir, 'expected.json'))).toBe(true)
+    }
+  })
+})
+
+describe('golden corpus — expected.json validates against the contract', () => {
+  for (const dir of fixtureDirs()) {
+    it(`${dir}/expected.json normalizes cleanly`, () => {
+      expect(() => loadExpected(dir)).not.toThrow()
+      const doc = loadExpected(dir)
+      expect(doc.notes.length).toBeGreaterThan(0)
+      // Every note carries the fields P0-B must produce.
+      for (const n of doc.notes) {
+        expect(n.midi).toBeGreaterThanOrEqual(21)
+        expect(n.midi).toBeLessThanOrEqual(108)
+        expect(Number.isFinite(n.start)).toBe(true)
+        expect(Number.isFinite(n.duration)).toBe(true)
+      }
+    })
+  }
+})
+
+describe('golden corpus — self-consistency invariants', () => {
+  it('grand-staff fixture assigns hands by staff (staff 1 → R, staff 2 → L)', () => {
+    const doc = loadExpected('04-grand-staff')
+    for (const n of doc.notes) {
+      if (n.staff === 1) expect(n.hand).toBe('R')
+      if (n.staff === 2) expect(n.hand).toBe('L')
+    }
+  })
+
+  it('multi-voice fixture keeps two voices on the same staff', () => {
+    const doc = loadExpected('05-multivoice')
+    const voices = new Set(doc.notes.map((n) => n.voice))
+    const staves = new Set(doc.notes.map((n) => n.staff))
+    expect(voices.size).toBe(2)
+    expect(staves.size).toBe(1)
+  })
+
+  it('chord fixture has three notes sharing an onset', () => {
+    const doc = loadExpected('02-chord')
+    const atZero = doc.notes.filter((n) => n.start === 0)
+    expect(atZero.length).toBe(3)
+  })
+})
+
+describe('compareAnimationData', () => {
+  it('reports a clean match when a document is compared with itself', () => {
+    const doc = loadExpected('01-monophonic')
+    const result = compareAnimationData(doc, doc)
+    expect(result.match).toBe(true)
+    expect(result.diffs).toHaveLength(0)
+  })
+
+  it('accepts onset/duration drift within tolerance', () => {
+    const expected = loadExpected('01-monophonic')
+    const actual: CanonicalAnimationData = {
+      ...expected,
+      notes: expected.notes.map((n) => ({ ...n, start: n.start + 0.005, duration: n.duration - 0.005 })),
+    }
+    expect(compareAnimationData(actual, expected, DEFAULT_TOLERANCE).match).toBe(true)
+  })
+
+  it('flags onset drift beyond tolerance', () => {
+    const expected = loadExpected('01-monophonic')
+    const actual: CanonicalAnimationData = {
+      ...expected,
+      notes: expected.notes.map((n, i) => (i === 0 ? { ...n, start: n.start + 0.5 } : n)),
+    }
+    const result = compareAnimationData(actual, expected)
+    expect(result.match).toBe(false)
+    expect(result.diffs.some((d) => d.field === 'start')).toBe(true)
+  })
+
+  it('flags a wrong pitch (the old middle-C collapse would surface here)', () => {
+    const expected = loadExpected('01-monophonic')
+    const actual: CanonicalAnimationData = {
+      ...expected,
+      notes: expected.notes.map((n) => ({ ...n, midi: 60 })), // everything collapsed to middle C
+    }
+    const result = compareAnimationData(actual, expected)
+    expect(result.match).toBe(false)
+    expect(result.diffs.filter((d) => d.field === 'midi').length).toBeGreaterThan(0)
+  })
+
+  it('flags a wrong hand assignment', () => {
+    const expected = loadExpected('04-grand-staff')
+    const actual: CanonicalAnimationData = {
+      ...expected,
+      notes: expected.notes.map((n) => ({ ...n, hand: 'R' as const })),
+    }
+    const result = compareAnimationData(actual, expected)
+    expect(result.match).toBe(false)
+    expect(result.diffs.some((d) => d.field === 'hand')).toBe(true)
+  })
+
+  it('reports missing and extra notes on count mismatch', () => {
+    const expected = loadExpected('01-monophonic')
+    const short: CanonicalAnimationData = { ...expected, notes: expected.notes.slice(0, 2) }
+    const result = compareAnimationData(short, expected)
+    expect(result.match).toBe(false)
+    expect(result.diffs.some((d) => d.field === 'missing')).toBe(true)
+  })
+})

--- a/src/utils/animationCompare.ts
+++ b/src/utils/animationCompare.ts
@@ -1,0 +1,112 @@
+/**
+ * Golden-fixture comparison for the canonical animation contract (P0-A).
+ *
+ * Compares an *actual* animation document (e.g. a future converter's output)
+ * against an *expected* golden document, with a float tolerance on timing. This
+ * is the measurement tool P0-B/P0-C accuracy work will run against the golden
+ * corpus in `fixtures/animation-contract/`.
+ *
+ * Pitch (`midi`), `hand`, `voice`, and `staff` are compared exactly; `start` and
+ * `duration` within tolerance. Notes are matched positionally after both lists
+ * are sorted by (start, midi, hand) so ordering differences do not cause false
+ * mismatches.
+ */
+
+import type { CanonicalAnimationData, CanonicalNote } from '@/types/animationContract'
+
+export interface CompareTolerance {
+  /** Max allowed absolute onset difference, seconds. */
+  onsetSec: number
+  /** Max allowed absolute duration difference, seconds. */
+  durationSec: number
+}
+
+export const DEFAULT_TOLERANCE: CompareTolerance = {
+  onsetSec: 0.01,
+  durationSec: 0.01,
+}
+
+export interface NoteDiff {
+  /** Index into the sorted note lists. */
+  index: number
+  field: 'midi' | 'start' | 'duration' | 'hand' | 'voice' | 'staff' | 'missing' | 'extra'
+  expected: unknown
+  actual: unknown
+}
+
+export interface ComparisonResult {
+  match: boolean
+  expectedCount: number
+  actualCount: number
+  diffs: NoteDiff[]
+}
+
+function sortNotes(notes: CanonicalNote[]): CanonicalNote[] {
+  return [...notes].sort(
+    (a, b) =>
+      a.start - b.start ||
+      a.midi - b.midi ||
+      (a.hand ?? '').localeCompare(b.hand ?? '')
+  )
+}
+
+/**
+ * Compare two canonical documents note-by-note. Returns a structured result;
+ * `match` is true only when counts agree and every note matches within tolerance.
+ */
+export function compareAnimationData(
+  actual: CanonicalAnimationData,
+  expected: CanonicalAnimationData,
+  tolerance: CompareTolerance = DEFAULT_TOLERANCE
+): ComparisonResult {
+  const exp = sortNotes(expected.notes)
+  const act = sortNotes(actual.notes)
+  const diffs: NoteDiff[] = []
+
+  const common = Math.min(exp.length, act.length)
+  for (let i = 0; i < common; i++) {
+    const e = exp[i]
+    const a = act[i]
+
+    if (e.midi !== a.midi) diffs.push({ index: i, field: 'midi', expected: e.midi, actual: a.midi })
+    if (Math.abs(e.start - a.start) > tolerance.onsetSec) {
+      diffs.push({ index: i, field: 'start', expected: e.start, actual: a.start })
+    }
+    if (Math.abs(e.duration - a.duration) > tolerance.durationSec) {
+      diffs.push({ index: i, field: 'duration', expected: e.duration, actual: a.duration })
+    }
+    if ((e.hand ?? null) !== (a.hand ?? null)) {
+      diffs.push({ index: i, field: 'hand', expected: e.hand ?? null, actual: a.hand ?? null })
+    }
+    if ((e.voice ?? null) !== (a.voice ?? null)) {
+      diffs.push({ index: i, field: 'voice', expected: e.voice ?? null, actual: a.voice ?? null })
+    }
+    if ((e.staff ?? null) !== (a.staff ?? null)) {
+      diffs.push({ index: i, field: 'staff', expected: e.staff ?? null, actual: a.staff ?? null })
+    }
+  }
+
+  // Report length mismatches as missing/extra notes.
+  for (let i = common; i < exp.length; i++) {
+    diffs.push({ index: i, field: 'missing', expected: exp[i], actual: null })
+  }
+  for (let i = common; i < act.length; i++) {
+    diffs.push({ index: i, field: 'extra', expected: null, actual: act[i] })
+  }
+
+  return {
+    match: diffs.length === 0,
+    expectedCount: exp.length,
+    actualCount: act.length,
+    diffs,
+  }
+}
+
+/** Human-readable one-line-per-diff rendering, for test output and CLIs. */
+export function formatComparison(result: ComparisonResult): string {
+  if (result.match) return `match: ${result.expectedCount} notes`
+  const lines = result.diffs.map(
+    (d) => `  note[${d.index}] ${d.field}: expected ${JSON.stringify(d.expected)}, actual ${JSON.stringify(d.actual)}`
+  )
+  return `mismatch (expected ${result.expectedCount}, actual ${result.actualCount}):\n${lines.join('\n')}`
+}

--- a/src/utils/animationCompare.ts
+++ b/src/utils/animationCompare.ts
@@ -41,57 +41,103 @@ export interface ComparisonResult {
   diffs: NoteDiff[]
 }
 
-function sortNotes(notes: CanonicalNote[]): CanonicalNote[] {
-  return [...notes].sort(
-    (a, b) =>
-      a.start - b.start ||
-      a.midi - b.midi ||
-      (a.hand ?? '').localeCompare(b.hand ?? '')
-  )
+function sameOrNull<T>(a: T | undefined, b: T | undefined): boolean {
+  return (a ?? null) === (b ?? null)
 }
 
 /**
- * Compare two canonical documents note-by-note. Returns a structured result;
- * `match` is true only when counts agree and every note matches within tolerance.
+ * Find the best unmatched actual note for an expected note.
+ *
+ * Candidates must share the exact `midi`. When `requireTolerance` is set they
+ * must also fall within the timing tolerance (pass 1 — clean matches). Among
+ * candidates, the one matching the most of {hand, voice, staff} wins, then the
+ * closest onset — so a chord's same-pitch notes are not mispaired across voices
+ * and small onset jitter does not swap them.
+ */
+function findMatch(
+  expectedNote: CanonicalNote,
+  actualNotes: CanonicalNote[],
+  used: Set<number>,
+  tolerance: CompareTolerance,
+  requireTolerance: boolean
+): number {
+  let best = -1
+  let bestScore = Number.POSITIVE_INFINITY
+
+  for (let j = 0; j < actualNotes.length; j++) {
+    if (used.has(j)) continue
+    const a = actualNotes[j]
+    if (a.midi !== expectedNote.midi) continue
+
+    const onsetDelta = Math.abs(a.start - expectedNote.start)
+    if (requireTolerance) {
+      if (onsetDelta > tolerance.onsetSec) continue
+      if (Math.abs(a.duration - expectedNote.duration) > tolerance.durationSec) continue
+    }
+
+    // Prefer exact hand/voice/staff, then the nearest onset.
+    const fieldMisses =
+      (sameOrNull(a.hand, expectedNote.hand) ? 0 : 1) +
+      (sameOrNull(a.voice, expectedNote.voice) ? 0 : 1) +
+      (sameOrNull(a.staff, expectedNote.staff) ? 0 : 1)
+    const score = fieldMisses * 1_000_000 + onsetDelta
+    if (score < bestScore) {
+      bestScore = score
+      best = j
+    }
+  }
+
+  return best
+}
+
+/**
+ * Compare two canonical documents with tolerance-aware note matching. `match` is
+ * true only when every expected note finds a partner within tolerance, no fields
+ * differ, and there are no extra notes.
+ *
+ * Notes are matched by pitch + timing (not by array position), so a missing or
+ * extra note does not cascade into every following note being reported wrong,
+ * and equal-onset chord notes are paired by their exact fields rather than input
+ * order. An expected note with the right pitch but out-of-tolerance timing is
+ * still matched (pass 2) and its timing reported as a diff; a pitch with no
+ * partner is reported `missing`.
  */
 export function compareAnimationData(
   actual: CanonicalAnimationData,
   expected: CanonicalAnimationData,
   tolerance: CompareTolerance = DEFAULT_TOLERANCE
 ): ComparisonResult {
-  const exp = sortNotes(expected.notes)
-  const act = sortNotes(actual.notes)
+  const exp = expected.notes
+  const act = actual.notes
+  const used = new Set<number>()
   const diffs: NoteDiff[] = []
 
-  const common = Math.min(exp.length, act.length)
-  for (let i = 0; i < common; i++) {
+  for (let i = 0; i < exp.length; i++) {
     const e = exp[i]
-    const a = act[i]
+    // Pass 1: a clean match within tolerance. Pass 2: same pitch, any timing.
+    let j = findMatch(e, act, used, tolerance, true)
+    if (j === -1) j = findMatch(e, act, used, tolerance, false)
 
-    if (e.midi !== a.midi) diffs.push({ index: i, field: 'midi', expected: e.midi, actual: a.midi })
+    if (j === -1) {
+      diffs.push({ index: i, field: 'missing', expected: e, actual: null })
+      continue
+    }
+
+    used.add(j)
+    const a = act[j]
     if (Math.abs(e.start - a.start) > tolerance.onsetSec) {
       diffs.push({ index: i, field: 'start', expected: e.start, actual: a.start })
     }
     if (Math.abs(e.duration - a.duration) > tolerance.durationSec) {
       diffs.push({ index: i, field: 'duration', expected: e.duration, actual: a.duration })
     }
-    if ((e.hand ?? null) !== (a.hand ?? null)) {
-      diffs.push({ index: i, field: 'hand', expected: e.hand ?? null, actual: a.hand ?? null })
-    }
-    if ((e.voice ?? null) !== (a.voice ?? null)) {
-      diffs.push({ index: i, field: 'voice', expected: e.voice ?? null, actual: a.voice ?? null })
-    }
-    if ((e.staff ?? null) !== (a.staff ?? null)) {
-      diffs.push({ index: i, field: 'staff', expected: e.staff ?? null, actual: a.staff ?? null })
-    }
+    if (!sameOrNull(e.hand, a.hand)) diffs.push({ index: i, field: 'hand', expected: e.hand ?? null, actual: a.hand ?? null })
+    if (!sameOrNull(e.voice, a.voice)) diffs.push({ index: i, field: 'voice', expected: e.voice ?? null, actual: a.voice ?? null })
+    if (!sameOrNull(e.staff, a.staff)) diffs.push({ index: i, field: 'staff', expected: e.staff ?? null, actual: a.staff ?? null })
   }
 
-  // Report length mismatches as missing/extra notes.
-  for (let i = common; i < exp.length; i++) {
-    diffs.push({ index: i, field: 'missing', expected: exp[i], actual: null })
-  }
-  for (let i = common; i < act.length; i++) {
-    diffs.push({ index: i, field: 'extra', expected: null, actual: act[i] })
+  for (let j = 0; j < act.length; j++) {
+    if (!used.has(j)) diffs.push({ index: j, field: 'extra', expected: null, actual: act[j] })
   }
 
   return {

--- a/src/utils/animationContract.ts
+++ b/src/utils/animationContract.ts
@@ -1,0 +1,203 @@
+/**
+ * Runtime validation and normalization for the canonical animation contract
+ * (`src/types/animationContract.ts`, P0-A).
+ *
+ * This is the single entry point that replaces the unchecked
+ * `JSON.parse(...) as PianoAnimationData` cast at the player boundary
+ * (`sheet/[id]/page.tsx`). It accepts:
+ * - canonical / MIDI-family JSON (`midi`, `start`, `hand:"L"|"R"`)
+ * - legacy Shape A JSON (`note:"C4"`, `startTime`, `hand:"left"|"right"`)
+ * - `converter.py`-style JSON (top-level fields partly under `metadata`)
+ *
+ * and returns a `CanonicalAnimationData`, or throws `AnimationContractError` with
+ * a specific reason. Unlike the old `convertToFallingNotes`, an unparseable pitch
+ * is a hard error — it never silently collapses to middle C.
+ */
+
+import {
+  ANIMATION_CONTRACT_VERSION,
+  MIDI_MIN,
+  MIDI_MAX,
+  type CanonicalAnimationData,
+  type CanonicalNote,
+  type CanonicalHand,
+  type CanonicalFinger,
+} from '@/types/animationContract'
+
+/** Thrown when input cannot be normalized into the canonical contract. */
+export class AnimationContractError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'AnimationContractError'
+  }
+}
+
+const SEMITONE: Record<string, number> = {
+  C: 0, D: 2, E: 4, F: 5, G: 7, A: 9, B: 11,
+}
+
+/**
+ * Strictly parse a scientific-pitch name (e.g. "C4", "F#5", "Bb3") to MIDI.
+ * Returns `null` when the name is malformed — the caller decides whether that is
+ * fatal. Deliberately not lenient: no default-to-60 fallback.
+ */
+export function parsePitchToMidi(name: string): number | null {
+  const match = /^([A-G])(#|b)?(-?\d+)$/.exec(name.trim())
+  if (!match) return null
+
+  const [, letter, accidental, octaveStr] = match
+  const base = SEMITONE[letter]
+  if (base === undefined) return null
+
+  const alter = accidental === '#' ? 1 : accidental === 'b' ? -1 : 0
+  const octave = Number.parseInt(octaveStr, 10)
+  // MIDI: C4 = 60, so (octave + 1) * 12 + semitone.
+  const midi = (octave + 1) * 12 + base + alter
+
+  return Number.isFinite(midi) ? midi : null
+}
+
+function normalizeHand(raw: unknown): CanonicalHand | undefined {
+  if (raw === 'L' || raw === 'R') return raw
+  if (raw === 'left') return 'L'
+  if (raw === 'right') return 'R'
+  return undefined
+}
+
+function normalizeFinger(raw: unknown): CanonicalFinger | undefined {
+  const n = typeof raw === 'string' ? Number.parseInt(raw, 10) : raw
+  if (typeof n === 'number' && Number.isInteger(n) && n >= 1 && n <= 5) {
+    return n as CanonicalFinger
+  }
+  return undefined
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null
+}
+
+function requireFiniteNumber(value: unknown, field: string, noteIndex: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new AnimationContractError(
+      `note[${noteIndex}].${field} must be a finite number, got ${JSON.stringify(value)}`
+    )
+  }
+  return value
+}
+
+/**
+ * Normalize a single raw note (any supported shape) to a `CanonicalNote`.
+ * Throws on a missing/unparseable pitch, a MIDI number out of the 21–108 piano
+ * range, or a non-finite start/duration.
+ */
+function normalizeNote(raw: unknown, index: number): CanonicalNote {
+  if (!isObject(raw)) {
+    throw new AnimationContractError(`note[${index}] must be an object, got ${JSON.stringify(raw)}`)
+  }
+
+  // Pitch: prefer canonical `midi`, else parse a legacy `note` string.
+  let midi: number
+  if (typeof raw.midi === 'number') {
+    midi = raw.midi
+  } else if (typeof raw.note === 'string') {
+    const parsed = parsePitchToMidi(raw.note)
+    if (parsed === null) {
+      throw new AnimationContractError(`note[${index}].note is not a valid pitch: ${JSON.stringify(raw.note)}`)
+    }
+    midi = parsed
+  } else {
+    throw new AnimationContractError(`note[${index}] has no usable pitch (need \`midi\` number or \`note\` string)`)
+  }
+
+  if (!Number.isInteger(midi) || midi < MIDI_MIN || midi > MIDI_MAX) {
+    throw new AnimationContractError(
+      `note[${index}] MIDI ${midi} is outside the piano range ${MIDI_MIN}–${MIDI_MAX}`
+    )
+  }
+
+  // Onset: prefer canonical `start`, else legacy `startTime`.
+  const startRaw = raw.start ?? raw.startTime
+  const start = requireFiniteNumber(startRaw, 'start', index)
+  const duration = requireFiniteNumber(raw.duration, 'duration', index)
+  if (start < 0) throw new AnimationContractError(`note[${index}].start must be >= 0, got ${start}`)
+  if (duration < 0) throw new AnimationContractError(`note[${index}].duration must be >= 0, got ${duration}`)
+
+  const note: CanonicalNote = { midi, start, duration }
+
+  const hand = normalizeHand(raw.hand)
+  if (hand) note.hand = hand
+  if (typeof raw.velocity === 'number' && Number.isFinite(raw.velocity)) note.velocity = raw.velocity
+  const finger = normalizeFinger(raw.finger)
+  if (finger) note.finger = finger
+  if (typeof raw.voice === 'number' && Number.isInteger(raw.voice)) note.voice = raw.voice
+  if (typeof raw.staff === 'number' && Number.isInteger(raw.staff)) note.staff = raw.staff
+
+  return note
+}
+
+function pickString(...candidates: unknown[]): string | undefined {
+  for (const c of candidates) {
+    if (typeof c === 'string' && c.length > 0) return c
+  }
+  return undefined
+}
+
+/**
+ * Validate and normalize arbitrary parsed JSON into `CanonicalAnimationData`.
+ * Accepts canonical, legacy Shape A, and `converter.py`-style documents; throws
+ * `AnimationContractError` with a specific reason when it cannot.
+ */
+export function normalizeAnimationData(raw: unknown): CanonicalAnimationData {
+  if (!isObject(raw)) {
+    throw new AnimationContractError(`animation data must be an object, got ${JSON.stringify(raw)}`)
+  }
+
+  if (!Array.isArray(raw.notes)) {
+    throw new AnimationContractError('animation data is missing a `notes` array')
+  }
+
+  const notes = raw.notes.map((n, i) => normalizeNote(n, i))
+
+  // Shape C keeps title/composer/keySignature under `metadata`; fall back to it.
+  const meta = isObject(raw.metadata) ? raw.metadata : {}
+
+  const title = pickString(raw.title, meta.title) ?? 'Untitled'
+  const composer = pickString(raw.composer, meta.composer) ?? 'Unknown'
+  const timeSignature = pickString(raw.timeSignature) ?? '4/4'
+  const keySignature = pickString(raw.keySignature, meta.keySignature)
+
+  const duration =
+    typeof raw.duration === 'number' && Number.isFinite(raw.duration)
+      ? raw.duration
+      : notes.reduce((max, n) => Math.max(max, n.start + n.duration), 0)
+
+  const tempo = typeof raw.tempo === 'number' && Number.isFinite(raw.tempo) ? raw.tempo : 120
+
+  const result: CanonicalAnimationData = {
+    version: pickString(raw.version) ?? ANIMATION_CONTRACT_VERSION,
+    title,
+    composer,
+    duration,
+    tempo,
+    timeSignature,
+    notes,
+  }
+  if (keySignature) result.keySignature = keySignature
+  if (isObject(raw.metadata)) result.metadata = raw.metadata as CanonicalAnimationData['metadata']
+
+  return result
+}
+
+/**
+ * Type guard form: returns true when `raw` normalizes cleanly. Prefer
+ * `normalizeAnimationData` directly when you want the normalized value or the
+ * specific error message.
+ */
+export function isValidAnimationData(raw: unknown): boolean {
+  try {
+    normalizeAnimationData(raw)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/src/utils/animationContract.ts
+++ b/src/utils/animationContract.ts
@@ -65,9 +65,12 @@ function normalizeHand(raw: unknown): CanonicalHand | undefined {
 }
 
 function normalizeFinger(raw: unknown): CanonicalFinger | undefined {
-  const n = typeof raw === 'string' ? Number.parseInt(raw, 10) : raw
-  if (typeof n === 'number' && Number.isInteger(n) && n >= 1 && n <= 5) {
-    return n as CanonicalFinger
+  if (typeof raw === 'number' && Number.isInteger(raw) && raw >= 1 && raw <= 5) {
+    return raw as CanonicalFinger
+  }
+  // Strings must be an exact integer 1–5 — "3.5" is not a valid finger.
+  if (typeof raw === 'string' && /^[1-5]$/.test(raw.trim())) {
+    return Number.parseInt(raw, 10) as CanonicalFinger
   }
   return undefined
 }
@@ -126,11 +129,15 @@ function normalizeNote(raw: unknown, index: number): CanonicalNote {
 
   const hand = normalizeHand(raw.hand)
   if (hand) note.hand = hand
-  if (typeof raw.velocity === 'number' && Number.isFinite(raw.velocity)) note.velocity = raw.velocity
+  // Velocity is spec'd 0–1; clamp rather than reject (loudness is non-critical).
+  if (typeof raw.velocity === 'number' && Number.isFinite(raw.velocity)) {
+    note.velocity = Math.max(0, Math.min(1, raw.velocity))
+  }
   const finger = normalizeFinger(raw.finger)
   if (finger) note.finger = finger
-  if (typeof raw.voice === 'number' && Number.isInteger(raw.voice)) note.voice = raw.voice
-  if (typeof raw.staff === 'number' && Number.isInteger(raw.staff)) note.staff = raw.staff
+  // voice/staff are 1-based; ignore 0 or negative.
+  if (typeof raw.voice === 'number' && Number.isInteger(raw.voice) && raw.voice >= 1) note.voice = raw.voice
+  if (typeof raw.staff === 'number' && Number.isInteger(raw.staff) && raw.staff >= 1) note.staff = raw.staff
 
   return note
 }
@@ -167,11 +174,13 @@ export function normalizeAnimationData(raw: unknown): CanonicalAnimationData {
   const keySignature = pickString(raw.keySignature, meta.keySignature)
 
   const duration =
-    typeof raw.duration === 'number' && Number.isFinite(raw.duration)
+    typeof raw.duration === 'number' && Number.isFinite(raw.duration) && raw.duration >= 0
       ? raw.duration
       : notes.reduce((max, n) => Math.max(max, n.start + n.duration), 0)
 
-  const tempo = typeof raw.tempo === 'number' && Number.isFinite(raw.tempo) ? raw.tempo : 120
+  // Guard against tempo <= 0 (division-by-zero for any BPM-based timing).
+  const tempo =
+    typeof raw.tempo === 'number' && Number.isFinite(raw.tempo) && raw.tempo > 0 ? raw.tempo : 120
 
   const result: CanonicalAnimationData = {
     version: pickString(raw.version) ?? ANIMATION_CONTRACT_VERSION,

--- a/src/utils/animationContract.ts
+++ b/src/utils/animationContract.ts
@@ -163,6 +163,17 @@ export function normalizeAnimationData(raw: unknown): CanonicalAnimationData {
     throw new AnimationContractError('animation data is missing a `notes` array')
   }
 
+  // The version envelope only protects against breaking changes if an unknown
+  // *declared* version is rejected rather than rendered with v1 semantics. A
+  // missing version is allowed (legacy Shape A / converter.py shape) and filled
+  // with the current version below.
+  const declaredVersion = pickString(raw.version)
+  if (declaredVersion && declaredVersion !== ANIMATION_CONTRACT_VERSION) {
+    throw new AnimationContractError(
+      `unsupported animation contract version ${JSON.stringify(declaredVersion)} (supported: ${ANIMATION_CONTRACT_VERSION})`
+    )
+  }
+
   const notes = raw.notes.map((n, i) => normalizeNote(n, i))
 
   // Shape C keeps title/composer/keySignature under `metadata`; fall back to it.

--- a/src/utils/dataConverter.ts
+++ b/src/utils/dataConverter.ts
@@ -1,5 +1,6 @@
 import type { PianoAnimationData, PianoNote } from '@/types/animation'
 import type { FallingNote } from '@/types/fallingNotes'
+import type { CanonicalAnimationData } from '@/types/animationContract'
 
 /**
  * Data Converter Utilities
@@ -82,6 +83,25 @@ export function convertToFallingNotes(animationData: PianoAnimationData): Fallin
       velocity: note.velocity
     };
   });
+}
+
+/**
+ * Convert a canonical animation document to the player's FallingNote array.
+ *
+ * The canonical note shape (MIDI family, per D-009) is already FallingNote-shaped
+ * — this is a near-identity map, dropping only `voice`/`staff` which the player
+ * does not consume. Prefer this over `convertToFallingNotes` (which parses the
+ * legacy string-pitch Shape A) once data has been through `normalizeAnimationData`.
+ */
+export function canonicalToFallingNotes(data: CanonicalAnimationData): FallingNote[] {
+  return data.notes.map((note) => ({
+    midi: note.midi,
+    start: note.start,
+    duration: note.duration,
+    hand: note.hand,
+    finger: note.finger,
+    velocity: note.velocity,
+  }));
 }
 
 /**


### PR DESCRIPTION
## 목적 (P0-A)

OMR 결과부터 플레이어 입력까지 **하나의 버전된 애니메이션 계약**을 쓰게 하고, 이후 정확도 작업(P0-B/P0-C)을 판정할 **golden corpus**를 만든다.

## 배경 — 왜 필요한가 (감사 근거)

`docs/recovery/validation/2026-07-21-p0a-animation-shape-audit.md`(main에 기록)에서 확인: 음표 데이터 shape가 **4종** 공존하고, 플레이어 경계(`sheet/[id]/page.tsx`)가 저장 JSON을 `as PianoAnimationData`로 **검증 없이 캐스트**한다. 결정적으로 **실제 OMR 출력(Shape C: `midi`/`start`/`R`/`L`)은 현재 플레이어가 렌더링하지 못한다** — `convertToFallingNotes`가 `note.note`(문자열)/`startTime`을 읽어 모든 음표가 middle C + `start: undefined`로 무너진다. 이슈 #22(OMR job 실패)를 고쳐도 그 출력이 안 그려지는 셈이라, 계약 통일이 선결 조건이다.

## 변경 (커밋 3개)

1. **canonical 계약 + 검증기** (`83a5e28`)
   - `src/types/animationContract.ts` — MIDI 계열 `{midi, start, duration, hand:'L'|'R', velocity?, finger?, voice?, staff?}` + `version` (D-009). `voice`/`staff`는 신규 추가 → P0-B가 채워 hand가 `part_idx==0?R:L` 휴리스틱에서 벗어나게 함.
   - `src/utils/animationContract.ts` — `normalizeAnimationData`가 canonical·legacy Shape A·converter.py shape를 모두 정규화. **malformed는 조용한 middle-C fallback 없이 `AnimationContractError`** (D-001 정신).
   - 결정 **D-009** 기록.
2. **golden corpus + 비교 툴** (`88724a1`)
   - `fixtures/animation-contract/` 7종: 단선율·코드·쉼표/붙임줄·grand staff·다성부·셋잇단/점음표·템포변경. 각 `input.musicxml` + 음악적으로 올바른 `expected.json`(tempo 60 기준 정확한 초).
   - `src/utils/animationCompare.ts` — `compareAnimationData`(pitch 정확·onset/duration 허용오차 10ms). P0-B/P0-C 측정 도구.
3. **렌더 경로 배선 + Python 정렬** (`41c2fa2`)
   - `sheet/[id]/page.tsx`의 `as` 캐스트 → `normalizeAnimationData`로 교체.
   - `FallingNotesPlayer`가 `CanonicalAnimationData`를 받고 `canonicalToFallingNotes`로 매핑. test-finger는 legacy Shape A를 정규화해 넘김.
   - `converter.py`가 `version`+top-level title/composer를 명시 출력.

## 완료 조건 대비

- ✅ malformed/구버전 JSON이 cast 없이 검증된다 — `normalizeAnimationData`, sheet page 배선, 12 테스트
- ✅ Python 출력이 TS validator를 통과한다 — converter.py shape 정규화 테스트 + `version` 명시 출력
- ✅ 모든 fixture에 기대 pitch/onset/duration/hand/staff/voice 기록 — 7 fixtures, 30 테스트
- ✅ 후속 단계용 비교 명령·허용오차 문서화 — `compareAnimationData` + `DEFAULT_TOLERANCE` + fixtures README

## 검증

- `npx jest src/utils src/components/animation src/hooks` — **136 pass** (contract 12 + fixtures 18 포함, 회귀 0)
- `npx tsc --noEmit` — 0 / `npx eslint` 변경 파일 — 0
- **미검증**: 실제 브라우저에서 저장 악보 렌더, converter.py를 corpus에 직접 실행(P0-B 범위)

## 범위 밖 (의도적)

전체 MusicXML 의미론(P0-B), 오디오 스케줄러 변경(P0-C, #18로 일부 완료). legacy Shape A는 저장 계약으로 되살리지 않고 읽기 정규화로만 흡수(D-009).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 애니메이션 데이터를 통일된 표준 형식으로 처리하고, 재생 전에 입력값을 검증합니다.
  * 기존 형식의 애니메이션 데이터도 읽는 과정에서 자동 변환됩니다.
  * MusicXML의 단선율, 코드, 쉼표·타이, 양손, 다중 보이스, 셋잇단음표, 템포 변경을 지원합니다.
  * 음표 애니메이션 비교 및 차이 확인 기능을 추가했습니다.

* **버그 수정**
  * 잘못된 음표, MIDI 범위, 시간 정보가 조용히 대체되지 않고 명확한 오류로 처리됩니다.

* **테스트**
  * 다양한 악보 사례와 애니메이션 변환 결과를 검증하는 골든 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->