### PR TITLE
P0-B: MusicXML 변환 정확도 재구현 (divisions·chord·tie·backup·staff)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,7 @@ next-env.d.ts
 
 # local agent/hook runtime state
 /.omx/
+
+# Python bytecode cache (omr-service)
+__pycache__/
+*.pyc

--- a/fixtures/animation-contract/08-multipart-tempo/expected.json
+++ b/fixtures/animation-contract/08-multipart-tempo/expected.json
@@ -1,0 +1,19 @@
+{
+  "version": "1.0",
+  "title": "Multi-part tempo",
+  "composer": "P0-A Fixtures",
+  "duration": 3.0,
+  "tempo": 60,
+  "timeSignature": "2/4",
+  "keySignature": "C",
+  "notes": [
+    { "midi": 60, "start": 0.0, "duration": 1.0, "hand": "R", "voice": 1 },
+    { "midi": 62, "start": 1.0, "duration": 1.0, "hand": "R", "voice": 1 },
+    { "midi": 64, "start": 2.0, "duration": 0.5, "hand": "R", "voice": 1 },
+    { "midi": 65, "start": 2.5, "duration": 0.5, "hand": "R", "voice": 1 },
+    { "midi": 48, "start": 0.0, "duration": 1.0, "hand": "L", "voice": 1 },
+    { "midi": 50, "start": 1.0, "duration": 1.0, "hand": "L", "voice": 1 },
+    { "midi": 52, "start": 2.0, "duration": 0.5, "hand": "L", "voice": 1 },
+    { "midi": 53, "start": 2.5, "duration": 0.5, "hand": "L", "voice": 1 }
+  ]
+}

--- a/fixtures/animation-contract/08-multipart-tempo/input.musicxml
+++ b/fixtures/animation-contract/08-multipart-tempo/input.musicxml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <work><work-title>Multi-part tempo</work-title></work>
+  <identification><creator type="composer">P0-A Fixtures</creator></identification>
+  <part-list>
+    <score-part id="P1"><part-name>Right</part-name></score-part>
+    <score-part id="P2"><part-name>Left</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>12</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>2</beats><beat-type>4</beat-type></time>
+        <clef number="1"><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction placement="above">
+        <direction-type><metronome><beat-unit>quarter</beat-unit><per-minute>60</per-minute></metronome></direction-type>
+        <sound tempo="60"/>
+      </direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>12</duration><voice>1</voice><type>quarter</type></note>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>12</duration><voice>1</voice><type>quarter</type></note>
+    </measure>
+    <measure number="2">
+      <direction placement="above">
+        <direction-type><metronome><beat-unit>quarter</beat-unit><per-minute>120</per-minute></metronome></direction-type>
+        <sound tempo="120"/>
+      </direction>
+      <note><pitch><step>E</step><octave>4</octave></pitch><duration>12</duration><voice>1</voice><type>quarter</type></note>
+      <note><pitch><step>F</step><octave>4</octave></pitch><duration>12</duration><voice>1</voice><type>quarter</type></note>
+    </measure>
+  </part>
+  <part id="P2">
+    <measure number="1">
+      <attributes>
+        <divisions>12</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>2</beats><beat-type>4</beat-type></time>
+        <clef number="1"><sign>F</sign><line>4</line></clef>
+      </attributes>
+      <note><pitch><step>C</step><octave>3</octave></pitch><duration>12</duration><voice>1</voice><type>quarter</type></note>
+      <note><pitch><step>D</step><octave>3</octave></pitch><duration>12</duration><voice>1</voice><type>quarter</type></note>
+    </measure>
+    <measure number="2">
+      <note><pitch><step>E</step><octave>3</octave></pitch><duration>12</duration><voice>1</voice><type>quarter</type></note>
+      <note><pitch><step>F</step><octave>3</octave></pitch><duration>12</duration><voice>1</voice><type>quarter</type></note>
+    </measure>
+  </part>
+</score-partwise>

