### PR TITLE
Restore the native Audiveris upload runtime without demo fallback

### DIFF
--- a/omr-service/Dockerfile.audiveris
+++ b/omr-service/Dockerfile.audiveris
@@ -1,11 +1,17 @@
-# Dockerfile using weidi/audiveris-docker approach
 FROM ubuntu:22.04
 
-# Set environment variables
+ARG AUDIVERIS_VERSION=5.11.0
+ARG AUDIVERIS_DEB=Audiveris-5.11.0-ubuntu22.04-x86_64.deb
+ARG AUDIVERIS_SHA256=ae714594f40e54b1a4951fc3f914f08ae38fe5d07b7f2283b1a904fdb6e0a318
+
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
+ENV AUDIVERIS_EXECUTABLE=/opt/audiveris/bin/Audiveris
+ENV AUDIVERIS_MAX_CONCURRENCY=1
+ENV TESSDATA_PREFIX=/usr/share/tesseract-ocr/4.00/tessdata
 
-# Install system dependencies including Python and FastAPI requirements
+# Audiveris's official .deb includes its own jlink JRE. English OCR language
+# data is separate from that runtime and must be installed explicitly.
 RUN apt-get update && apt-get install -y \
     python3 \
     python3-pip \
@@ -15,6 +21,18 @@ RUN apt-get update && apt-get install -y \
     libxml2-dev \
     libxslt1-dev \
     zlib1g-dev \
