### PR TITLE
Give low notes the partials that make them read as a piano

### DIFF
--- a/src/hooks/__tests__/useFallingNotesAudio.test.ts
+++ b/src/hooks/__tests__/useFallingNotesAudio.test.ts
@@ -138,4 +138,75 @@ describe('useFallingNotesAudio', () => {
 
     unmount()
   })
+  it('keeps a velocity-0 note silent through every scheduled gain event', async () => {
+    // The canonical animation contract allows an explicit velocity of 0, and
+    // PR #26 switched `||` to `??` specifically so such a note stays silent.
+    // The piano-timbre envelope then reintroduced a floor: `exponentialRamp`
+    // cannot land on zero, so the decay target was clamped to 1e-4 — and the
+    // release scheduled that floor unconditionally, giving a silent note an
+    // audible tail. This asserts on every value ever written to the note's gain.
+    const scheduled: number[] = []
+
+    const makeGainNode = () => ({
+      connect: jest.fn(),
+      gain: {
+        value: 0,
+        setValueAtTime: jest.fn((v: number) => scheduled.push(v)),
+        linearRampToValueAtTime: jest.fn((v: number) => scheduled.push(v)),
+        exponentialRampToValueAtTime: jest.fn((v: number) => scheduled.push(v)),
+        cancelScheduledValues: jest.fn(),
+      },
+    })
+
+    let gainCalls = 0
+    const context = {
+      state: 'running' as AudioContextState,
+      currentTime: 10,
+      destination: {},
+      // The first createGain is the master bus; later ones belong to notes.
+      createGain: jest.fn(() => {
+        gainCalls += 1
+        return gainCalls === 1
+          ? { connect: jest.fn(), gain: { value: 0 } }
+          : makeGainNode()
+      }),
+      createOscillator: jest.fn(() => ({
+        connect: jest.fn(),
+        start: jest.fn(),
+        stop: jest.fn(),
+        frequency: { value: 0 },
+        type: 'sine',
+        setPeriodicWave: jest.fn(),
+      })),
+      createBiquadFilter: jest.fn(() => ({
+        connect: jest.fn(),
+        type: 'lowpass',
+        frequency: { value: 0 },
+        Q: { value: 0 },
+      })),
+      createPeriodicWave: jest.fn(() => ({})),
+      resume: jest.fn(() => Promise.resolve()),
+      close: jest.fn(() => Promise.resolve()),
+    } as unknown as AudioContext
+
+    const constructor = jest.fn(() => context) as unknown as typeof AudioContext
+    setAudioContextConstructor(constructor)
+    const { result, unmount } = renderHook(() => useFallingNotesAudio())
+
+    await act(async () => {
+      await result.current.startAudio(
+        [{ midi: 21, start: 0, duration: 1, hand: 'L', velocity: 0 }],
+        0,
+        1,
+        false
+      )
+    })
+
+    expect(scheduled.length).toBeGreaterThan(0)
+    for (const value of scheduled) {
+      expect(value).toBe(0)
+    }
+
+    unmount()
+  })
 })

--- a/src/hooks/useFallingNotesAudio.ts
+++ b/src/hooks/useFallingNotesAudio.ts
@@ -14,6 +14,11 @@ import {
   songTimeAtAudioTime,
   type PlaybackClockAnchor,
 } from '@/utils/playbackClock'