--- a/fixtures/animation-contract/09-tie-across-barline/expected.json
+++ b/fixtures/animation-contract/09-tie-across-barline/expected.json
@@ -1,0 +1,14 @@
+{
+  "version": "1.0",
+  "title": "Tie across barline",
+  "composer": "P0-A Fixtures",
+  "duration": 4.0,
+  "tempo": 60,
+  "timeSignature": "2/4",
+  "keySignature": "C",
+  "notes": [
+    { "midi": 60, "start": 0.0, "duration": 1.0, "hand": "R", "voice": 1, "staff": 1 },
+    { "midi": 62, "start": 1.0, "duration": 2.0, "hand": "R", "voice": 1, "staff": 1 },
+    { "midi": 64, "start": 3.0, "duration": 1.0, "hand": "R", "voice": 1, "staff": 1 }
+  ]
+}

--- a/fixtures/animation-contract/09-tie-across-barline/input.musicxml
+++ b/fixtures/animation-contract/09-tie-across-barline/input.musicxml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <work><work-title>Tie across barline</work-title></work>
+  <identification><creator type="composer">P0-A Fixtures</creator></identification>
+  <part-list>
+    <score-part id="P1"><part-name>Piano</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>12</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>2</beats><beat-type>4</beat-type></time>
+        <clef number="1"><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <direction placement="above">
+        <direction-type><metronome><beat-unit>quarter</beat-unit><per-minute>60</per-minute></metronome></direction-type>
+        <sound tempo="60"/>
+      </direction>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>12</duration><voice>1</voice><type>quarter</type><staff>1</staff></note>
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>12</duration><tie type="start"/><voice>1</voice><type>quarter</type><staff>1</staff><notations><tied type="start"/></notations></note>
+    </measure>
+    <measure number="2">
+      <note><pitch><step>D</step><octave>4</octave></pitch><duration>12</duration><tie type="stop"/><voice>1</voice><type>quarter</type><staff>1</staff><notations><tied type="stop"/></notations></note>
+      <note><pitch><step>E</step><octave>4</octave></pitch><duration>12</duration><voice>1</voice><type>quarter</type><staff>1</staff></note>
+    </measure>
+  </part>
+</score-partwise>

--- a/fixtures/animation-contract/README.md
+++ b/fixtures/animation-contract/README.md
@@ -41,6 +41,8 @@ quarter = 1.5s, an eighth = 0.5s, a triplet eighth (three in one beat) = 1/3s.
 | `05-multivoice` | 한 staff 내 다성부 | `<backup>` + `<voice>` overlapping in one staff |
 | `06-triplet-dotted` | 셋잇단음표·점음표 | `<time-modification>` triplet, dotted duration |
 | `07-tempo-change` | 템포/박자표 변경 | mid-piece tempo change re-scales seconds |
+| `08-multipart-tempo` | 멀티파트 전역 템포 | tempo declared in one part re-scales all parts at that measure (added in P0-B) |
+| `09-tie-across-barline` | 마디 넘는 붙임줄 | `<tie>` spanning a measure boundary merges into one sustained note (added in P0-B) |
 
 ## Comparison
 

--- a/omr-service/omr/cli.py
+++ b/omr-service/omr/cli.py
@@ -1,0 +1,37 @@
+"""
+CLI entry point for the MusicXML → ClairKeys converter.
+
+Runs `MusicXMLToClairKeysConverter.convert` on a single MusicXML file and prints
+the canonical animation JSON to stdout. This is the seam the P0-B accuracy gate
+(`src/utils/__tests__/converterCorpus.test.ts`) drives: the Jest test spawns this
+CLI per golden fixture and scores stdout with `compareAnimationData`.
+
+Usage:
+    python -m omr.cli path/to/input.musicxml [--title T] [--composer C]
+"""
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+from omr.converter import MusicXMLToClairKeysConverter
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="Convert MusicXML to ClairKeys animation JSON")
+    parser.add_argument("input", type=Path, help="Path to input MusicXML file")
+    parser.add_argument("--title", default=None, help="Optional title override")
+    parser.add_argument("--composer", default=None, help="Optional composer override")
+    args = parser.parse_args(argv)
+
+    converter = MusicXMLToClairKeysConverter()
+    data = asyncio.run(converter.convert(args.input, args.title, args.composer))
+    json.dump(data, sys.stdout, ensure_ascii=False)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/omr-service/omr/converter.py
+++ b/omr-service/omr/converter.py
@@ -106,91 +106,195 @@ class MusicXMLToClairKeysConverter:
         return metadata
     
     def _extract_notes(self, root: ET.Element) -> List[Dict[str, Any]]:
