### PR TITLE
Complete P0-C shared playback clock and drift gates

### DIFF
--- a/src/components/animation/FallingNotesPlayer.tsx
+++ b/src/components/animation/FallingNotesPlayer.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useEffect, useMemo } from 'react'
+import React, { useMemo } from 'react'
 import type { CanonicalAnimationData } from '@/types/animationContract'
 import { buildKeyLayout } from '@/utils/pianoLayout'
 import { canonicalToFallingNotes } from '@/utils/dataConverter'
@@ -8,6 +8,7 @@ import { useFallingNotesPlayer } from '@/hooks/useFallingNotesPlayer'
 import FallingNotes from './FallingNotes'
 import SimplePianoKeyboard from '../piano/SimplePianoKeyboard'
 import { PlaybackControls } from '@/components/playback'
+import { getActiveNotes } from '@/utils/visualUtils'
 
 /**
  * Falling Notes Player - MVP Style Piano Visualization
@@ -43,21 +44,15 @@ export default function FallingNotesPlayer({
   const keyWidth = 24
   const keyboardHeight = 120
   
-  // Animation state
-  const [activeKeys, setActiveKeys] = useState<Set<number>>(new Set())
-  
   // Calculate derived values
   const layout = useMemo(() => buildKeyLayout(keyWidth), [keyWidth])
   const height = Math.round(lookAheadSec * pxPerSec)
-  
-  // Update active keys based on current time
-  useEffect(() => {
-    const currentActiveNotes = notes.filter(note => 
-      note.start <= currentTime && 
-      currentTime <= note.start + note.duration
-    )
-    const newActiveKeys = new Set(currentActiveNotes.map(note => note.midi))
-    setActiveKeys(newActiveKeys)
+
+  // Derive key activation synchronously from the exact playhead passed to the
+  // falling-note visualization. An effect would leave the keyboard one render
+  // behind whenever the AudioContext clock advances.
+  const activeKeys = useMemo(() => {
+    return new Set(getActiveNotes(notes, currentTime).map(note => note.midi))
   }, [notes, currentTime])
   
   // Playback control handlers

--- a/src/components/animation/__tests__/FallingNotesPlayer.test.tsx
+++ b/src/components/animation/__tests__/FallingNotesPlayer.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react'
+import type { CanonicalAnimationData } from '@/types/animationContract'
+import FallingNotesPlayer from '../FallingNotesPlayer'
+
+const mockKeyboardFrames: Set<number>[] = []
+const mockPlayerState = {
+  isPlaying: true,
+  currentTime: 1.5,
+  tempoScale: 1,
+  lookAheadSec: 1.5,
+  totalLength: 3,
+  play: jest.fn(),
+  pause: jest.fn(),
+  stop: jest.fn(),
+  seek: jest.fn(),
+  setTempoScale: jest.fn(),
+}
+
+jest.mock('@/hooks/useFallingNotesPlayer', () => ({
+  useFallingNotesPlayer: () => mockPlayerState,
+}))
+
+jest.mock('../FallingNotes', () => ({
+  __esModule: true,
+  default: ({ nowSec }: { nowSec: number }) => (
+    <div data-testid="visual-playhead">{nowSec}</div>
+  ),
+}))
+
+jest.mock('../../piano/SimplePianoKeyboard', () => ({
+  __esModule: true,
+  default: ({ activeKeys }: { activeKeys: Set<number> }) => {
+    mockKeyboardFrames.push(new Set(activeKeys))
+    return <div data-testid="active-keys">{Array.from(activeKeys).join(',')}</div>
+  },
+}))
+
+jest.mock('@/components/playback', () => ({
+  PlaybackControls: () => null,
+}))
+
+const animationData: CanonicalAnimationData = {
+  version: '1.0',
+  title: 'Shared clock fixture',
+  composer: 'Test',
+  duration: 3,
+  tempo: 120,
+  timeSignature: '4/4',
+  notes: [
+    { midi: 60, start: 1, duration: 1 },
+    { midi: 64, start: 2, duration: 0.5 },
+  ],
+}
+
+describe('FallingNotesPlayer', () => {
+  beforeEach(() => {
+    mockKeyboardFrames.length = 0
+  })
+
+  it('derives the visual frame and active keys from the same playhead on first render', () => {
+    render(<FallingNotesPlayer animationData={animationData} />)
+
+    expect(screen.getByTestId('visual-playhead')).toHaveTextContent('1.5')
+    expect(screen.getByTestId('active-keys')).toHaveTextContent('60')
+    expect(mockKeyboardFrames[0]).toEqual(new Set([60]))
+  })
+})

--- a/src/hooks/__tests__/useFallingNotesAudio.test.ts
+++ b/src/hooks/__tests__/useFallingNotesAudio.test.ts
@@ -1,0 +1,141 @@
+import { act, renderHook } from '@testing-library/react'
+import { useFallingNotesAudio } from '../useFallingNotesAudio'
+
+type AudioWindow = Window & {
+  webkitAudioContext?: typeof AudioContext
+}
+
+const originalAudioContext = window.AudioContext
+const originalWebkitAudioContext = (window as AudioWindow).webkitAudioContext
+
+function makeAudioContext(state: AudioContextState): AudioContext {
+  const gain = {
+    value: 0,
+  }
+  const masterGain = {
+    connect: jest.fn(),
+    gain,
+  }
+
+  return {
+    state,
+    currentTime: 10,
+    destination: {},
+    createGain: jest.fn(() => masterGain),
+    resume: jest.fn(() => Promise.resolve()),
+    close: jest.fn(() => Promise.resolve()),
+  } as unknown as AudioContext
+}
+
+function setAudioContextConstructor(constructor?: typeof AudioContext) {
+  Object.defineProperty(window, 'AudioContext', {
+    configurable: true,
+    writable: true,
+    value: constructor,
+  })
+  Object.defineProperty(window, 'webkitAudioContext', {
+    configurable: true,
+    writable: true,
+    value: undefined,
+  })
+}
+
+describe('useFallingNotesAudio', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    setAudioContextConstructor(originalAudioContext)
+    Object.defineProperty(window, 'webkitAudioContext', {
+      configurable: true,
+      writable: true,
+      value: originalWebkitAudioContext,
+    })
+    jest.useRealTimers()
+  })
+
+  it('reports that playback cannot start when AudioContext is unavailable', async () => {
+    setAudioContextConstructor(undefined)
+    const { result } = renderHook(() => useFallingNotesAudio())
+    let started: boolean | undefined
+
+    await act(async () => {
+      started = await result.current.startAudio([], 0, 1, false)
+    })
+
+    expect(started).toBe(false)
+  })
+
+  it('resumes a suspended AudioContext before using it as the playback clock', async () => {
+    const context = makeAudioContext('suspended')
+    ;(context.resume as jest.Mock).mockImplementation(async () => {
+      Object.defineProperty(context, 'state', { value: 'running', configurable: true })
+    })
+    const constructor = jest.fn(() => context) as unknown as typeof AudioContext
+    setAudioContextConstructor(constructor)
+    const { result, unmount } = renderHook(() => useFallingNotesAudio())
+    let started: boolean | undefined
+
+    await act(async () => {
+      started = await result.current.startAudio([], 0, 1, false)
+    })
+
+    expect(started).toBe(true)
+    expect(context.resume).toHaveBeenCalledTimes(1)
+
+    unmount()
+  })
+
+  it('keeps playback stopped when a suspended AudioContext cannot resume', async () => {
+    const context = makeAudioContext('suspended')
+    ;(context.resume as jest.Mock).mockRejectedValue(new Error('resume denied'))
+    const warn = jest.spyOn(console, 'warn').mockImplementation()
+    const constructor = jest.fn(() => context) as unknown as typeof AudioContext
+    setAudioContextConstructor(constructor)
+    const { result, unmount } = renderHook(() => useFallingNotesAudio())
+    let started: boolean | undefined
+
+    await act(async () => {
+      started = await result.current.startAudio([], 0, 1, false)
+    })
+
+    expect(started).toBe(false)
+    expect(result.current.getTimingInfo().isPlaying).toBe(false)
+    expect(warn).toHaveBeenCalledWith('AudioContext resume failed:', expect.any(Error))
+
+    unmount()
+    warn.mockRestore()
+  })
+
+  it('does not start after stop invalidates a pending resume request', async () => {
+    const context = makeAudioContext('suspended')
+    let finishResume: (() => void) | undefined
+    ;(context.resume as jest.Mock).mockImplementation(() => new Promise<void>((resolve) => {
+      finishResume = () => {
+        Object.defineProperty(context, 'state', { value: 'running', configurable: true })
+        resolve()
+      }
+    }))
+    const constructor = jest.fn(() => context) as unknown as typeof AudioContext
+    setAudioContextConstructor(constructor)
+    const { result, unmount } = renderHook(() => useFallingNotesAudio())
+    let startPromise: Promise<boolean>
+
+    act(() => {
+      startPromise = result.current.startAudio([], 0, 1, false)
+      result.current.stopAudio()
+    })
+
+    let started: boolean | undefined
+    await act(async () => {
+      finishResume?.()
+      started = await startPromise!
+    })
+
+    expect(started).toBe(false)
+    expect(result.current.getTimingInfo().isPlaying).toBe(false)
+
+    unmount()
+  })
+})

--- a/src/hooks/useFallingNotesAudio.ts
+++ b/src/hooks/useFallingNotesAudio.ts
@@ -9,6 +9,11 @@ import {
   TICK_MS,
   VOICE_LIMIT,
 } from '@/utils/audioScheduler'
+import {
+  audioTimeAtSongTime,
+  songTimeAtAudioTime,
+  type PlaybackClockAnchor,
+} from '@/utils/playbackClock'
 
 /**
  * Audio nodes for a single note
@@ -40,6 +45,7 @@ export function useFallingNotesAudio() {
   const offsetSecRef = useRef(0)
   const tempoScaleRef = useRef(1)
   const isPlayingRef = useRef(false)
+  const playbackGenerationRef = useRef(0)
 
   // Rolling-scheduler state, all reset on every startAudio.
   const notesRef = useRef<FallingNote[]>([])
@@ -51,16 +57,28 @@ export function useFallingNotesAudio() {
   /**
    * Initialize audio context
    */
