### PR TITLE
Make the OMR image able to install and start Audiveris at all

### DIFF
--- a/omr-service/Dockerfile.audiveris
+++ b/omr-service/Dockerfile.audiveris
@@ -13,6 +13,18 @@ ENV TESSDATA_PREFIX=/usr/share/tesseract-ocr/4.00/tessdata
 
 # Audiveris's official .deb includes its own jlink JRE. English OCR language
 # data is separate from that runtime and must be installed explicitly.
+#
+# Three needs of the .deb are not expressed by its own metadata:
+#   - Its postinst runs xdg-desktop-menu/xdg-mime. Those exit 3 unless a system
+#     menu directory exists and desktop-file-utils/shared-mime-info supply the
+#     tools they shell out to, which fails `dpkg --configure` for the whole
+#     package even though the payload unpacks correctly.
+#   - libgtk-3-0 is absent from its Depends, but WellKnowns' static initialiser
+#     loads gtk-3 through JNA to read the HiDPI scale before any argument is
+#     parsed. Without it every invocation dies with UnsatisfiedLinkError, -batch
+#     included.
+# The desktop entries themselves are useless in a headless service; they are
+# provisioned only so the package configures cleanly.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
     python3-pip \
@@ -23,6 +35,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxslt1-dev \
     zlib1g-dev \
     tesseract-ocr-eng \
+    desktop-file-utils \
+    shared-mime-info \
+    libgtk-3-0 \
+    && mkdir -p /usr/share/applications /usr/share/desktop-directories \
     && curl -fsSL \
       "https://github.com/Audiveris/audiveris/releases/download/${AUDIVERIS_VERSION}/${AUDIVERIS_DEB}" \
       -o "/tmp/${AUDIVERIS_DEB}" \
@@ -35,6 +51,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       /opt/audiveris/lib/app/Audiveris.cfg \
     && test -x /opt/audiveris/bin/Audiveris \
     && test -x /opt/audiveris/lib/runtime/bin/java \
+    && /opt/audiveris/bin/Audiveris -version \
     && rm -f "/tmp/${AUDIVERIS_DEB}" \
     && rm -rf /var/lib/apt/lists/*
 

--- a/omr-service/tests/test_audiveris_runtime.py
+++ b/omr-service/tests/test_audiveris_runtime.py
@@ -258,6 +258,34 @@ class DeploymentStaticContractTests(unittest.TestCase):
         self.assertGreaterEqual(dockerfile.count("--no-install-recommends"), 2)
         self.assertNotIn("openjdk", dockerfile.lower())
 
+    def test_container_supplies_the_needs_the_deb_does_not_declare(self):
+        """The 5.11.0 .deb fails to install and then fails to run without these.
+
+        Both were found by building the image for the first time on
+        2026-08-21; neither is visible from the package metadata. The postinst
+        shells out to xdg-desktop-menu/xdg-mime, which exit 3 in a minimal
+        image and take `dpkg --configure` down with them. Separately, gtk-3 is
+        loaded through JNA by WellKnowns' static initialiser, so a launcher
+        that installed cleanly still died before parsing its own arguments.
+        """
+        dockerfile = (OMR_SERVICE_ROOT / "Dockerfile.audiveris").read_text(encoding="utf-8")
+
+        self.assertIn("desktop-file-utils", dockerfile)
+        self.assertIn("shared-mime-info", dockerfile)
+        self.assertIn("/usr/share/applications", dockerfile)
+        self.assertIn("libgtk-3-0", dockerfile)
+
+    def test_build_proves_the_launcher_starts_not_merely_that_it_exists(self):
+        """`test -x` passed on an image whose launcher could not run at all.
+
+        The build must invoke the launcher so that a missing runtime
+        dependency fails the build instead of surfacing as a failed
+        conversion in production.
+        """
+        dockerfile = (OMR_SERVICE_ROOT / "Dockerfile.audiveris").read_text(encoding="utf-8")
+
+        self.assertIn("/opt/audiveris/bin/Audiveris -version", dockerfile)
+
     def test_fly_memory_and_bundled_launcher_heap_leave_headroom(self):
         dockerfile = (OMR_SERVICE_ROOT / "Dockerfile.audiveris").read_text(encoding="utf-8")
         fly_configuration = (OMR_SERVICE_ROOT / "fly.toml").read_text(encoding="utf-8")


### PR DESCRIPTION
## Why

Building `omr-service/Dockerfile.audiveris` for the first time — on the NAVER Cloud Rocky 8.8 VM — failed. Fixing the build then exposed a second, worse defect. Both are needs of the official Audiveris 5.11.0 `.deb` that its own metadata does not express, and neither was visible to any static check in this repository.

## The two defects

**1. postinst fails `dpkg --configure` (build stops)**

The package's postinst is only `xdg-desktop-menu install` + `xdg-mime install`. `xdg-utils` *is* a declared dependency and is present, but in a minimal image there is no writable system menu directory and none of the tools those wrappers shell out to, so they exit 3 and take the whole package configuration down. Measured:

| Candidate | apt exit | `dpkg -l` |
|---|---|---|
| menu directories only | 100 | `iF` |
| `desktop-file-utils` + `shared-mime-info` only | 100 | `iF` |
| **both** | **0** | **`ii`** |
| `/bin/true` shim in `/usr/local/bin` | 100 | `iF` |

The shim fails because dpkg runs maintainer scripts with `PATH=/usr/sbin:/usr/bin:/sbin:/bin`.

**2. Undeclared `libgtk-3` dependency (every run dies)**

```
UnsatisfiedLinkError: Unable to load library 'gtk-3'
  at org.audiveris.omr.WellKnowns.getGdkMaxScale(WellKnowns.java:310)
  at org.audiveris.omr.WellKnowns.<clinit>(WellKnowns.java:211)
  at org.audiveris.omr.Main.<clinit>(Main.java:70)
```

`libgtk-3-0` is absent from the `.deb`'s `Depends`. The load happens in a static initialiser reached from `Main`'s own static initialiser, so it runs before argument parsing and `-batch` does not avoid it.

In both failure modes the payload still unpacks and `test -x` on the launcher and the bundled `java` both pass. **An image built from the previous Dockerfile would have failed every conversion in production while passing every check here.**

## What changed

- Install `desktop-file-utils`, `shared-mime-info`, `libgtk-3-0`; create the menu directories before installing the `.deb`.
- The build now runs `/opt/audiveris/bin/Audiveris -version`, so a missing runtime dependency fails the build instead of a user's upload.
- Two regression tests pinning both, which fail against the previous Dockerfile.

## Verification

Full record: `docs/recovery/validation/2026-08-21-issue-22-naver-vm-omr-runtime-proof.md` (already on `main` at `ebcd3d1`).

- Image builds and tags `clairkeys-omr:5.11.0` (911 MB) on the VM; in-build `-version` reports Audiveris 5.11.0 / OpenJDK 25.0.3 / Tesseract 5.5.2.
- PR #36's pinned SHA-256 verified `OK` — that part was correct.
- A real Mutopia PDF (Bach WTK1 Prelude 1, 2 pages) converted to `.mxl`, then through `omr.cli` to 514 notes of animation JSON.
- 11 Python tests pass.

## Not verified

Recognition accuracy (the test PDF has no ground truth in `fixtures/`, so `compareAnimationData` cannot score it), the FastAPI service itself, Supabase upload, and every Next.js end-to-end path. **Issue #22 should not be closed on this PR alone.**