+import {
+  harmonicAmplitudes,
+  timbreCutoffHz,
+  envelopeBreakpoints,
+} from '@/utils/pianoTimbre'
 
 /**
  * Audio nodes for a single note
@@ -83,7 +88,14 @@ export function useFallingNotesAudio() {
   }, [])
 
   /**
-   * Create audio nodes for a single note
+   * Create audio nodes for a single note.
+   *
+   * The oscillator carries a harmonic spectrum from `@/utils/pianoTimbre` rather
+   * than a bare sine. A sine has one partial, which left the lowpass with
+   * nothing to remove and left bass notes with no pitch definition — the "low
+   * notes sound like bass noise" report. Partials are supplied as a
+   * `PeriodicWave` so the whole spectrum still costs one oscillator, which
+   * matters because `VOICE_LIMIT` caps concurrent voices, not partials.
    */
   const createNoteAudio = useCallback((
     midi: number,
@@ -94,17 +106,35 @@ export function useFallingNotesAudio() {
     const gainNode = audioContext.createGain()
     const lowPassFilter = audioContext.createBiquadFilter()
 
-    // Configure oscillator
     const frequency = midiToFreq(midi)
-    oscillator.type = 'sine'
     oscillator.frequency.value = frequency
 
-    // Configure filter for more realistic piano sound
+    // `createPeriodicWave` takes cosine/sine coefficients indexed by harmonic,
+    // with index 0 the DC term, which must stay 0 to avoid a constant offset.
+    const amplitudes = harmonicAmplitudes(midi)
+    const real = new Float32Array(amplitudes.length + 1)
+    const imag = new Float32Array(amplitudes.length + 1)
+    for (let n = 0; n < amplitudes.length; n++) {
+      imag[n + 1] = amplitudes[n]
+    }
+
+    try {
+      // Already normalised in pianoTimbre, so skip the browser's own pass —
+      // normalising twice would undo the deliberate bass/treble weighting.
+      oscillator.setPeriodicWave(
+        audioContext.createPeriodicWave(real, imag, { disableNormalization: true })
+      )
+    } catch (error) {
+      // Test doubles and older engines may not implement PeriodicWave. Falling
+      // back to a sine is the pre-existing timbre, not a new failure mode.
+      console.warn('PeriodicWave unavailable, falling back to sine:', error)
+      oscillator.type = 'sine'
+    }
+
     lowPassFilter.type = 'lowpass'
-    lowPassFilter.frequency.value = frequency * 4
+    lowPassFilter.frequency.value = timbreCutoffHz(midi)
     lowPassFilter.Q.value = 1
 
-    // Configure gain for ADSR envelope
     gainNode.gain.value = 0
 
     // Connect nodes: oscillator -> filter -> gain -> master
@@ -170,36 +200,39 @@ export function useFallingNotesAudio() {
       try {
         const nodes = createNoteAudio(note.midi, audioContext, masterGain)
 
-        // Configure ADSR envelope
-        const attackTime = 0.02
-        const decayTime = 0.1
-        const sustainLevel = 0.6
-        const releaseTime = 0.3
-
         // Nullish (not `||`) so an explicit velocity of 0 stays silent rather
         // than snapping to the default 0.7 — the canonical contract allows 0.
         const velocity = note.velocity ?? 0.7
-        const peakGain = velocity * 0.3
+        const envelope = envelopeBreakpoints(velocity, endTime - clampedStart)
 
-        // Attack
+        // A struck string only loses energy after the hammer, so the note decays
+        // across its whole length instead of holding a plateau. The decay is
+        // exponential rather than linear because that is how the ear reads a
+        // piano's fade; `setTargetAtTime` cannot be used here since it never
+        // exactly reaches its target and would leave the release starting from
+        // an unknown level.
+        const attackEnd = clampedStart + envelope.attackSec
         nodes.gain.gain.setValueAtTime(0, clampedStart)
-        nodes.gain.gain.linearRampToValueAtTime(peakGain, clampedStart + attackTime)
+        nodes.gain.gain.linearRampToValueAtTime(envelope.peak, attackEnd)
 
-        // Decay to sustain
-        nodes.gain.gain.linearRampToValueAtTime(
-          peakGain * sustainLevel,
-          clampedStart + attackTime + decayTime
-        )
+        // exponentialRamp cannot pass through or land on zero.
+        const decayFloor = Math.max(envelope.sustain, 1e-4)
+        if (envelope.peak > 0) {
+          nodes.gain.gain.exponentialRampToValueAtTime(
+            decayFloor,
+            Math.max(attackEnd + 0.001, endTime)
+          )
+        }
 
         // Release
-        nodes.gain.gain.setValueAtTime(peakGain * sustainLevel, endTime)
-        nodes.gain.gain.linearRampToValueAtTime(0, endTime + releaseTime)
+        nodes.gain.gain.setValueAtTime(decayFloor, endTime)
+        nodes.gain.gain.linearRampToValueAtTime(0, endTime + envelope.releaseSec)
 
         // Start and stop oscillator
         nodes.osc.start(clampedStart)
-        nodes.osc.stop(endTime + releaseTime)
+        nodes.osc.stop(endTime + envelope.releaseSec)
 
-        nodes.end = endTime + releaseTime
+        nodes.end = endTime + envelope.releaseSec
         // Count the voice as active through its release tail (nodes.end), not
         // just to endTime — the oscillator is still sounding during release, so
         // pruning at endTime would let more than VOICE_LIMIT voices overlap.

--- a/src/hooks/useFallingNotesAudio.ts
+++ b/src/hooks/useFallingNotesAudio.ts
@@ -213,20 +213,27 @@ export function useFallingNotesAudio() {
         // an unknown level.
         const attackEnd = clampedStart + envelope.attackSec
         nodes.gain.gain.setValueAtTime(0, clampedStart)
-        nodes.gain.gain.linearRampToValueAtTime(envelope.peak, attackEnd)
 
-        // exponentialRamp cannot pass through or land on zero.
-        const decayFloor = Math.max(envelope.sustain, 1e-4)
         if (envelope.peak > 0) {
+          nodes.gain.gain.linearRampToValueAtTime(envelope.peak, attackEnd)
+
+          // `exponentialRamp` can neither pass through nor land on zero, so the
+          // decay target is floored. That floor must not escape this branch: a
+          // velocity-0 note has to stay at exactly zero, and scheduling the
+          // floor for it would give a silent note an audible tail — the very
+          // guarantee PR #26 introduced `??` to protect.
+          const decayFloor = Math.max(envelope.sustain, 1e-4)
           nodes.gain.gain.exponentialRampToValueAtTime(
             decayFloor,
             Math.max(attackEnd + 0.001, endTime)
           )
-        }
 
-        // Release
-        nodes.gain.gain.setValueAtTime(decayFloor, endTime)
-        nodes.gain.gain.linearRampToValueAtTime(0, endTime + envelope.releaseSec)
+          // Release
+          nodes.gain.gain.setValueAtTime(decayFloor, endTime)
+          nodes.gain.gain.linearRampToValueAtTime(0, endTime + envelope.releaseSec)
+        }
+        // A zero-peak note schedules nothing beyond the initial 0: the gain node
+        // is already silent and every later event could only raise it.
 
         // Start and stop oscillator
         nodes.osc.start(clampedStart)

--- a/src/types/fallingNotes.ts
+++ b/src/types/fallingNotes.ts
@@ -40,6 +40,21 @@ export type FallingNote = {
 };
 
 /**
+ * Amplitude envelope for one synthesised note, in seconds relative to its start.
+ * Produced by `envelopeBreakpoints` in `@/utils/pianoTimbre` and consumed by the
+ * playback hook when scheduling gain events.
+ */
+export interface NoteEnvelope {
+  /** Peak amplitude reached at the end of the attack. */
+  peak: number;
+  /** Amplitude the note has fallen to by the end of the decay. */
+  sustain: number;
+  attackSec: number;
+  decaySec: number;
+  releaseSec: number;
+}
+
+/**
  * Piano key layout information for 88-key keyboard
  */
 export type KeyLayout = {

--- a/src/utils/__tests__/pianoTimbre.test.ts
+++ b/src/utils/__tests__/pianoTimbre.test.ts
@@ -1,0 +1,145 @@
+import {
+  harmonicAmplitudes,
+  timbreCutoffHz,
+  envelopeBreakpoints,
+  MAX_PARTIAL_HZ,
+  MIN_KEPT_PARTIALS,
+} from '../pianoTimbre'
+import { A0_MIDI, C8_MIDI, midiToFreq } from '../pianoLayout'
+
+/**
+ * Regression basis for the "low notes sound like bass noise, not piano" report.
+ *
+ * The playback path synthesised every note as a single `sine` oscillator behind a
+ * lowpass at `frequency * 4`. A sine has exactly one partial, so the filter had
+ * nothing to remove and the note carried no harmonic content at all. That is
+ * inaudible as a defect in the treble — a 523 Hz sine still reads as a pitch —
+ * but piano bass tone lives almost entirely in its upper partials, so A0 at
+ * 27.5 Hz came out as a hum.
+ *
+ * These assertions are deliberately about *properties* rather than exact
+ * coefficients. The point is that a spectrum exists, that it is richer in the
+ * bass, and that nothing clips or aliases — not that any particular timbre is
+ * the right one, which is a listening judgement no test can make.
+ */
+
+const ALL_KEYS = Array.from({ length: C8_MIDI - A0_MIDI + 1 }, (_, i) => A0_MIDI + i)
+
+describe('harmonicAmplitudes', () => {
+  it('gives every key more than one partial', () => {
+    for (const midi of ALL_KEYS) {
+      expect(harmonicAmplitudes(midi).length).toBeGreaterThan(1)
+    }
+  })
+
+  it('gives the bass a richer spectrum than the treble', () => {
+    expect(harmonicAmplitudes(A0_MIDI).length).toBeGreaterThan(
+      harmonicAmplitudes(C8_MIDI).length
+    )
+  })
+
+  it('never places a partial where it would alias', () => {
+    for (const midi of ALL_KEYS) {
+      const fundamental = midiToFreq(midi)
+      const partials = harmonicAmplitudes(midi)
+      const highest = fundamental * partials.length
+      expect(highest).toBeLessThanOrEqual(MAX_PARTIAL_HZ)
+    }
+  })
+
+  it('keeps every amplitude non-negative and the total bounded', () => {
+    for (const midi of ALL_KEYS) {
+      const partials = harmonicAmplitudes(midi)
+      for (const amplitude of partials) {
+        expect(amplitude).toBeGreaterThanOrEqual(0)
+      }
+      expect(partials[0]).toBeGreaterThan(0)
+      const total = partials.reduce((sum, a) => sum + a, 0)
+      expect(total).toBeLessThanOrEqual(1 + 1e-6)
+      expect(total).toBeGreaterThan(0.5)
+    }
+  })
+
+  it('weights the bass fundamental below the treble fundamental', () => {
+    const share = (midi: number) => {
+      const partials = harmonicAmplitudes(midi)
+      return partials[0] / partials.reduce((sum, a) => sum + a, 0)
+    }
+
+    // A real piano's lowest strings put most of their energy above the
+    // fundamental; that is exactly what a lone sine cannot represent.
+    expect(share(A0_MIDI)).toBeLessThan(share(C8_MIDI))
+  })
+})
+
+describe('timbreCutoffHz', () => {
+  it('leaves the generated partials audible instead of cutting at 4x the fundamental', () => {
+    for (const midi of ALL_KEYS) {
+      const fundamental = midiToFreq(midi)
+      // In the top octave the aliasing ceiling leaves only a handful of partials
+      // in the first place, so demanding MIN_KEPT_PARTIALS there would be
+      // demanding headroom above partials that do not exist. What must hold
+      // everywhere is that the filter does not throw away what was generated.
+      const kept = Math.min(MIN_KEPT_PARTIALS, harmonicAmplitudes(midi).length)
+      expect(timbreCutoffHz(midi)).toBeGreaterThanOrEqual(fundamental * kept)
+
+      // Where a 4th partial can exist at all, the cutoff must clear it — the old
+      // `4 * f0` sat right on top of it. In the top octave `4 * f0` is already
+      // past the aliasing ceiling, so there is nothing there to compare against.
+      if (fundamental * 4 <= MAX_PARTIAL_HZ) {
+        expect(timbreCutoffHz(midi)).toBeGreaterThan(fundamental * 4)
+      }
+    }
+  })
+
+  it('stays inside the audible band', () => {
+    for (const midi of ALL_KEYS) {
+      const cutoff = timbreCutoffHz(midi)
+      expect(cutoff).toBeGreaterThan(0)
+      expect(cutoff).toBeLessThanOrEqual(MAX_PARTIAL_HZ)
+    }
+  })
+
+  it('does not brighten as pitch rises', () => {
+    // Cutoff tracks the fundamental but is clamped, so it must never decrease
+    // going up the keyboard — a treble note dimmer than a bass note would
+    // invert the register balance.
+    for (let i = 1; i < ALL_KEYS.length; i++) {
+      expect(timbreCutoffHz(ALL_KEYS[i])).toBeGreaterThanOrEqual(
+        timbreCutoffHz(ALL_KEYS[i - 1])
+      )
+    }
+  })
+})
+
+describe('envelopeBreakpoints', () => {
+  it('is silent at velocity 0', () => {
+    const envelope = envelopeBreakpoints(0, 1)
+    expect(envelope.peak).toBe(0)
+    expect(envelope.sustain).toBe(0)
+  })
+
+  it('scales the peak with velocity', () => {
+    expect(envelopeBreakpoints(1, 1).peak).toBeGreaterThan(
+      envelopeBreakpoints(0.5, 1).peak
+    )
+  })
+
+  it('decays after the attack rather than holding a plateau', () => {
+    // A piano string is never re-energised after the hammer strike, so the
+    // envelope must fall. The previous ADSR held 0.6 of peak for the whole
+    // note, which is an organ, not a piano.
+    const envelope = envelopeBreakpoints(1, 4)
+    expect(envelope.sustain).toBeLessThan(envelope.peak)
+    expect(envelope.decaySec).toBeGreaterThan(0)
+  })
+
+  it('reaches the note end before releasing, however short the note', () => {
+    for (const duration of [0.05, 0.2, 1, 8]) {
+      const envelope = envelopeBreakpoints(0.8, duration)
+      expect(envelope.attackSec).toBeGreaterThan(0)
+      expect(envelope.attackSec).toBeLessThanOrEqual(duration)
+      expect(envelope.releaseSec).toBeGreaterThan(0)
+    }
+  })
+})

--- a/src/utils/__tests__/pianoTimbre.test.ts
+++ b/src/utils/__tests__/pianoTimbre.test.ts
@@ -137,10 +137,13 @@ describe('envelopeBreakpoints', () => {
     expect(envelope.decaySec).toBeGreaterThan(0)
   })
 
-  it('reaches the note end before releasing, however short the note', () => {
-    for (const duration of [0.05, 0.2, 1, 8]) {
+  it('never lets the attack outlast the note, down to zero length', () => {
+    // A zero-length note is degenerate but reachable; its attack must not run
+    // past the note's own end. The scheduler also filters these out, but the
+    // envelope contract has to hold on its own.
+    for (const duration of [0, 0.05, 0.2, 1, 8]) {
       const envelope = envelopeBreakpoints(0.8, duration)
-      expect(envelope.attackSec).toBeGreaterThan(0)
+      expect(envelope.attackSec).toBeGreaterThanOrEqual(0)
       expect(envelope.attackSec).toBeLessThanOrEqual(duration)
       expect(envelope.releaseSec).toBeGreaterThan(0)
     }

--- a/src/utils/__tests__/pianoTimbre.test.ts
+++ b/src/utils/__tests__/pianoTimbre.test.ts
@@ -54,9 +54,12 @@ describe('harmonicAmplitudes', () => {
         expect(amplitude).toBeGreaterThanOrEqual(0)
       }
       expect(partials[0]).toBeGreaterThan(0)
+      // The module normalises to exactly 1, and the oscillator is built with
+      // `disableNormalization: true`, so the browser will not rescale this for
+      // us. A loose lower bound would let a normalisation bug through and take
+      // the output level with it — assert the documented contract instead.
       const total = partials.reduce((sum, a) => sum + a, 0)
-      expect(total).toBeLessThanOrEqual(1 + 1e-6)
-      expect(total).toBeGreaterThan(0.5)
+      expect(total).toBeCloseTo(1, 6)
     }
   })
 

--- a/src/utils/pianoTimbre.ts
+++ b/src/utils/pianoTimbre.ts
@@ -1,0 +1,172 @@
+import { A0_MIDI, C8_MIDI, midiToFreq } from './pianoLayout'
+
+/**
+ * Piano timbre: which partials a note carries, how bright it is, and how it decays.
+ *
+ * The playback path used to synthesise every note as one `sine` oscillator behind
+ * a lowpass at `frequency * 4`. A sine has exactly one partial, so that filter
+ * had nothing to remove — it was inert. In the treble the result still reads as a
+ * pitch, but a piano's bass tone lives mostly in its upper partials, so A0 at
+ * 27.5 Hz arrived as a hum rather than a struck string. That is the "low notes
+ * sound like bass noise" report.
+ *
+ * The spectrum and envelope decisions live here as pure functions, separate from
+ * oscillator construction, for the same reason `audioScheduler` split window
+ * selection out of node creation: fused with `createOscillator` they cannot be
+ * tested at all, and the original defect was invisible precisely because nothing
+ * could look at it.
+ *
+ * These are approximations of a piano, not a model of one. Real strings are
+ * inharmonic and their partials decay at different rates; neither is reproduced.
+ * The goal is a tone that reads as a struck string across the whole keyboard.
+ */
+
+/**
+ * Ceiling for any generated partial, in Hz.
+ *
+ * Sits below the Nyquist frequency of the lowest sample rate this runs at
+ * (44.1 kHz → 22.05 kHz) with margin, so no partial can fold back as an alias.
+ * It also bounds `timbreCutoffHz`, since a cutoff above the highest partial
+ * would do nothing.
+ */
+export const MAX_PARTIAL_HZ = 16000
+
+/**
+ * How many partials the lowpass must leave audible.
+ *
+ * The old cutoff of `4 * f0` is the number this replaces: even if the source had
+ * carried harmonics, four of them is not a piano. Bass notes need well over a
+ * dozen partials before they stop sounding like a sine.
+ */
+export const MIN_KEPT_PARTIALS = 12
+
+/** Lowest cutoff the filter may use, so no note loses its character entirely. */
+const MIN_CUTOFF_HZ = 2600
+
+/** Most partials generated for any one note, bounding per-note cost. */
+const MAX_PARTIALS = 24
+
+/**
+ * Spectral rolloff exponent: amplitude of partial `n` falls as `1 / n ** rolloff`.
+ *
+ * The bass end uses a gentler exponent so upper partials stay strong, which is
+ * what gives a low piano note its pitch definition. The treble rolls off harder,
+ * both because real strings do and because a bright top octave is fatiguing.
+ */
+const BASS_ROLLOFF = 1.15
+const TREBLE_ROLLOFF = 2.4
+
+/**
+ * How much the fundamental is held back in the lowest register.
+ *
+ * A grand piano's bottom strings are shorter than their pitch requires, so their
+ * fundamental is weak and the ear infers the pitch from the partials. Applying
+ * this to the whole keyboard would thin out the treble, so it fades out by the
+ * middle register.
+ */
+const BASS_FUNDAMENTAL_SCALE = 0.45
+
+/** 0 at A0, 1 at C8 — how far up the keyboard a note sits. */
+function registerPosition(midi: number): number {
+  const clamped = Math.min(Math.max(midi, A0_MIDI), C8_MIDI)
+  return (clamped - A0_MIDI) / (C8_MIDI - A0_MIDI)
+}
+
+/**
+ * Relative amplitudes of a note's harmonic partials, index 0 being the
+ * fundamental.
+ *
+ * The count is limited by three things at once: the aliasing ceiling
+ * (`MAX_PARTIAL_HZ`), a per-note cap (`MAX_PARTIALS`), and a floor of two so no
+ * note ever degenerates back to a bare sine. The result is normalised to sum to
+ * 1, which keeps a chord of many voices from clipping the master gain.
+ */
+export function harmonicAmplitudes(midi: number): number[] {
+  const fundamental = midiToFreq(midi)
+  const position = registerPosition(midi)
+
+  const affordable = Math.floor(MAX_PARTIAL_HZ / fundamental)
+  const count = Math.max(2, Math.min(MAX_PARTIALS, affordable))
+
+  const rolloff = BASS_ROLLOFF + (TREBLE_ROLLOFF - BASS_ROLLOFF) * position
+
+  const amplitudes: number[] = []
+  for (let n = 1; n <= count; n++) {
+    amplitudes.push(1 / Math.pow(n, rolloff))
+  }
+
+  // Weak fundamental in the bass, fading to none by the middle of the keyboard.
+  const bassWeight = Math.max(0, 1 - position * 2)
+  amplitudes[0] *= 1 - (1 - BASS_FUNDAMENTAL_SCALE) * bassWeight
+
+  const total = amplitudes.reduce((sum, a) => sum + a, 0)
+  return amplitudes.map((a) => a / total)
+}
+
+/**
+ * Lowpass cutoff for a note, in Hz.
+ *
+ * Tracks the fundamental so higher notes stay proportionally bright, but is
+ * floored so bass notes keep the partials that carry their pitch — the failure
+ * the old `4 * f0` cutoff would have caused had there been anything to cut.
+ * Clamped to `MAX_PARTIAL_HZ` because a cutoff above the highest partial is a
+ * filter that does nothing, which is what this replaces.
+ */
+export function timbreCutoffHz(midi: number): number {
+  const fundamental = midiToFreq(midi)
+  const tracking = fundamental * MIN_KEPT_PARTIALS
+  return Math.min(MAX_PARTIAL_HZ, Math.max(MIN_CUTOFF_HZ, tracking))
+}
+
+/** Amplitude envelope for one note, in seconds relative to its start. */
+export interface NoteEnvelope {
+  /** Peak amplitude reached at the end of the attack. */
+  peak: number
+  /** Amplitude the note has fallen to by the end of the decay. */
+  sustain: number
+  attackSec: number
+  decaySec: number
+  releaseSec: number
+}
+
+/** Loudest a single voice may be before the master gain stage. */
+const PEAK_GAIN = 0.3
+
+/** Fraction of peak a note has decayed to by the end of its decay phase. */
+const SUSTAIN_RATIO = 0.18
+
+const ATTACK_SEC = 0.004
+const RELEASE_SEC = 0.35
+
+/**
+ * Envelope for a note of the given velocity and duration.
+ *
+ * A piano string receives energy once, from the hammer, and only loses it after
+ * that. The previous envelope held 0.6 of peak for the note's whole length,
+ * which is a sustained instrument — an organ, not a piano. Here the note decays
+ * continuously toward `SUSTAIN_RATIO` instead.
+ *
+ * Longer notes decay more slowly, which is also how the instrument behaves: a
+ * whole note in the bass rings far longer than a semiquaver in the treble. The
+ * attack stays very short, since the hammer strike is close to instantaneous,
+ * but is clamped so a very brief note cannot have an attack longer than itself.
+ */
+export function envelopeBreakpoints(
+  velocity: number,
+  durationSec: number
+): NoteEnvelope {
+  const safeDuration = Math.max(durationSec, 0)
+  const attackSec = Math.min(ATTACK_SEC, safeDuration || ATTACK_SEC)
+  const peak = Math.max(0, velocity) * PEAK_GAIN
+
+  return {
+    peak,
+    sustain: peak * SUSTAIN_RATIO,
+    attackSec,
+    // Spend the note decaying rather than holding: the decay fills whatever is
+    // left after the attack, with a floor so extremely short notes still audibly
+    // fall instead of cutting off square.
+    decaySec: Math.max(0.08, safeDuration - attackSec),
+    releaseSec: RELEASE_SEC,
+  }
+}

--- a/src/utils/pianoTimbre.ts
+++ b/src/utils/pianoTimbre.ts
@@ -1,4 +1,5 @@
 import { A0_MIDI, C8_MIDI, midiToFreq } from './pianoLayout'
+import type { NoteEnvelope } from '@/types/fallingNotes'
 
 /**
  * Piano timbre: which partials a note carries, how bright it is, and how it decays.
@@ -118,17 +119,6 @@ export function timbreCutoffHz(midi: number): number {
   return Math.min(MAX_PARTIAL_HZ, Math.max(MIN_CUTOFF_HZ, tracking))
 }
 
-/** Amplitude envelope for one note, in seconds relative to its start. */
-export interface NoteEnvelope {
-  /** Peak amplitude reached at the end of the attack. */
-  peak: number
-  /** Amplitude the note has fallen to by the end of the decay. */
-  sustain: number
-  attackSec: number
-  decaySec: number
-  releaseSec: number
-}
-
 /** Loudest a single voice may be before the master gain stage. */
 const PEAK_GAIN = 0.3
 
@@ -156,7 +146,10 @@ export function envelopeBreakpoints(
   durationSec: number
 ): NoteEnvelope {
   const safeDuration = Math.max(durationSec, 0)
-  const attackSec = Math.min(ATTACK_SEC, safeDuration || ATTACK_SEC)
+  // Clamp to the note's own length so the attack never outlasts it — including
+  // a zero-length note, where the earlier `safeDuration || ATTACK_SEC` fell
+  // back to the full 4 ms.
+  const attackSec = Math.min(ATTACK_SEC, safeDuration)
   const peak = Math.max(0, velocity) * PEAK_GAIN
 
   return {


### PR DESCRIPTION
## Why

A user reported that low notes on the deployed site sound like **bass noise rather than piano tone**.

The playback path synthesised every note as a single `sine` oscillator behind a lowpass at `frequency * 4`:

```ts
oscillator.type = 'sine'
lowPassFilter.frequency.value = frequency * 4   // nothing to cut — a sine has one partial
```

**That filter was inert.** It reads in the source as though it shapes the timbre, but a sine's spectrum is a single line, so there was never anything for it to remove.

This is inaudible as a defect in the treble — a 523 Hz sine still reads as a pitch — which is exactly why the report is about low notes specifically. A piano's bass tone lives mostly *above* its fundamental: the bottom strings are shorter than their pitch requires, so the ear infers the note from the partials. At A0's 27.5 Hz a lone sine leaves nothing to infer from, and small speakers reproduce almost none of it. What arrives is a hum.

## What changed

New pure module `src/utils/pianoTimbre.ts`:

| | before | after |
|---|---|---|
| A0 partials | **1** | **24** (fundamental holds 17.5% of energy) |
| A0 cutoff | 110 Hz (`4 × f0`) | **2600 Hz** |
| C4 partials / cutoff | 1 / 1047 Hz | 24 / 3140 Hz |
| C8 partials / cutoff | 1 / 16744 Hz | 3 / 16000 Hz (aliasing ceiling) |
| envelope | `sustain 0.6` held for the whole note | exponential decay to 18% of peak |

Bass notes get a gentler spectral rolloff and a deliberately weakened fundamental; the treble rolls off harder. Partials ride **one `PeriodicWave`**, not one oscillator each.

The envelope changes for the same class of reason as the filter: a struck string only loses energy after the hammer, and holding 0.6 of peak for the note's full length is a sustained instrument — an organ, not a piano.

### Why the logic is split out

Fused with `createOscillator`, these decisions cannot be tested at all. That is *why* a filter doing nothing survived unremarked in the code. This follows what `audioScheduler` did for window selection — the same seam that made issue #18's 10-second cap visible.

### Rejected

- **One oscillator per partial** — simpler to read, but `VOICE_LIMIT` counts *voices*, so a 24-partial bass note would consume 24 of 24 and silently cut polyphony to a fraction.
- **Tone.js Sampler with real piano samples** — two other Tone.js synthesis paths already sit unused in this repo. Adding sample assets and a third path is a P2-A architecture decision, not a timbre fix.
- **`setTargetAtTime` for the decay** — never exactly reaches its target, so the release would start from an unknown level.

## Verification

`src/utils/__tests__/pianoTimbre.test.ts` — 12 property-based cases, written first and failing before the module existed. They assert that a spectrum exists at all, that it is richer in the bass, that no partial aliases, that amplitudes stay normalised, and that the envelope decays instead of holding.

| Check | Result |
|---|---|
| `npm test` | **41 suites / 379 tests pass** |
| `npx tsc --noEmit` | clean |
| `npm run lint` | no warnings or errors |
| `npm run build` | succeeds |

## Not verified — please read

**Nobody has heard this.** jsdom has no Web Audio and no offline renderer is installed, so no waveform was rendered and no spectrum measured from actual output. The evidence above is about the **coefficients fed to `PeriodicWave`**, not about what a browser produces from them.

Whether this actually sounds like a piano is a listening judgement that has to happen after deploy. It also changes the timbre of **every** note, not only low ones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 피아노 음색 생성이 음역별 하모닉 구성과 음색 컷오프 계산을 기반으로 개선되어 더욱 풍부하고 자연스럽게 재생됩니다.
  * 음의 벨로시티와 길이에 따라 엔벨로프(피크/서스테인·어택/디케이·릴리즈) 브레이크포인트가 정교하게 적용됩니다.

* **버그 수정**
  * 벨로시티 0 음표가 실제로 무음이 되도록 보장하고, 기존 대비 음 끊김 및 종료 구간의 자연스러움을 개선했습니다.

* **테스트**
  * 피아노 음색 유틸리티 및 오디오 재생 훅에 대한 회귀 테스트를 추가/강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->