-  const initializeAudio = useCallback(() => {
-    if (!audioContextRef.current) {
-      // Create audio context with compatibility
-      const AudioContextClass = window.AudioContext || (window as Window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
+  const initializeAudio = useCallback((): boolean => {
+    if (audioContextRef.current) return true
+
+    // Create audio context with compatibility. Some browsers and test/webview
+    // environments expose neither constructor; playback must stay stopped
+    // instead of throwing after the UI has already entered its playing state.
+    const AudioContextClass = window.AudioContext || (window as Window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
+    if (!AudioContextClass) return false
+
+    try {
       audioContextRef.current = new AudioContextClass()
 
       // Create master gain node
       masterGainRef.current = audioContextRef.current.createGain()
       masterGainRef.current.gain.value = 0.1 // Reasonable volume level
       masterGainRef.current.connect(audioContextRef.current.destination)
+      return true
+    } catch (error) {
+      console.warn('Web Audio initialization failed:', error)
+      audioContextRef.current = null
+      masterGainRef.current = null
+      return false
     }
   }, [])
 
@@ -119,6 +137,11 @@ export function useFallingNotesAudio() {
     const tempoScale = tempoScaleRef.current
     const offsetSec = offsetSecRef.current
     const now = audioContext.currentTime
+    const clock: PlaybackClockAnchor = {
+      audioTimeSec: baseAudioTime,
+      songTimeSec: offsetSec,
+      tempoScale,
+    }
 
     // Drop voices that have already finished so the polyphony count reflects
     // only notes still sounding, across the whole song rather than one window.
@@ -130,8 +153,8 @@ export function useFallingNotesAudio() {
 
     for (const note of notes) {
       // Map song time to AudioContext time through the single shared anchor.
-      const startTime = baseAudioTime + (note.start - offsetSec) / tempoScale
-      const endTime = baseAudioTime + (note.start + note.duration - offsetSec) / tempoScale
+      const startTime = audioTimeAtSongTime(clock, note.start)
+      const endTime = audioTimeAtSongTime(clock, note.start + note.duration)
 
       // A note captured by includeSounding may start slightly in the past;
       // clamp it just ahead of now so it still articulates without an error.
@@ -211,8 +234,11 @@ export function useFallingNotesAudio() {
     if (!audioContext || baseAudioTime === null || !isPlayingRef.current) return
 
     const tempoScale = tempoScaleRef.current
-    const songNow = offsetSecRef.current +
-      Math.max(0, audioContext.currentTime - baseAudioTime) * tempoScale
+    const songNow = songTimeAtAudioTime({
+      audioTimeSec: baseAudioTime,
+      songTimeSec: offsetSecRef.current,
+      tempoScale,
+    }, audioContext.currentTime)
 
     const win = nextScheduleWindow(songNow, scheduleCursorRef.current, tempoScale)
     if (!win) return
@@ -230,21 +256,45 @@ export function useFallingNotesAudio() {
    * and timer are torn down and a fresh anchor is established, so no stale
    * future node can double-fire and the cursor restarts from the new position.
    */
-  const startAudio = useCallback((
+  const startAudio = useCallback(async (
     notes: FallingNote[],
     offsetSec: number,
     tempoScale: number,
     mute: boolean
-  ) => {
-    initializeAudio()
+  ): Promise<boolean> => {
+    if (!initializeAudio()) return false
 
-    if (!audioContextRef.current || !masterGainRef.current) return
+    const audioContext = audioContextRef.current
+    if (!audioContext || !masterGainRef.current) return false
+
+    // Invalidate any older start request before awaiting `resume()`. This also
+    // prevents a delayed resume from restarting playback after stop/unmount or
+    // after a newer seek/tempo request has taken ownership of the clock.
+    const generation = ++playbackGenerationRef.current
 
     // Tear down any currently playing audio and its timer.
     stopTick()
     stopAudioNodes(scheduledNodesRef.current)
     scheduledNodesRef.current = []
     activeEndsRef.current = []
+    isPlayingRef.current = false
+    baseAudioTimeRef.current = null
+
+    // A suspended AudioContext is not a usable clock. Await the browser's
+    // user-gesture-gated resume result and report failure to the player instead
+    // of entering a visual-only "playing" state with a frozen playhead.
+    if (audioContext.state === 'suspended') {
+      try {
+        await audioContext.resume()
+      } catch (error) {
+        console.warn('AudioContext resume failed:', error)
+        return false
+      }
+    }
+
+    if (generation !== playbackGenerationRef.current || audioContext.state !== 'running') {
+      return false
+    }
 
     // Store current state
     notesRef.current = notes
@@ -252,14 +302,9 @@ export function useFallingNotesAudio() {
     tempoScaleRef.current = tempoScale
     isPlayingRef.current = true
 
-    // Resume audio context if suspended (required by some browsers)
-    if (audioContextRef.current.state === 'suspended') {
-      audioContextRef.current.resume()
-    }
-
     // Establish the single timing anchor: songTime `offsetSec` maps to this
     // AudioContext time. A small lead keeps the first notes just in the future.
-    const baseAudioTime = audioContextRef.current.currentTime + 0.05
+    const baseAudioTime = audioContext.currentTime + 0.05
     baseAudioTimeRef.current = baseAudioTime
     offsetSecRef.current = offsetSec
     scheduleCursorRef.current = offsetSec
@@ -275,12 +320,15 @@ export function useFallingNotesAudio() {
     if (!mute) {
       tickRef.current = setInterval(tick, TICK_MS)
     }
+
+    return true
   }, [initializeAudio, stopTick, scheduleWindow, tick])
 
   /**
    * Stop all audio playback
    */
   const stopAudio = useCallback(() => {
+    playbackGenerationRef.current += 1
     isPlayingRef.current = false
     stopTick()
     stopAudioNodes(scheduledNodesRef.current)
@@ -292,15 +340,16 @@ export function useFallingNotesAudio() {
   /**
    * Get current playback time with precise synchronization
    */
-  const getCurrentTime = useCallback((tempoScale: number): number => {
+  const getCurrentTime = useCallback((): number => {
     const context = audioContextRef.current
     const baseTime = baseAudioTimeRef.current
 
     if (context && baseTime !== null && isPlayingRef.current) {
-      // High-precision timing using AudioContext.currentTime
-      const audioElapsed = Math.max(0, context.currentTime - baseTime)
-      const scaledElapsed = audioElapsed * tempoScale
-      return offsetSecRef.current + scaledElapsed
+      return songTimeAtAudioTime({
+        audioTimeSec: baseTime,
+        songTimeSec: offsetSecRef.current,
+        tempoScale: tempoScaleRef.current,
+      }, context.currentTime)
     }
 
     return offsetSecRef.current

--- a/src/hooks/useFallingNotesPlayer.ts
+++ b/src/hooks/useFallingNotesPlayer.ts
@@ -18,12 +18,17 @@ export function useFallingNotesPlayer(notes: FallingNote[]) {
   const [lookAheadSec, setLookAheadSec] = useState(1.5)
 
   // Audio management
-  const audioPlayback = useFallingNotesAudio()
+  const {
+    startAudio,
+    stopAudio,
+    getCurrentTime,
+    updateTempoScale,
+    setOffsetTime,
+    reset,
+  } = useFallingNotesAudio()
   
   // Animation refs
   const rafRef = useRef<number | null>(null)
-  const lastFrameTimeRef = useRef<number>(0)
-  const syncCheckIntervalRef = useRef<number>(0)
 
   // Calculate song length
   const totalLength = calculateSongLength(notes)
@@ -31,18 +36,18 @@ export function useFallingNotesPlayer(notes: FallingNote[]) {
   /**
    * Start playback
    */
-  const handlePlay = useCallback(() => {
+  const handlePlay = useCallback(async () => {
     if (isPlaying) return
 
-    setIsPlaying(true)
-    audioPlayback.updateTempoScale(tempoScale)
-    audioPlayback.startAudio(
+    updateTempoScale(tempoScale)
+    const started = await startAudio(
       notes,
-      audioPlayback.getCurrentTime(tempoScale),
+      getCurrentTime(),
       tempoScale,
       mute
     )
-  }, [isPlaying, tempoScale, mute, notes, audioPlayback])
+    if (started) setIsPlaying(true)
+  }, [isPlaying, tempoScale, mute, notes, getCurrentTime, startAudio, updateTempoScale])
 
   /**
    * Pause playback
@@ -51,73 +56,80 @@ export function useFallingNotesPlayer(notes: FallingNote[]) {
     if (!isPlaying) return
 
     // Get precise current time from audio context
-    const currentAudioTime = audioPlayback.getCurrentTime(tempoScale)
+    const currentAudioTime = getCurrentTime()
     setIsPlaying(false)
-    audioPlayback.stopAudio()
-    audioPlayback.setOffsetTime(currentAudioTime)
+    stopAudio()
+    setOffsetTime(currentAudioTime)
     setCurrentTime(currentAudioTime)
-  }, [isPlaying, tempoScale, audioPlayback])
+  }, [isPlaying, getCurrentTime, setOffsetTime, stopAudio])
 
   /**
    * Stop playback
    */
   const handleStop = useCallback(() => {
     setIsPlaying(false)
-    audioPlayback.reset()
+    reset()
     setCurrentTime(0)
-  }, [audioPlayback])
+  }, [reset])
 
   /**
    * Seek to specific time
    */
-  const handleSeek = useCallback((newTime: number) => {
+  const handleSeek = useCallback(async (newTime: number) => {
     const clampedTime = Math.max(0, Math.min(newTime, totalLength))
-    audioPlayback.setOffsetTime(clampedTime)
+    if (!isPlaying) stopAudio()
+    setOffsetTime(clampedTime)
     setCurrentTime(clampedTime)
 
     // If currently playing, restart audio from new position
     if (isPlaying) {
-      audioPlayback.startAudio(notes, clampedTime, tempoScale, mute)
+      const started = await startAudio(notes, clampedTime, tempoScale, mute)
+      if (!started) setIsPlaying(false)
     }
-  }, [totalLength, isPlaying, notes, tempoScale, mute, audioPlayback])
+  }, [totalLength, isPlaying, notes, tempoScale, mute, setOffsetTime, startAudio, stopAudio])
 
   /**
    * Change tempo with re-synchronization
    */
-  const handleTempoChange = useCallback((newTempoScale: number) => {
+  const handleTempoChange = useCallback(async (newTempoScale: number) => {
     const wasPlaying = isPlaying
 
     if (wasPlaying) {
       // Get current precise time before stopping
-      const currentAudioTime = audioPlayback.getCurrentTime(tempoScale)
-      audioPlayback.stopAudio()
+      const currentAudioTime = getCurrentTime()
+      stopAudio()
 
       // Update tempo scale
       setTempoScale(newTempoScale)
-      audioPlayback.updateTempoScale(newTempoScale)
+      updateTempoScale(newTempoScale)
 
       // Restart with new tempo
-      audioPlayback.setOffsetTime(currentAudioTime)
-      audioPlayback.startAudio(notes, currentAudioTime, newTempoScale, mute)
+      setOffsetTime(currentAudioTime)
+      const started = await startAudio(notes, currentAudioTime, newTempoScale, mute)
+      if (!started) setIsPlaying(false)
     } else {
+      stopAudio()
       setTempoScale(newTempoScale)
-      audioPlayback.updateTempoScale(newTempoScale)
+      updateTempoScale(newTempoScale)
     }
-  }, [isPlaying, tempoScale, mute, notes, audioPlayback])
+  }, [isPlaying, mute, notes, getCurrentTime, setOffsetTime, startAudio, stopAudio, updateTempoScale])
 
   /**
    * Toggle mute
    */
-  const handleMuteChange = useCallback((newMute: boolean) => {
+  const handleMuteChange = useCallback(async (newMute: boolean) => {
     setMute(newMute)
 
     // If currently playing, restart audio with new mute setting
     if (isPlaying) {
-      const currentAudioTime = audioPlayback.getCurrentTime(tempoScale)
-      audioPlayback.stopAudio()
-      audioPlayback.startAudio(notes, currentAudioTime, tempoScale, newMute)
+      const currentAudioTime = getCurrentTime()
+      stopAudio()
+      const started = await startAudio(notes, currentAudioTime, tempoScale, newMute)
+      if (!started) setIsPlaying(false)
+    } else {
+      stopAudio()
     }
-  }, [isPlaying, tempoScale, notes, audioPlayback])
+  }, [isPlaying, tempoScale, notes, getCurrentTime, startAudio, stopAudio])
 
   /**
    * Change look ahead time
@@ -133,39 +145,14 @@ export function useFallingNotesPlayer(notes: FallingNote[]) {
         cancelAnimationFrame(rafRef.current)
         rafRef.current = null
       }
-      lastFrameTimeRef.current = 0
-      syncCheckIntervalRef.current = 0
       return
     }
 
-    const animationLoop = (frameTime: number) => {
-      // Calculate frame delta for smooth animation
-      const deltaTime = lastFrameTimeRef.current ? frameTime - lastFrameTimeRef.current : 0
-      lastFrameTimeRef.current = frameTime
-
-      // Get precise current time from AudioContext
-      const currentAudioTime = audioPlayback.getCurrentTime(tempoScale)
+    const animationLoop = () => {
+      // Audio, falling notes, and active keys all consume this one score-time
+      // value derived from the AudioContext playback anchor.
+      const currentAudioTime = getCurrentTime()
       setCurrentTime(currentAudioTime)
-
-      // Periodic synchronization check (every ~100ms)
-      syncCheckIntervalRef.current += deltaTime
-      if (syncCheckIntervalRef.current > 100) {
-        syncCheckIntervalRef.current = 0
-
-        // Verify audio-visual synchronization
-        const timingInfo = audioPlayback.getTimingInfo()
-        if (timingInfo.isPlaying && timingInfo.audioContextTime && timingInfo.baseAudioTime) {
-          const audioTime = timingInfo.offsetSec + 
-            (timingInfo.audioContextTime - timingInfo.baseAudioTime) * tempoScale
-
-          // If drift is significant (>50ms), resync
-          const drift = Math.abs(audioTime - currentAudioTime)
-          if (drift > 0.05) {
-            console.log(`Audio-visual drift detected: ${drift.toFixed(3)}s, resyncing...`)
-            setCurrentTime(audioTime)
-          }
-        }
-      }
 
       // Auto-stop when song ends
       if (shouldAutoStop(currentAudioTime, totalLength, 2)) {
@@ -183,10 +170,8 @@ export function useFallingNotesPlayer(notes: FallingNote[]) {
         cancelAnimationFrame(rafRef.current)
         rafRef.current = null
       }
-      lastFrameTimeRef.current = 0
-      syncCheckIntervalRef.current = 0
     }
-  }, [isPlaying, tempoScale, totalLength, audioPlayback, handleStop])
+  }, [isPlaying, totalLength, getCurrentTime, handleStop])
 
   return {
     // State

--- a/src/utils/__tests__/playbackClock.test.ts
+++ b/src/utils/__tests__/playbackClock.test.ts
@@ -1,0 +1,50 @@
+import {
+  audioTimeAtSongTime,
+  songTimeAtAudioTime,
+  type PlaybackClockAnchor,
+} from '../playbackClock'
+
+const anchor: PlaybackClockAnchor = {
+  audioTimeSec: 100,
+  songTimeSec: 12.5,
+  tempoScale: 1,
+}
+
+function measureMaxDrift(realDurationSec: number, tempoScale: number): number {
+  const framesPerSecond = 60
+  const testAnchor = { ...anchor, tempoScale }
+  let maxDrift = 0
+
+  for (let frame = 0; frame <= realDurationSec * framesPerSecond; frame++) {
+    const realElapsedSec = frame / framesPerSecond
+    const audioTimeSec = testAnchor.audioTimeSec + realElapsedSec
+    const expectedSongTimeSec = testAnchor.songTimeSec + realElapsedSec * tempoScale
+    const actualSongTimeSec = songTimeAtAudioTime(testAnchor, audioTimeSec)
+
+    maxDrift = Math.max(maxDrift, Math.abs(actualSongTimeSec - expectedSongTimeSec))
+  }
+
+  return maxDrift
+}
+
+describe('playbackClock', () => {
+  it('maps song time and AudioContext time through the same anchor', () => {
+    const songTimeSec = songTimeAtAudioTime(anchor, 142.25)
+
+    expect(songTimeSec).toBeCloseTo(54.75, 10)
+    expect(audioTimeAtSongTime(anchor, songTimeSec)).toBeCloseTo(142.25, 10)
+  })
+
+  it.each([
+    ['1 minute', 60, 1],
+    ['5 minutes', 300, 1],
+    ['5 minutes at 2x', 300, 2],
+    ['5 minutes at 0.5x', 300, 0.5],
+  ])('keeps %s playback drift below 1ms', (_label, durationSec, tempoScale) => {
+    expect(measureMaxDrift(durationSec, tempoScale)).toBeLessThan(0.001)
+  })
+
+  it('does not run backwards before the audio anchor begins', () => {
+    expect(songTimeAtAudioTime(anchor, 99)).toBe(anchor.songTimeSec)
+  })
+})

--- a/src/utils/playbackClock.ts
+++ b/src/utils/playbackClock.ts
@@ -1,0 +1,34 @@
+/**
+ * The single mapping between AudioContext time and score time.
+ *
+ * Audio scheduling converts score timestamps into AudioContext timestamps,
+ * while the visual player converts the AudioContext playhead back into score
+ * time. Keeping both directions on one immutable anchor prevents the audio,
+ * falling notes, and active piano keys from accumulating independent drift.
+ */
+export interface PlaybackClockAnchor {
+  /** AudioContext.currentTime at which playback starts. */
+  audioTimeSec: number
+  /** Score position represented by audioTimeSec. */
+  songTimeSec: number
+  /** Score seconds advanced per real AudioContext second. */
+  tempoScale: number
+}
+
+/** Convert an AudioContext timestamp into score time without running backward. */
+export function songTimeAtAudioTime(
+  anchor: PlaybackClockAnchor,
+  audioTimeSec: number
+): number {
+  const elapsedAudioSec = Math.max(0, audioTimeSec - anchor.audioTimeSec)
+  return anchor.songTimeSec + elapsedAudioSec * Math.max(0, anchor.tempoScale)
+}
+
+/** Convert a score timestamp into the AudioContext timeline used for scheduling. */
+export function audioTimeAtSongTime(
+  anchor: PlaybackClockAnchor,
+  songTimeSec: number
+): number {
+  if (anchor.tempoScale <= 0) return anchor.audioTimeSec
+  return anchor.audioTimeSec + (songTimeSec - anchor.songTimeSec) / anchor.tempoScale
+}


### PR DESCRIPTION
## Purpose
Complete P0-C stages 4-5 by making audio scheduling, falling-note visuals, and piano-key activation consume one AudioContext-derived score clock, with deterministic long-run drift gates.

## Scope
- add a bidirectional AudioContext/score-time anchor used by scheduling and the visual playhead
- derive active piano keys synchronously from the same render playhead
- reject unavailable, failed-resume, and stale pending AudioContext starts
- simulate 1-minute and 5-minute playback at 0.5x, 1x, and 2x with <1ms measured arithmetic drift
- add component and hook regressions for first-frame key sync and AudioContext lifecycle

## Excluded
- no animation contract or rolling scheduler window changes
- no live OMR or storage changes
- authenticated live playback on /sheet/2 remains a separate environment-backed verification

## Risk
Moderate: playback lifecycle methods now await AudioContext resume. Generation cancellation prevents stale async starts after stop, seek, tempo, or mute changes.

## Validation
- `npm test -- --runInBand` — 39 suites, 362 tests passed
- `npx tsc --noEmit` — passed
- `npm run lint` — passed
- `npm run build` — passed (project build still skips type/lint internally; both were run separately)
- Playwright Chromium + Mobile Chrome — 6/6 passed
- independent code review — no remaining actionable findings

## Baseline difference
P0-C stages 1-3 from PR #19 remain intact. This PR removes the visual/key one-render split and replaces duplicate clock math with one shared anchor.

## Known verification gaps
- Firefox/WebKit local binaries are not installed, so those local projects were not runnable
- `/sheet/2` authenticated live playback requires runtime credentials and database data

## Rollback
Revert commit `e175314`; no schema, stored-data, or dependency migration is involved.