-        """Extract notes from MusicXML and convert to ClairKeys format"""
-        notes = []
-        current_time = 0.0
-        
-        # Find all parts (typically separate hands/voices)
+        """Extract notes from MusicXML into canonical timed notes.
+
+        Timing is accumulated in *seconds*, not divisions, because tempo can
+        change between measures and each change re-scales tick->second. Within a
+        measure a cursor tracks the seconds offset so `<backup>`/`<forward>` and
+        `<chord>` place notes at the right onset; `<tie>` merges durations instead
+        of emitting a second note. Hand comes from `<staff>` (1->R, 2->L), falling
+        back to the part index only when no staff is given.
+        """
+        notes: List[Dict[str, Any]] = []
         parts = root.findall('.//part')
-        
+
         for part_idx, part in enumerate(parts):
-            part_time = 0.0
-            
-            # Determine hand assignment (simple heuristic)
-            hand = "R" if part_idx == 0 else "L"  # First part = right hand, second = left hand
-            
-            # Find all measures in this part
-            measures = part.findall('measure')
-            
-            for measure in measures:
-                measure_time = part_time
-                
-                # Find all notes in this measure
-                note_elements = measure.findall('note')
-                
-                for note_elem in note_elements:
-                    note_data = self._parse_note_element(note_elem, measure_time, hand)
-                    if note_data:
-                        notes.append(note_data)
-                        measure_time = note_data['start'] + note_data['duration']
-                
-                part_time = measure_time
-        
-        # Sort notes by start time
-        notes.sort(key=lambda n: n['start'])
-        
+            divisions = 1
+            tempo = self._extract_tempo(root)  # initial; overridden per measure below
+            measure_start_sec = 0.0
+
+            for measure in part.findall('measure'):
+                attributes = measure.find('attributes')
+                if attributes is not None:
+                    div_elem = attributes.find('divisions')
+                    if div_elem is not None and div_elem.text:
+                        try:
+                            divisions = int(div_elem.text)
+                        except ValueError:
+                            pass
+                if divisions <= 0:
+                    divisions = 1
+
+                measure_tempo = self._find_tempo(measure)
+                if measure_tempo is not None and measure_tempo > 0:
+                    tempo = measure_tempo
+                sec_per_tick = (60.0 / tempo) / divisions if tempo > 0 else 0.0
+
+                cursor_sec = 0.0        # seconds offset from measure_start_sec
+                measure_max_sec = 0.0   # furthest point reached (measure length)
+                last_onset_sec = 0.0    # onset of the last non-chord note (chords share it)
+                open_ties: Dict[Any, Dict[str, Any]] = {}  # (midi, voice) -> tie-open note
+
+                for elem in list(measure):
+                    tag = elem.tag
+                    if tag == 'backup':
+                        cursor_sec = max(0.0, cursor_sec - self._duration_ticks(elem) * sec_per_tick)
+                        continue
+                    if tag == 'forward':
+                        cursor_sec += self._duration_ticks(elem) * sec_per_tick
+                        measure_max_sec = max(measure_max_sec, cursor_sec)
+                        continue
+                    if tag != 'note':
+                        continue
+
+                    dur_sec = self._duration_ticks(elem) * sec_per_tick
+                    is_chord = elem.find('chord') is not None
+                    onset_sec = last_onset_sec if is_chord else cursor_sec
+                    end_sec = onset_sec + dur_sec
+
+                    # Rests and unpitched/unparseable notes advance time but emit nothing.
+                    parsed = None if elem.find('rest') is not None else self._parse_pitch(elem)
+                    if parsed is not None:
+                        midi_num, voice, staff = parsed
+                        tie_start, tie_stop = self._tie_flags(elem)
+                        key = (midi_num, voice)
+                        if tie_stop and key in open_ties:
+                            started = open_ties[key]
+                            started['duration'] = round(started['duration'] + dur_sec, 6)
+                            if not tie_start:
+                                del open_ties[key]
+                        else:
+                            note: Dict[str, Any] = {
+                                "midi": midi_num,
+                                "start": round(measure_start_sec + onset_sec, 6),
+                                "duration": round(dur_sec, 6),
+                                "hand": self._hand_for(staff, part_idx),
+                                "finger": self._fingering(elem),
+                            }
+                            if voice is not None:
+                                note["voice"] = voice
+                            if staff is not None:
+                                note["staff"] = staff
+                            notes.append(note)
+                            if tie_start:
+                                open_ties[key] = note
+
+                    if not is_chord:
+                        cursor_sec = end_sec
+                        last_onset_sec = onset_sec
+                    measure_max_sec = max(measure_max_sec, end_sec)
+
+                measure_start_sec += measure_max_sec
+
+        notes.sort(key=lambda n: (n['start'], n['midi']))
         return notes
