### PR TITLE
Remove the deploy path that never worked (issue #28)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,13 @@
-name: Deploy
+# Post-merge validation for `main`.
+#
+# This workflow does NOT deploy. Deployment is handled solely by the Vercel Git
+# integration. It previously carried `Deploy to production`, `Run database migrations`,
+# `Post-deploy health check`, and `Notify deployment status` jobs, none of which ever
+# succeeded: the repository has no secrets configured, so the Vercel action received an
+# empty token and Prisma received an empty DATABASE_URL. They were removed in issue #28.
+# A workflow named `Deploy` that only runs tests is worse than none -- it reads as
+# evidence that a merge shipped.
+name: Post-merge checks
 
 on:
   push:
@@ -7,7 +16,7 @@ on:
 
 jobs:
   test:
-    name: Test before deploy
+    name: Post-merge tests
     runs-on: ubuntu-latest
     
     services:
@@ -59,7 +68,7 @@ jobs:
         run: npx tsc --noEmit
 
   build:
-    name: Build application
+    name: Post-merge build
     runs-on: ubuntu-latest
     needs: test
 
@@ -96,106 +105,3 @@ jobs:
             public/
             package*.json
           retention-days: 1
-
-  deploy:
-    name: Deploy to production
-    runs-on: ubuntu-latest
-    needs: [test, build]
-    environment: production
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: build-files
-
-      - name: Deploy to Vercel
-        uses: amondnet/vercel-action@v25
-        with:
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
-          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-          vercel-args: '--prod'
-          github-comment: true
-
-  database-migrate:
-    name: Run database migrations
-    runs-on: ubuntu-latest
-    needs: [test, build]
-    environment: production
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Generate Prisma client
-        run: npx prisma generate
-
-      - name: Run database migrations
-        run: npx prisma migrate deploy
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-
-  health-check:
-    name: Post-deploy health check
-    runs-on: ubuntu-latest
-    needs: [deploy, database-migrate]
-
-    steps:
-      - name: Wait for deployment
-        run: sleep 30
-
-      - name: Health check
-        run: |
-          response=$(curl -s -o /dev/null -w "%{http_code}" https://clairkeys.vercel.app/api/health)
-          if [ $response -eq 200 ]; then
-            echo "✅ Health check passed"
-          else
-            echo "❌ Health check failed with status: $response"
-            exit 1
-          fi
-
-      - name: Test critical endpoints
-        run: |
-          # Test homepage
-          curl -f https://clairkeys.vercel.app/ || exit 1
-          
-          # Test API health
-          curl -f https://clairkeys.vercel.app/api/health || exit 1
-          
-          # Test auth pages
-          curl -f https://clairkeys.vercel.app/auth/signin || exit 1
-          
-          echo "✅ All critical endpoints are responding"
-
-  notify:
-    name: Notify deployment status
-    runs-on: ubuntu-latest
-    needs: [deploy, database-migrate, health-check]
-    if: always()
-
-    steps:
-      - name: Notify success
-        if: needs.deploy.result == 'success' && needs.database-migrate.result == 'success' && needs.health-check.result == 'success'
-        run: |
-          echo "🎉 Deployment successful!"
-          # Add Slack/Discord notification here if needed
-
-      - name: Notify failure
-        if: needs.deploy.result == 'failure' || needs.database-migrate.result == 'failure' || needs.health-check.result == 'failure'
-        run: |
-          echo "❌ Deployment failed!"
-          # Add Slack/Discord notification here if needed
-          exit 1

--- a/src/ci/__tests__/postMergeWorkflow.test.ts
+++ b/src/ci/__tests__/postMergeWorkflow.test.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * Guards the removal made for issue #28.
+ *
+ * `.github/workflows/deploy.yml` used to carry a deploy path that had never
+ * succeeded: no repository secrets are configured, so `amondnet/vercel-action`
+ * received an empty token and `prisma migrate deploy` an empty `DATABASE_URL`.
+ * Every commit on `main` therefore ended with red checks, which is exactly the
+ * noise that let a genuinely broken production deployment go unnoticed for days.
+ *
+ * These assertions are about the workflow *not* claiming to deploy. Re-adding a
+ * deploy job here is not forbidden — but it has to come with the secrets that
+ * make it work, and that will make this test fail loudly first.
+ */
+describe('post-merge workflow', () => {
+  const workflow = readFileSync(
+    join(process.cwd(), '.github/workflows/deploy.yml'),
+    'utf8'
+  )
+
+  it('does not present itself as a deployment', () => {
+    expect(workflow).toMatch(/^name: Post-merge checks$/m)
+    expect(workflow).not.toMatch(/^name: Deploy$/m)
+  })
+
+  it('carries no job that deploys, migrates, or reports a deployment', () => {
+    expect(workflow).not.toMatch(/^ {2}deploy:\s*$/m)
+    expect(workflow).not.toMatch(/^ {2}database-migrate:\s*$/m)
+    expect(workflow).not.toMatch(/^ {2}health-check:\s*$/m)
+    expect(workflow).not.toMatch(/^ {2}notify:\s*$/m)
+  })
+
+  it('holds no credential the repository cannot supply for deployment', () => {
+    expect(workflow).not.toContain('secrets.VERCEL_TOKEN')
+    expect(workflow).not.toContain('secrets.VERCEL_ORG_ID')
+    expect(workflow).not.toContain('secrets.VERCEL_PROJECT_ID')
+    expect(workflow).not.toContain('vercel-action')
+    expect(workflow).not.toContain('prisma migrate deploy')
+  })
+
+  // The surviving `build` job still passes `secrets.DATABASE_URL` and friends to
+  // `npm run build`. They all resolve to empty strings today and the job passes
+  // anyway, so the build does not actually need them. They are left alone
+  // deliberately: that job was never failing, and issue #28 is about the deploy
+  // path. Asserting their absence here would be asserting something untrue.
+
+  it('still validates the merge commit', () => {
+    expect(workflow).toMatch(/^ {2}test:\s*$/m)
+    expect(workflow).toMatch(/^ {2}build:\s*$/m)
+    expect(workflow).toContain('run: npm test')
+    expect(workflow).toContain('run: npm run lint')
+    expect(workflow).toContain('run: npx tsc --noEmit')
+    expect(workflow).toContain('run: npm run build')
+  })
+
+  it('leaves every job reachable', () => {
+    const declaredJobs = [...workflow.matchAll(/^ {2}([a-z][a-z0-9-]*):\s*$/gm)].map(
+      (match) => match[1]
+    )
+    const neededJobs = [...workflow.matchAll(/^ {4}needs:\s*(.+)$/gm)].flatMap((match) =>
+      match[1]
+        .replace(/[[\]]/g, '')
+        .split(',')
+        .map((name) => name.trim())
+        .filter(Boolean)
+    )
+
+    for (const needed of neededJobs) {
+      expect(declaredJobs).toContain(needed)
+    }
+  })
+})


### PR DESCRIPTION
Closes #28.

## Why

Every commit on `main` ended red. `deploy.yml` carried four jobs that have **never once succeeded**, because this repository has no secrets at all — both `gh secret list` and the `production` environment's secret list return empty:

| Job | Failure |
|---|---|
| `Deploy to production` | `amondnet/vercel-action@v25` received an empty `secrets.VERCEL_TOKEN` |
| `Run database migrations` | `prisma migrate deploy` received an empty `DATABASE_URL` → `P1012` |
| `Notify deployment status` | its failure branch `exit 1`s when the two above fail |
| `Post-deploy health check` | permanently `skipped` behind them |

That permanent red is not cosmetic. **It is why a genuinely broken production deployment went unnoticed for days**: when every commit fails identically, a real failure carries no signal. Production was serving a pre-P0 bundle — issue #18's 10-second audio cutoff reproducing live for users — while CI looked exactly as red as always. Evidence: `docs/recovery/validation/2026-07-24-production-serves-pre-p0-bundle.md`.

## What changed

- Removed `deploy`, `database-migrate`, `health-check`, and `notify`. Deployment is Vercel's Git integration alone.
- Renamed the workflow `Deploy` → `Post-merge checks`, and its jobs to `Post-merge tests` / `Post-merge build`. A workflow called `Deploy` that only runs tests is worse than none — in the checks list it reads as evidence that a merge shipped, which is precisely the misreading this whole investigation was about. New names avoid `Run Tests` and `Build Check`, which are already check names owned by `test.yml` / `pr-checks.yml`.
- Added `src/ci/__tests__/postMergeWorkflow.test.ts`, following the existing `prChecksWorkflow.test.ts` convention.

### Left alone deliberately

The surviving `build` job still passes `secrets.DATABASE_URL`, `NEXTAUTH_SECRET`, `SUPABASE_URL`, and `SUPABASE_ANON_KEY` to `npm run build`. They all resolve to empty strings today and the job passes regardless, so the build does not need them. That job was never failing and is outside issue #28's scope; the test file records this explicitly rather than asserting something untrue.

## Regression evidence (added before the change)

| Workflow state | `postMergeWorkflow.test.ts` |
|---|---|
| Before this change | **3 of 5 fail** — workflow name, deploy/migrate/health/notify jobs, Vercel credentials |
| After | 5 of 5 pass |

Verification: full suite **40 files / 367 tests pass**, `npx tsc --noEmit` clean, `next lint` reports no warnings or errors, and no surviving `needs:` entry references a removed job.

**Not verified:** the renamed workflow has not run on GitHub yet, so the new check names are unobserved until this merges.

## Does not fix, by design

`main` still will not deploy itself after this lands. The cause is now confirmed from the Vercel dashboard: **Production Branch Tracking is set to `master`**, which GitHub no longer has after the DOC-1 rename (`643ce71`, 2026-07-19). Every `main` push therefore builds as Preview only. Changing that field to `main` is a dashboard action, tracked in #28.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 머지 후 자동화가 배포 대신 테스트와 빌드 검증을 수행하도록 변경되었습니다.
  * 기존 배포, 데이터베이스 마이그레이션, 헬스 체크 및 알림 단계가 제거되었습니다.
  * 머지 후 테스트에서 린트, 타입 검사, 테스트 실행을 확인합니다.
  * 머지 후 빌드에서 애플리케이션 빌드 상태를 검증합니다.
  * 관련 자동화 설정이 의도한 검사 단계와 일치하는지 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->