### PR TITLE
Add a live treble-brightness control to tune its default by ear

### DIFF
--- a/src/components/animation/FallingNotesPlayer.tsx
+++ b/src/components/animation/FallingNotesPlayer.tsx
@@ -6,6 +6,7 @@ import { buildKeyLayout } from '@/utils/pianoLayout'
 import { canonicalToFallingNotes } from '@/utils/dataConverter'
 import { useFallingNotesPlayer } from '@/hooks/useFallingNotesPlayer'
 import { MAX_MASTER_GAIN } from '@/hooks/useFallingNotesAudio'
+import { MIN_TREBLE_ROLLOFF, MAX_TREBLE_ROLLOFF } from '@/utils/pianoTimbre'
 import FallingNotes from './FallingNotes'
 import SimplePianoKeyboard from '../piano/SimplePianoKeyboard'
 import { PlaybackControls } from '@/components/playback'
@@ -33,13 +34,15 @@ export default function FallingNotesPlayer({
     tempoScale,
     lookAheadSec,
     volume,
+    trebleRolloff,
     totalLength,
     play,
     pause,
     stop,
     seek,
     setTempoScale,
-    setVolume
+    setVolume,
+    setTrebleRolloff
   } = useFallingNotesPlayer(notes)
 
   // Constants
@@ -111,6 +114,31 @@ export default function FallingNotesPlayer({
         />
         <span className="text-xs font-mono text-gray-500 tabular-nums w-10 text-right">
           {volume.toFixed(2)}
+        </span>
+      </div>
+
+      {/* Treble brightness — a tuning control. Higher = darker (partials roll off
+          faster). The readout is TREBLE_ROLLOFF; whatever sounds right is the
+          value to lock in as DEFAULT_TREBLE_ROLLOFF in pianoTimbre. Unlike
+          volume, a change is heard only on notes scheduled after it, since each
+          note's spectrum is fixed when it is created. */}
+      <div className="mb-4 flex items-center gap-3">
+        <label htmlFor="treble-rolloff" className="text-xs text-gray-600 whitespace-nowrap">
+          고음
+        </label>
+        <input
+          id="treble-rolloff"
+          type="range"
+          min={MIN_TREBLE_ROLLOFF}
+          max={MAX_TREBLE_ROLLOFF}
+          step={0.1}
+          value={trebleRolloff}
+          onChange={(e) => setTrebleRolloff(parseFloat(e.target.value))}
+          className="flex-1 max-w-xs"
+          aria-label="고음 밝기 (treble rolloff, 높을수록 어두움)"
+        />
+        <span className="text-xs font-mono text-gray-500 tabular-nums w-10 text-right">
+          {trebleRolloff.toFixed(1)}
         </span>
       </div>
       

--- a/src/components/animation/__tests__/FallingNotesPlayer.test.tsx
+++ b/src/components/animation/__tests__/FallingNotesPlayer.test.tsx
@@ -9,6 +9,7 @@ const mockPlayerState = {
   tempoScale: 1,
   lookAheadSec: 1.5,
   volume: 0.22,
+  trebleRolloff: 3.2,
   totalLength: 3,
   play: jest.fn(),
   pause: jest.fn(),
@@ -16,6 +17,7 @@ const mockPlayerState = {
   seek: jest.fn(),
   setTempoScale: jest.fn(),
   setVolume: jest.fn(),
+  setTrebleRolloff: jest.fn(),
 }
 
 jest.mock('@/hooks/useFallingNotesPlayer', () => ({
@@ -81,5 +83,19 @@ describe('FallingNotesPlayer', () => {
     // the hook, verified separately.
     fireEvent.change(slider, { target: { value: '0.3' } })
     expect(mockPlayerState.setVolume).toHaveBeenCalledWith(0.3)
+  })
+
+  it('shows the current treble rolloff and forwards slider changes to setTrebleRolloff', () => {
+    mockPlayerState.setTrebleRolloff.mockClear()
+    render(<FallingNotesPlayer animationData={animationData} />)
+
+    const slider = screen.getByLabelText(
+      '고음 밝기 (treble rolloff, 높을수록 어두움)'
+    ) as HTMLInputElement
+    expect(slider.value).toBe('3.2')
+    expect(screen.getByText('3.2')).toBeInTheDocument()
+
+    fireEvent.change(slider, { target: { value: '4' } })
+    expect(mockPlayerState.setTrebleRolloff).toHaveBeenCalledWith(4)
   })
 })

--- a/src/hooks/__tests__/useFallingNotesAudio.test.ts
+++ b/src/hooks/__tests__/useFallingNotesAudio.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_MASTER_GAIN,
   MAX_MASTER_GAIN,
 } from '../useFallingNotesAudio'
+import { MIN_TREBLE_ROLLOFF, MAX_TREBLE_ROLLOFF } from '@/utils/pianoTimbre'
 
 type AudioWindow = Window & {
   webkitAudioContext?: typeof AudioContext
@@ -267,6 +268,21 @@ describe('useFallingNotesAudio', () => {
     })
     expect(targets[targets.length - 1]).toBe(0)
     expect(applied).toBe(0)
+
+    unmount()
+  })
+
+  it('clamps the treble rolloff to its range and returns the applied value', () => {
+    setAudioContextConstructor(
+      jest.fn(() => makeAudioContext('running')) as unknown as typeof AudioContext
+    )
+    const { result, unmount } = renderHook(() => useFallingNotesAudio())
+
+    // A value in range passes through; out-of-range clamps to each bound. The
+    // return value is what the UI stores, so it must equal the applied rolloff.
+    expect(result.current.setTrebleRolloff(3)).toBeCloseTo(3)
+    expect(result.current.setTrebleRolloff(99)).toBe(MAX_TREBLE_ROLLOFF)
+    expect(result.current.setTrebleRolloff(0)).toBe(MIN_TREBLE_ROLLOFF)
 
     unmount()
   })

--- a/src/hooks/useFallingNotesAudio.ts
+++ b/src/hooks/useFallingNotesAudio.ts
@@ -18,6 +18,9 @@ import {
   harmonicAmplitudes,
   timbreCutoffHz,
   envelopeBreakpoints,
+  DEFAULT_TREBLE_ROLLOFF,
+  MIN_TREBLE_ROLLOFF,
+  MAX_TREBLE_ROLLOFF,
 } from '@/utils/pianoTimbre'
 
 /**
@@ -68,6 +71,10 @@ export function useFallingNotesAudio() {
   // Current master level, kept in a ref so a runtime change survives the next
   // AudioContext (re)initialisation and is applied the moment the bus exists.
   const masterGainValueRef = useRef(DEFAULT_MASTER_GAIN)
+  // Treble rolloff for new notes. Unlike the master gain this cannot retune
+  // already-scheduled notes: their PeriodicWave is baked at creation, so a
+  // change takes effect from the next note the scheduler builds.
+  const trebleRolloffRef = useRef(DEFAULT_TREBLE_ROLLOFF)
   const scheduledNodesRef = useRef<AudioNodes[]>([])
   const baseAudioTimeRef = useRef<number | null>(null)
   const offsetSecRef = useRef(0)
@@ -147,7 +154,7 @@ export function useFallingNotesAudio() {
 
     // `createPeriodicWave` takes cosine/sine coefficients indexed by harmonic,
     // with index 0 the DC term, which must stay 0 to avoid a constant offset.
-    const amplitudes = harmonicAmplitudes(midi)
+    const amplitudes = harmonicAmplitudes(midi, trebleRolloffRef.current)
     const real = new Float32Array(amplitudes.length + 1)
     const imag = new Float32Array(amplitudes.length + 1)
     for (let n = 0; n < amplitudes.length; n++) {
@@ -464,6 +471,20 @@ export function useFallingNotesAudio() {
   }, [])
 
   /**
+   * Set the treble rolloff for notes scheduled from now on, clamped to a range
+   * that keeps the treble darker than the bass without over-dulling it.
+   *
+   * There is no ramp and no effect on sounding notes: each note's spectrum is
+   * fixed in its PeriodicWave at creation, so this changes only what the
+   * scheduler builds next. Returns the applied value so the UI readout matches.
+   */
+  const setTrebleRolloff = useCallback((value: number): number => {
+    const clamped = Math.min(MAX_TREBLE_ROLLOFF, Math.max(MIN_TREBLE_ROLLOFF, value))
+    trebleRolloffRef.current = clamped
+    return clamped
+  }, [])
+
+  /**
    * Set offset time (for seeking)
    */
   const setOffsetTime = useCallback((time: number) => {
@@ -509,6 +530,7 @@ export function useFallingNotesAudio() {
     updateTempoScale,
     setOffsetTime,
     setVolume,
+    setTrebleRolloff,
     reset,
     getTimingInfo
   }

--- a/src/hooks/useFallingNotesPlayer.ts
+++ b/src/hooks/useFallingNotesPlayer.ts
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import type { FallingNote } from '@/types/fallingNotes'
 import { useFallingNotesAudio, DEFAULT_MASTER_GAIN } from './useFallingNotesAudio'
+import { DEFAULT_TREBLE_ROLLOFF } from '@/utils/pianoTimbre'
 import { calculateSongLength, shouldAutoStop } from '@/utils/visualUtils'
 
 /**
@@ -17,6 +18,7 @@ export function useFallingNotesPlayer(notes: FallingNote[]) {
   const [mute, setMute] = useState(false)
   const [lookAheadSec, setLookAheadSec] = useState(1.5)
   const [volume, setVolumeState] = useState(DEFAULT_MASTER_GAIN)
+  const [trebleRolloff, setTrebleRolloffState] = useState(DEFAULT_TREBLE_ROLLOFF)
 
   // Audio management
   const {
@@ -26,6 +28,7 @@ export function useFallingNotesPlayer(notes: FallingNote[]) {
     updateTempoScale,
     setOffsetTime,
     setVolume,
+    setTrebleRolloff,
     reset,
   } = useFallingNotesAudio()
   
@@ -152,6 +155,16 @@ export function useFallingNotesPlayer(notes: FallingNote[]) {
     setVolumeState(applied)
   }, [setVolume])
 
+  /**
+   * Change treble rolloff live. Like volume, the readout reflects the clamped
+   * value the audio hook applied. Unlike volume, it retunes only notes scheduled
+   * after the change — sounding notes keep their baked spectrum.
+   */
+  const handleTrebleRolloffChange = useCallback((newRolloff: number) => {
+    const applied = setTrebleRolloff(newRolloff)
+    setTrebleRolloffState(applied)
+  }, [setTrebleRolloff])
+
   // Enhanced animation loop with precise audio-visual synchronization
   useEffect(() => {
     if (!isPlaying) {
@@ -195,6 +208,7 @@ export function useFallingNotesPlayer(notes: FallingNote[]) {
     mute,
     lookAheadSec,
     volume,
+    trebleRolloff,
     totalLength,
 
     // Actions
@@ -206,6 +220,7 @@ export function useFallingNotesPlayer(notes: FallingNote[]) {
     setMute: handleMuteChange,
     setLookAheadSec: handleLookAheadChange,
     setVolume: handleVolumeChange,
+    setTrebleRolloff: handleTrebleRolloffChange,
 
     // Combined play/pause toggle
     togglePlayPause: isPlaying ? handlePause : handlePlay

--- a/src/utils/__tests__/pianoTimbre.test.ts
+++ b/src/utils/__tests__/pianoTimbre.test.ts
@@ -90,6 +90,21 @@ describe('harmonicAmplitudes', () => {
     const a0Share = a0[0] / a0.reduce((sum, a) => sum + a, 0)
     expect(a0Share).toBeLessThan(0.4)
   })
+
+  it('darkens the treble as the rolloff argument rises', () => {
+    // The runtime brightness control passes a rolloff here; a larger value must
+    // move more energy into the fundamental (darker), and it must bite harder in
+    // the treble than the bass, since the exponent is scaled by register.
+    const share = (midi: number, rolloff: number) => {
+      const p = harmonicAmplitudes(midi, rolloff)
+      return p[0] / p.reduce((sum, a) => sum + a, 0)
+    }
+
+    expect(share(84, 4.5)).toBeGreaterThan(share(84, 2.0)) // C6 darker at higher rolloff
+    const trebleDelta = share(84, 4.5) - share(84, 2.0)
+    const bassDelta = share(A0_MIDI, 4.5) - share(A0_MIDI, 2.0)
+    expect(trebleDelta).toBeGreaterThan(bassDelta)
+  })
 })
 
 describe('timbreCutoffHz', () => {

--- a/src/utils/pianoTimbre.ts
+++ b/src/utils/pianoTimbre.ts
@@ -57,7 +57,18 @@ const MAX_PARTIALS = 24
 const BASS_ROLLOFF = 1.15
 // Raised from 2.4 after the first deployed version was judged too bright in the
 // treble: a larger exponent drops the upper partials faster, darkening the top.
-const TREBLE_ROLLOFF = 3.2
+// Exported as the default so the playback UI can retune it live and read off the
+// value to lock in here, exactly as the volume control does for the master gain.
+export const DEFAULT_TREBLE_ROLLOFF = 3.2
+
+/**
+ * Bounds the runtime treble control. Below `BASS_ROLLOFF` the treble would roll
+ * off more gently than the bass, inverting the register balance; the upper bound
+ * is where the top octave is already down to its fundamental and darkening
+ * further stops being audible.
+ */
+export const MIN_TREBLE_ROLLOFF = 1.5
+export const MAX_TREBLE_ROLLOFF = 5
 
 /**
  * How much the fundamental is held back in the lowest register.
@@ -84,14 +95,17 @@ function registerPosition(midi: number): number {
  * note ever degenerates back to a bare sine. The result is normalised to sum to
  * 1, which keeps a chord of many voices from clipping the master gain.
  */
-export function harmonicAmplitudes(midi: number): number[] {
+export function harmonicAmplitudes(
+  midi: number,
+  trebleRolloff: number = DEFAULT_TREBLE_ROLLOFF
+): number[] {
   const fundamental = midiToFreq(midi)
   const position = registerPosition(midi)
 
   const affordable = Math.floor(MAX_PARTIAL_HZ / fundamental)
   const count = Math.max(2, Math.min(MAX_PARTIALS, affordable))
 
-  const rolloff = BASS_ROLLOFF + (TREBLE_ROLLOFF - BASS_ROLLOFF) * position
+  const rolloff = BASS_ROLLOFF + (trebleRolloff - BASS_ROLLOFF) * position
 
   const amplitudes: number[] = []
   for (let n = 1; n <= count; n++) {


### PR DESCRIPTION
The volume slider (#32) let `DEFAULT_MASTER_GAIN` be chosen by ear. This does the same for treble brightness, which was only the `TREBLE_ROLLOFF` constant and needed a redeploy to change.

## What changed

- `harmonicAmplitudes(midi, trebleRolloff = DEFAULT_TREBLE_ROLLOFF)` — the rolloff is now an argument; the default preserves current behaviour so the pure function and its tests are unchanged when called bare.
- Audio hook: a `trebleRolloffRef` + `setTrebleRolloff`, clamped to `[MIN_TREBLE_ROLLOFF, MAX_TREBLE_ROLLOFF]` (1.5–5) so the treble stays darker than the bass without going flat. `createNoteAudio` reads it per note.
- A 고음 slider on the playback screen whose readout is the rolloff value — **higher = darker**.

## One honest difference from the volume control

It **cannot retune sounding notes.** Each note's spectrum is baked into its `PeriodicWave` at creation, so a change is heard only from the next scheduled note — during playback, notes already in the look-ahead window finish on the old brightness. Volume, a single downstream gain, changes everything at once. This is stated in the control's comment and reflected in the label.

## Confirm-the-default flow

Deploy → drag the 고음 slider → read the value that sounds right → set `DEFAULT_TREBLE_ROLLOFF` to it. Same as volume.

## Verification

| Check | Result |
|---|---|
| `pianoTimbre` test | a higher rolloff argument raises the fundamental share and bites harder in treble than bass |
| audio-hook test | `setTrebleRolloff` clamps to MIN/MAX and returns the applied value |
| component test | the 고음 slider shows the rolloff and forwards changes |
| `npm test` | 41 suites / **386 tests** pass |
| `npx tsc --noEmit` / lint / build | clean / clean / succeeds |

**Not verified:** unseen in a real browser; the brightness that sounds right is a listening judgement — which is what the control is for.

Related: #32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 낙하 음표 플레이어에 고음 밝기를 조절하는 슬라이더를 추가했습니다.
  * 현재 고음 롤오프 값을 화면에 표시합니다.
  * 설정 범위를 벗어난 값은 허용 범위로 자동 조정됩니다.
  * 변경된 고음 설정은 이후 재생되는 음표부터 적용됩니다.
* **테스트**
  * 슬라이더 값 표시, 변경 처리 및 음색 변화 동작을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->