-    
-    def _parse_note_element(self, note_elem: ET.Element, current_time: float, hand: str) -> Optional[Dict[str, Any]]:
-        """Parse individual note element"""
-        try:
-            # Skip rests
-            if note_elem.find('rest') is not None:
-                # Still need to advance time for rests
-                duration_elem = note_elem.find('duration')
-                if duration_elem is not None:
-                    duration = float(duration_elem.text) / 4.0  # Convert to seconds (assuming quarter note = 1 second)
-                return None
-            
-            # Get pitch information
-            pitch_elem = note_elem.find('pitch')
-            if pitch_elem is None:
-                return None
-            
-            step = pitch_elem.find('step').text
-            octave = int(pitch_elem.find('octave').text)
-            alter = pitch_elem.find('alter')
-            alter_value = int(alter.text) if alter is not None else 0
-            
-            # Convert to MIDI note number
-            midi_num = self._note_to_midi(step, octave, alter_value)
-            if midi_num is None:
-                return None
-            
-            # Get duration
-            duration_elem = note_elem.find('duration')
-            duration = float(duration_elem.text) / 4.0 if duration_elem is not None else 0.5  # Default to quarter note
-            
-            # Get fingering if available
-            fingering_elem = note_elem.find('.//fingering')
-            finger = int(fingering_elem.text) if fingering_elem is not None and fingering_elem.text.isdigit() else None
-            
-            # Ensure finger is within valid range (1-5)
-            if finger is not None and (finger < 1 or finger > 5):
-                finger = None
-            
-            return {
-                "midi": midi_num,
-                "start": current_time,
-                "duration": duration,
-                "hand": hand,
-                "finger": finger
-            }
-            
-        except Exception as e:
-            logger.warning(f"Error parsing note element: {str(e)}")
+
+    def _duration_ticks(self, elem: ET.Element) -> int:
+        """Read a `<duration>` child as an integer tick count (0 if absent)."""
+        dur_elem = elem.find('duration')
+        if dur_elem is not None and dur_elem.text:
+            try:
+                return int(dur_elem.text)
+            except ValueError:
+                try:
+                    return int(float(dur_elem.text))
+                except ValueError:
+                    return 0
+        return 0
+
+    def _parse_pitch(self, note_elem: ET.Element) -> Optional[tuple]:
+        """Return (midi, voice, staff) for a pitched note, or None if unpitched."""
+        pitch_elem = note_elem.find('pitch')
+        if pitch_elem is None:
             return None
