### PR TITLE
Pin brace-expansion past the DoS advisory blocking the audit gate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4468,16 +4468,6 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -5292,11 +5282,14 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.43",
@@ -5325,14 +5318,16 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -5731,13 +5726,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
     },
@@ -7514,16 +7502,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/glob/node_modules/minimatch": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   },
   "overrides": {
     "sharp": ">=0.35.0",
-    "postcss": ">=8.5.12"
+    "postcss": ">=8.5.12",
+    "brace-expansion": ">=5.0.8"
   },
   "dependencies": {
     "@napi-rs/canvas": "^0.1.76",


### PR DESCRIPTION
## Why

`Security Audit` (`npm audit --audit-level high`, a required check) went red on `main` again — the **third time** in this pattern where a newly published advisory flips the gate with no dependency in the tree having changed (see PR #25, PR #27).

`GHSA-mh99-v99m-4gvg`: DoS in `brace-expansion` via unbounded expansion, vulnerable range `<=5.0.7`. **31 of the reported high entries all trace to this one package** — jest and eslint each pull it transitively, inflating one advisory into a long chain.

This is currently blocking **PR #30** (low-note timbre), whose `Security Audit` failed on exactly this and nothing else.

## What changed

```json
"overrides": { ..., "brace-expansion": ">=5.0.8" }
```

`brace-expansion` sits in the tree at both `1.1.16` and `2.1.2`, and the advisory's only fixed version is `5.0.8`, so the fix cannot be a within-major bump. The override forces both chains onto `5.0.8`.

It is a single stable function used only by dev tooling (`minimatch`/`glob` under jest and eslint). Forcing one major's consumers onto another is the real risk, so the check is the full toolchain running green:

| Check | Before | After |
|---|---|---|
| `npm audit --audit-level high` | **exit 1 — 31 high** | **exit 0 — 0 vulnerabilities** |
| `brace-expansion` resolved | 1.1.16 + 2.1.2 | **5.0.8** (both) |
| `npm test` | — | 40 suites / 367 tests pass |
| `npx tsc --noEmit` | — | clean |
| `npm run lint` | — | no warnings or errors |

## Split out deliberately

Not folded into PR #30, matching how **PR #25**'s `sharp` pin was split from PR #24: one purpose per PR, and this re-greens the gate for **every** open branch, not just the timbre one.

### Rejected

- **`npm audit fix --force`** — rewrites unrelated resolutions and offered a semver-major `@eslint/eslintrc` downgrade.
- **Fold into PR #30** — mixes a repo-wide dependency fix into an audio change.

Related: #25, #27, #30