+    tesseract-ocr-eng \
+    && curl -fsSL \
+      "https://github.com/Audiveris/audiveris/releases/download/${AUDIVERIS_VERSION}/${AUDIVERIS_DEB}" \
+      -o "/tmp/${AUDIVERIS_DEB}" \
+    && echo "${AUDIVERIS_SHA256}  /tmp/${AUDIVERIS_DEB}" | sha256sum -c - \
+    && apt-get install -y "/tmp/${AUDIVERIS_DEB}" \
+    && sed -i \
+      's/java-options=-Xmx8G/java-options=-Xmx3G/' \
+      /opt/audiveris/lib/app/Audiveris.cfg \
+    && test -x /opt/audiveris/bin/Audiveris \
+    && test -x /opt/audiveris/lib/runtime/bin/java \
+    && rm -f "/tmp/${AUDIVERIS_DEB}" \
     && rm -rf /var/lib/apt/lists/*
 
 # Create working directory

--- a/omr-service/Dockerfile.audiveris
+++ b/omr-service/Dockerfile.audiveris
@@ -8,11 +8,12 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV AUDIVERIS_EXECUTABLE=/opt/audiveris/bin/Audiveris
 ENV AUDIVERIS_MAX_CONCURRENCY=1
+ENV AUDIVERIS_TIMEOUT_SECONDS=900
 ENV TESSDATA_PREFIX=/usr/share/tesseract-ocr/4.00/tessdata
 
 # Audiveris's official .deb includes its own jlink JRE. English OCR language
 # data is separate from that runtime and must be installed explicitly.
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
     python3-pip \
     python3-dev \
@@ -26,9 +27,11 @@ RUN apt-get update && apt-get install -y \
       "https://github.com/Audiveris/audiveris/releases/download/${AUDIVERIS_VERSION}/${AUDIVERIS_DEB}" \
       -o "/tmp/${AUDIVERIS_DEB}" \
     && echo "${AUDIVERIS_SHA256}  /tmp/${AUDIVERIS_DEB}" | sha256sum -c - \
-    && apt-get install -y "/tmp/${AUDIVERIS_DEB}" \
+    && apt-get install -y --no-install-recommends "/tmp/${AUDIVERIS_DEB}" \
     && sed -i \
       's/java-options=-Xmx8G/java-options=-Xmx3G/' \
+      /opt/audiveris/lib/app/Audiveris.cfg \
+    && grep -Fqx 'java-options=-Xmx3G' \
       /opt/audiveris/lib/app/Audiveris.cfg \
     && test -x /opt/audiveris/bin/Audiveris \
     && test -x /opt/audiveris/lib/runtime/bin/java \

--- a/omr-service/README.md
+++ b/omr-service/README.md
@@ -24,8 +24,12 @@ Optical Music Recognition service for converting PDF sheet music to ClairKeys an
    ```
 
 3. **Install Audiveris**
-   - Download Audiveris 5.3.1 from GitHub releases
-   - Extract to `/opt/audiveris` or set `AUDIVERIS_HOME` environment variable
+   - Install the official Audiveris 5.11.0 package for your OS.
+   - The Ubuntu package installs its bundled JRE and launcher at
+     `/opt/audiveris/bin/Audiveris`; override that path with
+     `AUDIVERIS_EXECUTABLE` when developing elsewhere.
+   - Install the required Tesseract language data separately. The container
+     supplies English and points `TESSDATA_PREFIX` at its trained-data folder.
 
 4. **Run Development Server**
    ```bash
@@ -35,7 +39,7 @@ Optical Music Recognition service for converting PDF sheet music to ClairKeys an
 ## Docker Build
 
 ```bash
-docker build -t clairkeys-omr .
+docker build -f Dockerfile.audiveris -t clairkeys-omr .
 docker run -p 8000:8000 -e SUPABASE_URL=... -e SUPABASE_ANON_KEY=... clairkeys-omr
 ```
 
@@ -105,14 +109,21 @@ Health check endpoint.
 
 ## Memory Configuration
 
-The service is configured for Fly.io's shared-cpu-1x@512MB specification:
-- Java heap size limited to 400MB
-- Container memory: 512MB
-- Suitable for most sheet music processing tasks
+The current Fly configuration is a provisional safe starting point:
+
+- Audiveris maximum Java heap: 3GB
+- Container memory: 4GB
+- Native Audiveris conversions per service instance: 1
+- Remaining memory is reserved for Python, native OCR libraries, and the OS
+
+These values have not yet been validated with a real container conversion or
+Fly deployment. Measure representative PDFs before reducing the headroom.
 
 ## Error Handling
 
 - Processing failures are tracked in job status
 - Automatic cleanup of temporary files
+- Missing or failed Audiveris execution remains an explicit failed job; it
+  never falls back to demo MusicXML
 - Fallback to local storage if Supabase is unavailable
 - Comprehensive logging for debugging

--- a/omr-service/README.md
+++ b/omr-service/README.md
@@ -114,6 +114,7 @@ The current Fly configuration is a provisional safe starting point:
 - Audiveris maximum Java heap: 3GB
 - Container memory: 4GB
 - Native Audiveris conversions per service instance: 1
+- Audiveris conversion timeout: 15 minutes
 - Remaining memory is reserved for Python, native OCR libraries, and the OS
 
 These values have not yet been validated with a real container conversion or

--- a/omr-service/app.py
+++ b/omr-service/app.py
@@ -20,17 +20,7 @@ from typing import Optional
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-# Try different OMR processors in order of preference
-try:
-    from omr.audiveris_docker import AudiverisDockerProcessor as AudiverisProcessor
-    logger.info("Using Audiveris Docker processor")
-except ImportError:
-    try:
-        from omr.audiveris import AudiverisProcessor
-        logger.info("Using native Audiveris processor")
-    except ImportError:
-        logger.warning("Audiveris not available, using alternative OMR")
-        from omr.audiveris_alt import AlternativeOMRProcessor as AudiverisProcessor
+from omr.audiveris import AudiverisProcessor
 from omr.converter import MusicXMLToClairKeysConverter
 from omr.storage import SupabaseStorage
 

--- a/omr-service/fly.toml
+++ b/omr-service/fly.toml
@@ -40,7 +40,7 @@ kill_timeout = "5s"
   soft_limit = 20
 
 [[vm]]
-  memory = "512mb"
+  memory = "4gb"
   cpu_kind = "shared"
   cpus = 1
 

--- a/omr-service/omr/audiveris.py
+++ b/omr-service/omr/audiveris.py
@@ -4,7 +4,6 @@ Handles PDF to MusicXML conversion using Audiveris
 """
 
 import asyncio
-import subprocess
 import logging
 from pathlib import Path
 from typing import Optional
@@ -15,10 +14,24 @@ logger = logging.getLogger(__name__)
 class AudiverisProcessor:
     """Processes PDF files using Audiveris OMR engine"""
     
-    def __init__(self):
-        self.audiveris_home = os.getenv("AUDIVERIS_HOME", "/opt/audiveris")
-        self.java_home = os.getenv("JAVA_HOME", "/usr/lib/jvm/java-11-openjdk-amd64")
-        
+    def __init__(
+        self,
+        audiveris_executable: Optional[Path] = None,
+        max_concurrent_conversions: Optional[int] = None,
+    ):
+        configured_executable = os.getenv(
+            "AUDIVERIS_EXECUTABLE", "/opt/audiveris/bin/Audiveris"
+        )
+        self.audiveris_executable = Path(
+            audiveris_executable or configured_executable
+        )
+        concurrency = max_concurrent_conversions
+        if concurrency is None:
+            concurrency = int(os.getenv("AUDIVERIS_MAX_CONCURRENCY", "1"))
+        if concurrency < 1:
+            raise ValueError("AUDIVERIS_MAX_CONCURRENCY must be at least 1")
+        self._conversion_slots = asyncio.Semaphore(concurrency)
+
     async def process_pdf(self, pdf_path: Path, output_dir: Path) -> Path:
         """
         Process PDF file with Audiveris to generate MusicXML
@@ -30,30 +43,30 @@ class AudiverisProcessor:
         Returns:
             Path to generated MusicXML file
         """
+        async with self._conversion_slots:
+            return await self._process_pdf_unlocked(pdf_path, output_dir)
+
+    async def _process_pdf_unlocked(
+        self, pdf_path: Path, output_dir: Path
+    ) -> Path:
         try:
             logger.info(f"Starting Audiveris processing for {pdf_path}")
             
-            # Prepare output path
-            musicxml_path = output_dir / "output.xml"
-            
-            # Build Audiveris command
-            # Audiveris CLI: java -jar audiveris.jar -batch -export -output output.xml input.pdf
-            audiveris_jar = Path(self.audiveris_home) / "lib" / "audiveris.jar"
-            
-            if not audiveris_jar.exists():
-                # Try alternative path structure
-                audiveris_jar = Path(self.audiveris_home) / "audiveris.jar"
-            
-            if not audiveris_jar.exists():
-                raise FileNotFoundError(f"Audiveris JAR not found at {audiveris_jar}")
+            if not self.audiveris_executable.is_file() or not os.access(
+                self.audiveris_executable, os.X_OK
+            ):
+                raise FileNotFoundError(
+                    f"Audiveris launcher is not executable: {self.audiveris_executable}"
+                )
+
+            output_dir.mkdir(parents=True, exist_ok=True)
             
             cmd = [
-                "java",
-                "-Xmx400m",  # Limit memory to 400MB (keeping some buffer for 512MB container)
-                "-jar", str(audiveris_jar),
+                str(self.audiveris_executable),
                 "-batch",
                 "-export",
-                "-output", str(musicxml_path),
+                "-output", str(output_dir),
+                "--",
                 str(pdf_path)
             ]
             
@@ -79,16 +92,18 @@ class AudiverisProcessor:
                 logger.error(error_msg)
                 raise RuntimeError(error_msg)
             
-            # Verify output file exists
-            if not musicxml_path.exists():
-                # Sometimes Audiveris creates files with different names
-                # Look for any .xml files in the output directory
-                xml_files = list(output_dir.glob("*.xml"))
-                if xml_files:
-                    musicxml_path = xml_files[0]
-                    logger.info(f"Found MusicXML file: {musicxml_path}")
-                else:
-                    raise FileNotFoundError("No MusicXML output file generated")
+            output_files = sorted(output_dir.glob("*.mxl"))
+            if not output_files:
+                output_files = sorted(output_dir.glob("*.xml"))
+            if not output_files:
+                raise FileNotFoundError("No MusicXML output file generated")
+            if len(output_files) > 1:
+                raise RuntimeError(
+                    "Audiveris generated multiple MusicXML files; "
+                    "multi-output scores are not yet supported"
+                )
+
+            musicxml_path = output_files[0]
             
             logger.info(f"Successfully generated MusicXML: {musicxml_path}")
             return musicxml_path
@@ -105,17 +120,16 @@ class AudiverisProcessor:
             True if Audiveris is available, False otherwise
         """
         try:
-            audiveris_jar = Path(self.audiveris_home) / "lib" / "audiveris.jar"
-            if not audiveris_jar.exists():
-                audiveris_jar = Path(self.audiveris_home) / "audiveris.jar"
-            
-            if not audiveris_jar.exists():
-                logger.error(f"Audiveris JAR not found at {audiveris_jar}")
+            if not self.audiveris_executable.is_file() or not os.access(
+                self.audiveris_executable, os.X_OK
+            ):
+                logger.error(
+                    f"Audiveris launcher is not executable: {self.audiveris_executable}"
+                )
                 return False
             
-            # Test Java availability
             process = await asyncio.create_subprocess_exec(
-                "java", "-version",
+                str(self.audiveris_executable), "-version",
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE
             )
@@ -123,7 +137,7 @@ class AudiverisProcessor:
             stdout, stderr = await process.communicate()
             
             if process.returncode != 0:
-                logger.error("Java not available")
+                logger.error("Audiveris launcher is not available")
                 return False
             
             logger.info("Audiveris installation validated successfully")

--- a/omr-service/omr/audiveris.py
+++ b/omr-service/omr/audiveris.py
@@ -18,6 +18,7 @@ class AudiverisProcessor:
         self,
         audiveris_executable: Optional[Path] = None,
         max_concurrent_conversions: Optional[int] = None,
+        process_timeout_seconds: Optional[float] = None,
     ):
         configured_executable = os.getenv(
             "AUDIVERIS_EXECUTABLE", "/opt/audiveris/bin/Audiveris"
@@ -31,6 +32,43 @@ class AudiverisProcessor:
         if concurrency < 1:
             raise ValueError("AUDIVERIS_MAX_CONCURRENCY must be at least 1")
         self._conversion_slots = asyncio.Semaphore(concurrency)
+        timeout_seconds = process_timeout_seconds
+        if timeout_seconds is None:
+            timeout_seconds = float(
+                os.getenv("AUDIVERIS_TIMEOUT_SECONDS", "900")
+            )
+        if timeout_seconds <= 0:
+            raise ValueError("AUDIVERIS_TIMEOUT_SECONDS must be greater than 0")
+        self.process_timeout_seconds = timeout_seconds
+
+    async def _kill_and_wait(
+        self,
+        process: asyncio.subprocess.Process,
+    ) -> None:
+        try:
+            process.kill()
+        except ProcessLookupError:
+            pass
+        await process.wait()
+
+    async def _communicate_with_timeout(
+        self,
+        process: asyncio.subprocess.Process,
+        timeout_seconds: float,
+    ) -> tuple[bytes, bytes]:
+        try:
+            return await asyncio.wait_for(
+                process.communicate(),
+                timeout=timeout_seconds,
+            )
+        except asyncio.TimeoutError:
+            await self._kill_and_wait(process)
+            raise RuntimeError(
+                f"Audiveris timed out after {timeout_seconds:g} seconds"
+            ) from None
+        except asyncio.CancelledError:
+            await self._kill_and_wait(process)
+            raise
 
     async def process_pdf(self, pdf_path: Path, output_dir: Path) -> Path:
         """
@@ -80,7 +118,10 @@ class AudiverisProcessor:
                 cwd=output_dir
             )
             
-            stdout, stderr = await process.communicate()
+            stdout, stderr = await self._communicate_with_timeout(
+                process,
+                self.process_timeout_seconds,
+            )
             
             # Check if process completed successfully
             if process.returncode != 0:
@@ -134,7 +175,10 @@ class AudiverisProcessor:
                 stderr=asyncio.subprocess.PIPE
             )
             
-            stdout, stderr = await process.communicate()
+            stdout, stderr = await self._communicate_with_timeout(
+                process,
+                min(self.process_timeout_seconds, 30.0),
+            )
             
             if process.returncode != 0:
                 logger.error("Audiveris launcher is not available")

--- a/omr-service/omr/converter.py
+++ b/omr-service/omr/converter.py
@@ -5,10 +5,11 @@ Converts MusicXML files to ClairKeys animation data format
 
 import json
 import logging
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Dict, List, Optional, Any
 import xml.etree.ElementTree as ET
 from datetime import datetime
+import zipfile
 
 logger = logging.getLogger(__name__)
 
@@ -45,8 +46,10 @@ class MusicXMLToClairKeysConverter:
         try:
             logger.info(f"Converting MusicXML to ClairKeys format: {musicxml_path}")
             
-            # Parse MusicXML file
-            tree = ET.parse(musicxml_path)
+            # Audiveris exports compressed MusicXML (.mxl). Resolve its declared
+            # root document without extracting the archive; plain MusicXML remains
+            # supported for the existing converter corpus.
+            tree = self._parse_musicxml(musicxml_path)
             root = tree.getroot()
             
             # Extract basic metadata
@@ -80,6 +83,39 @@ class MusicXMLToClairKeysConverter:
         except Exception as e:
             logger.error(f"Error converting MusicXML: {str(e)}")
             raise
+
+    def _parse_musicxml(self, musicxml_path: Path) -> ET.ElementTree:
+        """Parse plain MusicXML or the root document declared by an MXL container."""
+        if not zipfile.is_zipfile(musicxml_path):
+            return ET.parse(musicxml_path)
+
+        with zipfile.ZipFile(musicxml_path) as archive:
+            try:
+                container = ET.fromstring(archive.read("META-INF/container.xml"))
+            except KeyError as exc:
+                raise ValueError("MXL archive has no META-INF/container.xml") from exc
+
+            rootfile = container.find(
+                ".//{urn:oasis:names:tc:opendocument:xmlns:container}rootfile"
+            )
+            if rootfile is None:
+                rootfile = container.find(".//rootfile")
+
+            root_path = rootfile.get("full-path") if rootfile is not None else None
+            if not root_path:
+                raise ValueError("MXL container does not declare a root MusicXML file")
+
+            archive_path = PurePosixPath(root_path)
+            if archive_path.is_absolute() or ".." in archive_path.parts:
+                raise ValueError(f"Unsafe MXL root path: {root_path}")
+
+            try:
+                with archive.open(root_path) as musicxml:
+                    return ET.parse(musicxml)
+            except KeyError as exc:
+                raise ValueError(
+                    f"MXL root MusicXML file is missing: {root_path}"
+                ) from exc
     
     def _extract_metadata(self, root: ET.Element, title: Optional[str], composer: Optional[str]) -> Dict[str, Any]:
         """Extract metadata from MusicXML"""

--- a/omr-service/tests/test_audiveris_runtime.py
+++ b/omr-service/tests/test_audiveris_runtime.py
@@ -19,6 +19,27 @@ class SuccessfulProcess:
         return b"", b""
 
 
+class HangingProcess:
+    returncode = None
+
+    def __init__(self):
+        self.killed = False
+        self.waited = False
+        self.communicate_started = asyncio.Event()
+
+    async def communicate(self):
+        self.communicate_started.set()
+        await asyncio.Future()
+
+    def kill(self):
+        self.killed = True
+        self.returncode = -9
+
+    async def wait(self):
+        self.waited = True
+        return self.returncode
+
+
 class AudiverisProcessorTests(unittest.TestCase):
     def test_native_launcher_receives_output_folder_and_returns_mxl(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -121,6 +142,91 @@ class AudiverisProcessorTests(unittest.TestCase):
                 ):
                     asyncio.run(processor.process_pdf(pdf_path, output_dir))
 
+    def test_timed_out_conversion_kills_process_and_releases_slot(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temp_dir = Path(temporary_directory)
+            executable = temp_dir / "Audiveris"
+            executable.touch(mode=0o755)
+            os.chmod(executable, 0o755)
+            pdf_path = temp_dir / "input.pdf"
+            pdf_path.write_bytes(b"%PDF-1.4")
+            output_dir = temp_dir / "output"
+            retry_output_dir = temp_dir / "retry-output"
+            retry_output_dir.mkdir()
+            retry_mxl_path = retry_output_dir / "input.mxl"
+            retry_mxl_path.write_bytes(b"PK")
+            hanging_process = HangingProcess()
+            processor = AudiverisProcessor(
+                audiveris_executable=executable,
+                process_timeout_seconds=0.01,
+            )
+
+            with patch(
+                "omr.audiveris.asyncio.create_subprocess_exec",
+                new=AsyncMock(
+                    side_effect=[hanging_process, SuccessfulProcess()]
+                ),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "timed out after"):
+                    asyncio.run(processor.process_pdf(pdf_path, output_dir))
+                retry_result = asyncio.run(
+                    processor.process_pdf(pdf_path, retry_output_dir)
+                )
+
+            self.assertTrue(hanging_process.killed)
+            self.assertTrue(hanging_process.waited)
+            self.assertEqual(retry_result, retry_mxl_path)
+
+    def test_timed_out_installation_validation_kills_process(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            executable = Path(temporary_directory) / "Audiveris"
+            executable.touch(mode=0o755)
+            os.chmod(executable, 0o755)
+            hanging_process = HangingProcess()
+            processor = AudiverisProcessor(
+                audiveris_executable=executable,
+                process_timeout_seconds=0.01,
+            )
+
+            with patch(
+                "omr.audiveris.asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=hanging_process),
+            ):
+                result = asyncio.run(processor.validate_audiveris_installation())
+
+            self.assertFalse(result)
+            self.assertTrue(hanging_process.killed)
+            self.assertTrue(hanging_process.waited)
+
+    def test_cancelled_conversion_kills_process_before_releasing_slot(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temp_dir = Path(temporary_directory)
+            executable = temp_dir / "Audiveris"
+            executable.touch(mode=0o755)
+            os.chmod(executable, 0o755)
+            pdf_path = temp_dir / "input.pdf"
+            pdf_path.write_bytes(b"%PDF-1.4")
+            hanging_process = HangingProcess()
+            processor = AudiverisProcessor(audiveris_executable=executable)
+
+            async def run_and_cancel():
+                task = asyncio.create_task(
+                    processor.process_pdf(pdf_path, temp_dir / "output")
+                )
+                await hanging_process.communicate_started.wait()
+                task.cancel()
+                with self.assertRaises(asyncio.CancelledError):
+                    await task
+
+            with patch(
+                "omr.audiveris.asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=hanging_process),
+            ):
+                asyncio.run(run_and_cancel())
+
+            self.assertTrue(hanging_process.killed)
+            self.assertTrue(hanging_process.waited)
+
 
 class DeploymentStaticContractTests(unittest.TestCase):
     def test_app_uses_only_the_native_audiveris_processor(self):
@@ -147,6 +253,9 @@ class DeploymentStaticContractTests(unittest.TestCase):
         self.assertIn("TESSDATA_PREFIX=/usr/share/tesseract-ocr/4.00/tessdata", dockerfile)
         self.assertIn("/opt/audiveris/bin/Audiveris", dockerfile)
         self.assertIn("AUDIVERIS_MAX_CONCURRENCY=1", dockerfile)
+        self.assertIn("AUDIVERIS_TIMEOUT_SECONDS=900", dockerfile)
+        self.assertIn("grep -Fqx 'java-options=-Xmx3G'", dockerfile)
+        self.assertGreaterEqual(dockerfile.count("--no-install-recommends"), 2)
         self.assertNotIn("openjdk", dockerfile.lower())
 
     def test_fly_memory_and_bundled_launcher_heap_leave_headroom(self):

--- a/omr-service/tests/test_audiveris_runtime.py
+++ b/omr-service/tests/test_audiveris_runtime.py
@@ -1,0 +1,161 @@
+import ast
+import asyncio
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+from omr.audiveris import AudiverisProcessor
+
+
+OMR_SERVICE_ROOT = Path(__file__).resolve().parents[1]
+
+
+class SuccessfulProcess:
+    returncode = 0
+
+    async def communicate(self):
+        return b"", b""
+
+
+class AudiverisProcessorTests(unittest.TestCase):
+    def test_native_launcher_receives_output_folder_and_returns_mxl(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temp_dir = Path(temporary_directory)
+            executable = temp_dir / "Audiveris"
+            executable.touch(mode=0o755)
+            os.chmod(executable, 0o755)
+            pdf_path = temp_dir / "input.pdf"
+            pdf_path.write_bytes(b"%PDF-1.4")
+            output_dir = temp_dir / "output"
+            output_dir.mkdir()
+            mxl_path = output_dir / "input.mxl"
+            mxl_path.write_bytes(b"PK")
+
+            processor = AudiverisProcessor(audiveris_executable=executable)
+
+            with patch(
+                "omr.audiveris.asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=SuccessfulProcess()),
+            ) as create_process:
+                result = asyncio.run(processor.process_pdf(pdf_path, output_dir))
+
+            self.assertEqual(result, mxl_path)
+            create_process.assert_awaited_once_with(
+                str(executable),
+                "-batch",
+                "-export",
+                "-output",
+                str(output_dir),
+                "--",
+                str(pdf_path),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=output_dir,
+            )
+
+    def test_concurrent_conversions_are_serialized_to_one_jvm(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temp_dir = Path(temporary_directory)
+            executable = temp_dir / "Audiveris"
+            executable.touch(mode=0o755)
+            os.chmod(executable, 0o755)
+            processor = AudiverisProcessor(
+                audiveris_executable=executable,
+                max_concurrent_conversions=1,
+            )
+            active_conversions = 0
+            maximum_active_conversions = 0
+
+            async def fake_process(pdf_path, output_dir):
+                nonlocal active_conversions, maximum_active_conversions
+                active_conversions += 1
+                maximum_active_conversions = max(
+                    maximum_active_conversions, active_conversions
+                )
+                await asyncio.sleep(0.01)
+                active_conversions -= 1
+                return output_dir / f"{pdf_path.stem}.mxl"
+
+            async def run_concurrently():
+                with patch.object(
+                    processor,
+                    "_process_pdf_unlocked",
+                    side_effect=fake_process,
+                ):
+                    await asyncio.gather(
+                        processor.process_pdf(
+                            temp_dir / "first.pdf", temp_dir / "first-output"
+                        ),
+                        processor.process_pdf(
+                            temp_dir / "second.pdf", temp_dir / "second-output"
+                        ),
+                    )
+
+            asyncio.run(run_concurrently())
+
+            self.assertEqual(maximum_active_conversions, 1)
+
+    def test_multiple_mxl_outputs_fail_instead_of_returning_partial_score(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temp_dir = Path(temporary_directory)
+            executable = temp_dir / "Audiveris"
+            executable.touch(mode=0o755)
+            os.chmod(executable, 0o755)
+            pdf_path = temp_dir / "input.pdf"
+            pdf_path.write_bytes(b"%PDF-1.4")
+            output_dir = temp_dir / "output"
+            output_dir.mkdir()
+            (output_dir / "movement-1.mxl").write_bytes(b"PK")
+            (output_dir / "movement-2.mxl").write_bytes(b"PK")
+
+            processor = AudiverisProcessor(audiveris_executable=executable)
+
+            with patch(
+                "omr.audiveris.asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=SuccessfulProcess()),
+            ):
+                with self.assertRaisesRegex(
+                    RuntimeError, "generated multiple MusicXML files"
+                ):
+                    asyncio.run(processor.process_pdf(pdf_path, output_dir))
+
+
+class DeploymentStaticContractTests(unittest.TestCase):
+    def test_app_uses_only_the_native_audiveris_processor(self):
+        tree = ast.parse((OMR_SERVICE_ROOT / "app.py").read_text(encoding="utf-8"))
+        imported_modules = {
+            node.module
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom) and node.module is not None
+        }
+
+        self.assertIn("omr.audiveris", imported_modules)
+        self.assertNotIn("omr.audiveris_docker", imported_modules)
+        self.assertNotIn("omr.audiveris_alt", imported_modules)
+
+    def test_container_installs_the_verified_release_and_ocr_language_data(self):
+        dockerfile = (OMR_SERVICE_ROOT / "Dockerfile.audiveris").read_text(encoding="utf-8")
+
+        self.assertIn("Audiveris-5.11.0-ubuntu22.04-x86_64.deb", dockerfile)
+        self.assertIn(
+            "ae714594f40e54b1a4951fc3f914f08ae38fe5d07b7f2283b1a904fdb6e0a318",
+            dockerfile,
+        )
+        self.assertIn("tesseract-ocr-eng", dockerfile)
+        self.assertIn("TESSDATA_PREFIX=/usr/share/tesseract-ocr/4.00/tessdata", dockerfile)
+        self.assertIn("/opt/audiveris/bin/Audiveris", dockerfile)
+        self.assertIn("AUDIVERIS_MAX_CONCURRENCY=1", dockerfile)
+        self.assertNotIn("openjdk", dockerfile.lower())
+
+    def test_fly_memory_and_bundled_launcher_heap_leave_headroom(self):
+        dockerfile = (OMR_SERVICE_ROOT / "Dockerfile.audiveris").read_text(encoding="utf-8")
+        fly_configuration = (OMR_SERVICE_ROOT / "fly.toml").read_text(encoding="utf-8")
+
+        self.assertIn("java-options=-Xmx3G", dockerfile)
+        self.assertIn('memory = "4gb"', fly_configuration)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/utils/__tests__/converterCorpus.test.ts
+++ b/src/utils/__tests__/converterCorpus.test.ts
@@ -16,6 +16,7 @@
 
 import { execFileSync } from 'child_process'
 import fs from 'fs'
+import os from 'os'
 import path from 'path'
 import { normalizeAnimationData } from '../animationContract'
 import { compareAnimationData, formatComparison, DEFAULT_TOLERANCE } from '../animationCompare'
@@ -41,6 +42,10 @@ function loadExpected(dir: string): CanonicalAnimationData {
 
 function runConverter(dir: string): CanonicalAnimationData {
   const input = path.join(FIXTURES_DIR, dir, 'input.musicxml')
+  return runConverterInput(input)
+}
+
+function runConverterInput(input: string): CanonicalAnimationData {
   const stdout = execFileSync(PYTHON, ['-m', 'omr.cli', input], {
     cwd: OMR_DIR,
     encoding: 'utf-8',
@@ -65,4 +70,39 @@ describe('converter corpus accuracy (P0-B)', () => {
       expect(result.match).toBe(true)
     })
   }
+
+  it('accepts an Audiveris-style .mxl container through the converter CLI', () => {
+    const fixtureDir = path.join(FIXTURES_DIR, '01-monophonic')
+    const input = path.join(fixtureDir, 'input.musicxml')
+    const expected = loadExpected('01-monophonic')
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'clairkeys-mxl-'))
+    const mxlPath = path.join(tempDir, 'audiveris-output.mxl')
+    const buildMxl = [
+      'import pathlib, sys, zipfile',
+      'source = pathlib.Path(sys.argv[1])',
+      'target = pathlib.Path(sys.argv[2])',
+      'container = """<?xml version="1.0" encoding="UTF-8"?>',
+      '<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">',
+      '  <rootfiles><rootfile full-path="score/score.musicxml" media-type="application/vnd.recordare.musicxml+xml"/></rootfiles>',
+      '</container>"""',
+      'with zipfile.ZipFile(target, "w") as archive:',
+      '    archive.writestr("META-INF/container.xml", container)',
+      '    archive.write(source, "score/score.musicxml")',
+    ].join('\n')
+
+    try {
+      execFileSync(PYTHON, ['-c', buildMxl, input, mxlPath], {
+        cwd: OMR_DIR,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+      const actual = runConverterInput(mxlPath)
+      const result = compareAnimationData(actual, expected, DEFAULT_TOLERANCE)
+      if (!result.match) {
+        throw new Error(formatComparison(result))
+      }
+      expect(result.match).toBe(true)
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
 })

--- a/src/utils/__tests__/omrRuntimeContract.test.ts
+++ b/src/utils/__tests__/omrRuntimeContract.test.ts
@@ -1,0 +1,23 @@
+import { execFileSync } from 'child_process'
+import path from 'path'
+
+const OMR_DIR = path.join(process.cwd(), 'omr-service')
+const PYTHON = process.env.PYTHON_BIN || 'python3'
+
+describe('OMR processor behavior and deployment static contracts (issue #22)', () => {
+  it('passes the Python behavior and static configuration suite', () => {
+    expect(() =>
+      execFileSync(
+        PYTHON,
+        ['-m', 'unittest', 'discover', '-s', 'tests', '-p', 'test_audiveris_runtime.py'],
+        {
+          cwd: OMR_DIR,
+          encoding: 'utf-8',
+          stdio: ['ignore', 'pipe', 'pipe'],
+          timeout: 30_000,
+          maxBuffer: 4 * 1024 * 1024,
+        }
+      )
+    ).not.toThrow()
+  })
+})


### PR DESCRIPTION
## Purpose

Issue #22 blocks the canonical upload path after P1-A correctly removed the demo concealment. This PR aligns the service with the real Audiveris 5.11.0 package and its `.mxl` output without reintroducing D-001 fallback behavior.

## Scope

- accept compressed MusicXML through `META-INF/container.xml`
- invoke the official `/opt/audiveris/bin/Audiveris` launcher with `-output` as a folder
- select only the native processor; no Docker-in-Docker or demo import fallback
- install the checksum-pinned Ubuntu 22.04 `.deb`, its separate English traineddata, and use the bundled JRE
- set a provisional 4GB Fly VM / 3GB heap and serialize native conversions to one JVM
- fail explicitly when Audiveris emits multiple `.mxl` files instead of storing a partial score

## Out of scope / unverified

- no Docker image build or launcher smoke: the local Docker daemon is stopped
- no real PDF conversion
- no Fly deployment/config validation: no Fly access token is available
- no change to D-008 hosting choice
- no restoration of any demo success path

## Risk

- 4GB / 3GB is a conservative starting point, not a measured production optimum
- multi-output books fail honestly until deliberate merge/multi-result support exists
- OCR language provisioning currently covers English only

## Verification

- `npm test -- --runInBand` — 42 suites / 389 tests
- `python3 -m unittest discover -s tests -p test_audiveris_runtime.py` — 6 tests
- `npx tsc --noEmit` — pass
- `npm run lint` — pass
- `npm run build` — pass (build itself skips lint/types; both were run separately)
- independent code review — initial 3 findings fixed; final 0 blockers
- official asset SHA-256 verified: `ae714594f40e54b1a4951fc3f914f08ae38fe5d07b7f2283b1a904fdb6e0a318`

Baseline difference: PR #35 recorded 41 suites / 387 tests; this adds one Jest suite and two Jest-visible regression cases, plus six Python subtests.

## Rollback

Revert commits `8f21c2b` and `49f78b6`. Upload will return to the known explicit failure state; it must not be redirected to demo generation.

Related: #22, D-001, D-008

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - Audiveris 기반 악보 인식 처리가 안정화되어 PDF를 MusicXML로 변환하는 신뢰성이 향상되었습니다.
  - 압축 MusicXML(`.mxl`)과 일반 MusicXML 파일을 모두 지원합니다.
  - 여러 결과가 생성되거나 변환 결과가 누락된 경우 부분 결과 대신 명확한 오류로 처리합니다.
  - 변환 작업을 안전하게 순차 처리해 서버 과부하와 처리 충돌을 줄였습니다.
  - 배포 환경의 메모리 설정과 Audiveris 실행 검증이 강화되었습니다.

- **문서**
  - 설치, 실행 및 장애 처리 관련 안내를 최신 환경에 맞게 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->