-    
+        step_elem = pitch_elem.find('step')
+        octave_elem = pitch_elem.find('octave')
+        if step_elem is None or not step_elem.text or octave_elem is None or not octave_elem.text:
+            return None
+        try:
+            octave = int(octave_elem.text)
+        except ValueError:
+            return None
+        alter_elem = pitch_elem.find('alter')
+        alter_value = 0
+        if alter_elem is not None and alter_elem.text:
+            try:
+                alter_value = int(alter_elem.text)
+            except ValueError:
+                alter_value = 0
+
+        midi_num = self._note_to_midi(step_elem.text, octave, alter_value)
+        if midi_num is None:
+            return None
+
+        voice = self._int_child(note_elem, 'voice')
+        staff = self._int_child(note_elem, 'staff')
+        return midi_num, voice, staff
+
+    @staticmethod
+    def _int_child(elem: ET.Element, tag: str) -> Optional[int]:
+        child = elem.find(tag)
+        if child is not None and child.text and child.text.strip().isdigit():
+            return int(child.text.strip())
+        return None
+
+    def _hand_for(self, staff: Optional[int], part_idx: int) -> str:
+        """Assign hand from staff (1->R, >=2->L); fall back to part index."""
+        if staff == 1:
+            return "R"
+        if staff is not None and staff >= 2:
+            return "L"
+        return "R" if part_idx == 0 else "L"
+
+    @staticmethod
+    def _tie_flags(note_elem: ET.Element) -> tuple:
+        """Return (tie_start, tie_stop) from the sounding `<tie>` elements."""
+        tie_start = tie_stop = False
+        for tie in note_elem.findall('tie'):
+            tie_type = tie.get('type')
+            if tie_type == 'start':
+                tie_start = True
+            elif tie_type == 'stop':
+                tie_stop = True
+        return tie_start, tie_stop
+
+    @staticmethod
+    def _fingering(note_elem: ET.Element) -> Optional[int]:
+        """Read a fingering 1-5, or None."""
+        fingering_elem = note_elem.find('.//fingering')
+        if fingering_elem is not None and fingering_elem.text and fingering_elem.text.strip().isdigit():
+            finger = int(fingering_elem.text.strip())
+            if 1 <= finger <= 5:
+                return finger
+        return None
+
+    def _find_tempo(self, measure: ET.Element) -> Optional[float]:
+        """Find a tempo (BPM) declared in this measure, or None."""
+        sound = measure.find('.//sound[@tempo]')
+        if sound is not None:
+            try:
+                return float(sound.get('tempo'))
+            except (TypeError, ValueError):
+                pass
+        per_minute = measure.find('.//per-minute')
+        if per_minute is not None and per_minute.text:
+            try:
+                return float(per_minute.text)
+            except ValueError:
+                pass
+        return None
+
+
     def _note_to_midi(self, step: str, octave: int, alter: int = 0) -> Optional[int]:
         """Convert note name to MIDI number"""
         try:

--- a/omr-service/omr/converter.py
+++ b/omr-service/omr/converter.py
@@ -117,13 +117,21 @@ class MusicXMLToClairKeysConverter:
         """
         notes: List[Dict[str, Any]] = []
         parts = root.findall('.//part')
+        # Tempo is a score-wide property in MusicXML: a <sound tempo> / <per-minute>
+        # in one part (conventionally the first) governs playback for every part at
+        # that measure position. Build one measure-indexed timeline from all parts so
+        # a tempo change declared in one part re-scales the others' timing too.
+        tempo_timeline = self._build_tempo_timeline(parts, self._extract_tempo(root))
 
         for part_idx, part in enumerate(parts):
             divisions = 1
-            tempo = self._extract_tempo(root)  # initial; overridden per measure below
             measure_start_sec = 0.0
+            # Tie state must persist across measure boundaries — a note tied into the
+            # next measure has to merge with the note that opened the tie — so
+            # open_ties lives at part scope, not per measure.
+            open_ties: Dict[Any, Dict[str, Any]] = {}  # (midi, voice) -> tie-open note
 
-            for measure in part.findall('measure'):
+            for measure_idx, measure in enumerate(part.findall('measure')):
                 attributes = measure.find('attributes')
                 if attributes is not None:
                     div_elem = attributes.find('divisions')
@@ -135,15 +143,12 @@ class MusicXMLToClairKeysConverter:
                 if divisions <= 0:
                     divisions = 1
 
-                measure_tempo = self._find_tempo(measure)
-                if measure_tempo is not None and measure_tempo > 0:
-                    tempo = measure_tempo
+                tempo = tempo_timeline[measure_idx] if measure_idx < len(tempo_timeline) else self._extract_tempo(root)
                 sec_per_tick = (60.0 / tempo) / divisions if tempo > 0 else 0.0
 
                 cursor_sec = 0.0        # seconds offset from measure_start_sec
                 measure_max_sec = 0.0   # furthest point reached (measure length)
                 last_onset_sec = 0.0    # onset of the last non-chord note (chords share it)
-                open_ties: Dict[Any, Dict[str, Any]] = {}  # (midi, voice) -> tie-open note
 
                 for elem in list(measure):
                     tag = elem.tag
@@ -294,6 +299,28 @@ class MusicXMLToClairKeysConverter:
                 pass
         return None
 
+    def _build_tempo_timeline(self, parts: List[ET.Element], initial_tempo: float) -> List[float]:
+        """Build a measure-indexed tempo (BPM) timeline shared across all parts.
+
+        For each measure position, the first tempo declared by any part (scanning
+        parts in document order) wins and carries forward until the next change.
+        This mirrors MusicXML's convention that a tempo direction in one part is a
+        global playback change, so parts that carry no tempo of their own still get
+        re-scaled at a measure where another part changed tempo.
+        """
+        max_measures = max((len(part.findall('measure')) for part in parts), default=0)
+        timeline: List[float] = []
+        current = initial_tempo
+        for i in range(max_measures):
+            for part in parts:
+                measures = part.findall('measure')
+                if i < len(measures):
+                    measure_tempo = self._find_tempo(measures[i])
+                    if measure_tempo is not None and measure_tempo > 0:
+                        current = measure_tempo
+                        break
+            timeline.append(current)
+        return timeline
 
     def _note_to_midi(self, step: str, octave: int, alter: int = 0) -> Optional[int]:
         """Convert note name to MIDI number"""

--- a/src/utils/__tests__/converterCorpus.test.ts
+++ b/src/utils/__tests__/converterCorpus.test.ts
@@ -1,0 +1,64 @@
+/**
+ * P0-B accuracy gate — score `omr-service/omr/converter.py` against the golden
+ * corpus (`fixtures/animation-contract/`) with the P0-A measurement tool.
+ *
+ * For each fixture this spawns the converter CLI (`python -m omr.cli input.musicxml`),
+ * normalizes its output through the same `normalizeAnimationData` the player uses,
+ * and scores it against `expected.json` with `compareAnimationData`. A fixture
+ * passes only when every expected note is matched within tolerance with exact
+ * pitch/hand/voice/staff and no extra notes — the Completion criteria of
+ * `docs/recovery/phases/P0-B-musicxml-converter.md`.
+ *
+ * Unlike `animationFixtures.test.ts` (which locks the corpus + tool without
+ * running any converter), this test DOES run the converter, so it is red until
+ * P0-B fixes the timing/chord/rest/tie/tuplet/backup/staff-hand handling.
+ */
+
+import { execFileSync } from 'child_process'
+import fs from 'fs'
+import path from 'path'
+import { normalizeAnimationData } from '../animationContract'
+import { compareAnimationData, formatComparison, DEFAULT_TOLERANCE } from '../animationCompare'
+import type { CanonicalAnimationData } from '@/types/animationContract'
+
+const REPO_ROOT = process.cwd()
+const FIXTURES_DIR = path.join(REPO_ROOT, 'fixtures', 'animation-contract')
+const OMR_DIR = path.join(REPO_ROOT, 'omr-service')
+const PYTHON = process.env.PYTHON_BIN || 'python3'
+
+function fixtureDirs(): string[] {
+  return fs
+    .readdirSync(FIXTURES_DIR, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name)
+    .sort()
+}
+
+function loadExpected(dir: string): CanonicalAnimationData {
+  const raw = fs.readFileSync(path.join(FIXTURES_DIR, dir, 'expected.json'), 'utf-8')
+  return normalizeAnimationData(JSON.parse(raw))
+}
+
+function runConverter(dir: string): CanonicalAnimationData {
+  const input = path.join(FIXTURES_DIR, dir, 'input.musicxml')
+  const stdout = execFileSync(PYTHON, ['-m', 'omr.cli', input], {
+    cwd: OMR_DIR,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  return normalizeAnimationData(JSON.parse(stdout))
+}
+
+describe('converter corpus accuracy (P0-B)', () => {
+  for (const dir of fixtureDirs()) {
+    it(`${dir}: converter output matches expected.json within tolerance`, () => {
+      const expected = loadExpected(dir)
+      const actual = runConverter(dir)
+      const result = compareAnimationData(actual, expected, DEFAULT_TOLERANCE)
+      if (!result.match) {
+        throw new Error(`${dir}\n${formatComparison(result)}`)
+      }
+      expect(result.match).toBe(true)
+    })
+  }
+})

--- a/src/utils/__tests__/converterCorpus.test.ts
+++ b/src/utils/__tests__/converterCorpus.test.ts
@@ -45,6 +45,10 @@ function runConverter(dir: string): CanonicalAnimationData {
     cwd: OMR_DIR,
     encoding: 'utf-8',
     stdio: ['ignore', 'pipe', 'pipe'],
+    // Cap runtime so a hung converter fails the test instead of blocking CI, and
+    // raise maxBuffer above the 1 MB default for large corpora.
+    timeout: 30_000,
+    maxBuffer: 32 * 1024 * 1024,
   })
   return normalizeAnimationData(JSON.parse(stdout))
 }


### PR DESCRIPTION
## 목적 (P0-B)

`omr-service/omr/converter.py`가 MusicXML의 음악적 시간과 양손 구조를 canonical animation contract로 정확히 변환하도록 재구현한다. 기존 converter는 모든 음표를 `duration_ticks / 4.0`로 계산하고 손을 part 인덱스로 배정해, corpus의 `divisions=12`에서 모든 음표가 3배 길고, 코드가 직렬화되며, 쉼표·붙임줄·backup이 무시되고, grand-staff 양손이 한 손으로 뭉개졌다.

## 접근

- **회귀 우선**: 코드 변경 전에 실패하는 게이트부터 세웠다. `omr/cli.py`(`python -m omr.cli input.musicxml` → canonical JSON)를 추가하고, Jest 테스트가 fixture별로 이를 subprocess로 실행해 P0-A의 `compareAnimationData`로 채점한다. CI에는 Python 잡이 없으므로 게이트를 강제되는 Jest(`Run Tests`) 안에 둔다.
- **초 단위 onset 누적**: tick이 아니라 초로 누적한다. measure마다 tempo가 바뀌면 tick→초 비율이 달라져(07-tempo-change), tick 커서로는 템포 경계를 넘는 onset을 표현할 수 없다.
- **measure 내 커서**로 `<backup>`/`<forward>`/`<chord>` 처리. chord 음표는 직전 non-chord onset을 공유하고 커서를 전진시키지 않는다.
- `<tie type="stop">`은 `(midi, voice)`로 열린 음표의 duration을 연장하고 새 음표를 내지 않는다.
- 손은 `<staff>` 기반(1→R, 2→L), staff가 없을 때만 part 인덱스로 fallback.
- `<time-modification>`은 별도 타이밍 경로가 필요 없다 — 삼잇단음표의 `<duration>`이 이미 실제 tick(4 = 12/3)이다.

## 검증

- `npx jest src/utils/__tests__/converterCorpus.test.ts` — 7/7 fixture가 10ms 허용 오차 내 일치 (수정 전 7/7 실패).
- `src/utils/` 전체 Jest 97/97, `npx tsc --noEmit` clean, ESLint clean.

## 완료 조건 대응 (phase 문서)

- pitch mismatch 0건 ✓ / hand·staff·voice 보존 ✓ / 동시 음표 동일 onset ✓ / onset·duration 허용 오차 만족 ✓ / tempo·time-signature 변경 fixture 통과 ✓

## 범위 밖 (미검증)

실제 Audiveris 산출 MusicXML(cross-staff, grace note, 7개 fixture 밖 다중 part)은 P0-B fixture 범위 밖이라 검증하지 않았다.

Related: `docs/recovery/phases/P0-B-musicxml-converter.md`, P0-A PR #23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - MusicXML 파일을 ClairKeys용 애니메이션 JSON으로 변환하는 명령줄 실행 기능을 추가했습니다.
  - 제목과 작곡가 정보를 변환 시 지정할 수 있습니다.

- **버그 수정**
  - 음표의 시작 시간과 길이 계산 정확도를 개선했습니다.
  - 쉼표, 화음, 타이, 박자 단위 변경 및 템포 변화를 올바르게 반영합니다.
  - 음표의 손 배정과 유효한 운지 정보 처리를 개선했습니다.

- **테스트**
  - 다양한 MusicXML 샘플을 기준 결과와 비교하는 정확도 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->