### PR TITLE
Stop the OMR service reporting success for work it did not do

### DIFF
--- a/omr-service/app.py
+++ b/omr-service/app.py
@@ -5,7 +5,7 @@ FastAPI server for processing PDF sheet music to ClairKeys animation data
 
 import os
 import uvicorn
-from fastapi import FastAPI, File, UploadFile, HTTPException, BackgroundTasks
+from fastapi import FastAPI, File, Form, UploadFile, HTTPException, BackgroundTasks
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 import aiofiles
@@ -72,12 +72,18 @@ async def root():
 async def process_pdf(
     background_tasks: BackgroundTasks,
     file: UploadFile = File(...),
-    title: Optional[str] = None,
-    composer: Optional[str] = None,
-    user_id: Optional[str] = None
+    title: Optional[str] = Form(None),
+    composer: Optional[str] = Form(None),
+    user_id: Optional[str] = Form(None),
+    sheet_music_id: Optional[str] = Form(None),
 ):
     """
     Process PDF sheet music to ClairKeys animation data
+
+    Every field below `file` must be declared with `Form(...)`. FastAPI binds a
+    plain scalar parameter to the query string, and `/api/omr/upload` sends
+    these as multipart form fields, so without it they arrive as None and a
+    score is stored under its PDF filename.
     """
     # Validate file type
     if not file.filename.lower().endswith('.pdf'):
@@ -96,7 +102,8 @@ async def process_pdf(
             "filename": file.filename,
             "title": title,
             "composer": composer,
-            "user_id": user_id
+            "user_id": user_id,
+            "sheet_music_id": sheet_music_id
         }
     }
     

--- a/omr-service/omr/storage.py
+++ b/omr-service/omr/storage.py
@@ -13,6 +13,28 @@ import uuid
 
 logger = logging.getLogger(__name__)
 
+
+class StorageUploadError(RuntimeError):
+    """Animation data could not be stored anywhere a client can read it."""
+
+
+def assert_local_fallback_allowed() -> None:
+    """Refuse the local-file fallback outside development.
+
+    Writing the result inside the container and returning a `file://` URL is
+    useful when developing without Supabase. In production it produces a job
+    that reports success and an animation URL no browser can fetch, which is
+    the concealment D-001 and D-010 were written against. An unset ENVIRONMENT
+    is treated as production so this fails closed.
+    """
+    if os.getenv("ENVIRONMENT", "production").strip().lower() == "production":
+        raise StorageUploadError(
+            "Supabase Storage is not configured and the local fallback is "
+            "disabled in production. The job must fail rather than report "
+            "success with an unreachable file:// URL."
+        )
+
+
 class SupabaseStorage:
     """Handles uploading animation data to Supabase Storage"""
     
@@ -45,7 +67,7 @@ class SupabaseStorage:
         """
         try:
             if not self.supabase_url or not self.supabase_key:
-                # Fallback: save to local file for testing
+                assert_local_fallback_allowed()
                 return await self._save_local_fallback(job_id, animation_data, title)
             
             # Generate unique filename
@@ -73,9 +95,10 @@ class SupabaseStorage:
                 )
                 
                 if response.status_code not in [200, 201]:
-                    logger.error(f"Failed to upload to Supabase: {response.status_code} - {response.text}")
-                    # Fallback to local storage
-                    return await self._save_local_fallback(job_id, animation_data, title)
+                    raise StorageUploadError(
+                        "Supabase Storage rejected the upload: "
+                        f"{response.status_code} - {response.text}"
+                    )
             
             # Generate public URL
             public_url = f"{self.supabase_url}/storage/v1/object/public/{self.bucket_name}/{filename}"
@@ -83,10 +106,14 @@ class SupabaseStorage:
             logger.info(f"Successfully uploaded animation data: {public_url}")
             return public_url
             
+        except StorageUploadError:
+            raise
         except Exception as e:
-            logger.error(f"Error uploading to Supabase Storage: {str(e)}")
-            # Fallback to local storage
-            return await self._save_local_fallback(job_id, animation_data, title)
+            # A deleted, paused, or unreachable project must fail the job. Writing
+            # a local file here is what let a dead backend look like a success.
+            raise StorageUploadError(
+                f"Supabase Storage upload failed: {e}"
+            ) from e
     
     async def _save_local_fallback(self, job_id: str, animation_data: Dict[str, Any], title: str) -> str:
         """

--- a/omr-service/tests/test_service_contract.py
+++ b/omr-service/tests/test_service_contract.py
@@ -1,0 +1,186 @@
+"""Contract tests for the OMR service's HTTP surface and storage behaviour.
+
+Both defects covered here were found by running the service against a real PDF
+on 2026-08-21 and are recorded in
+`docs/recovery/validation/2026-08-21-omr-service-first-run-defects.md`. Each
+test fails against the code as it stood before that date.
+
+`app.py` cannot be imported here — fastapi and aiofiles are not installed in
+this environment — so its request contract is asserted from its AST, the same
+way `test_audiveris_runtime.py` asserts the Dockerfile's contract from its
+text. `storage.py` imports only stdlib plus httpx, so it is exercised for real.
+"""
+
+import ast
+import asyncio
+import unittest
+from pathlib import Path
+from unittest import mock
+
+OMR_SERVICE_ROOT = Path(__file__).resolve().parents[1]
+
+import sys
+
+if str(OMR_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(OMR_SERVICE_ROOT))
+
+from omr.storage import StorageUploadError, SupabaseStorage, assert_local_fallback_allowed
+
+
+def _process_pdf_signature() -> ast.arguments:
+    tree = ast.parse((OMR_SERVICE_ROOT / "app.py").read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "process_pdf":
+            return node.args
+    raise AssertionError("process_pdf is not defined in app.py")
+
+
+def _default_call_name(default: ast.expr) -> str:
+    if isinstance(default, ast.Call):
+        func = default.func
+        if isinstance(func, ast.Name):
+            return func.id
+        if isinstance(func, ast.Attribute):
+            return func.attr
+    return ""
+
+
+class ProcessEndpointContractTests(unittest.TestCase):
+    """`/process` must read the fields the Next.js route actually sends."""
+
+    def _defaults_by_argument(self) -> dict:
+        args = _process_pdf_signature()
+        positional = args.args + args.kwonlyargs
+        defaults = list(args.defaults) + [d for d in args.kw_defaults if d is not None]
+        # Defaults align to the tail of the positional list.
+        tail = positional[len(positional) - len(defaults):]
+        return {arg.arg: default for arg, default in zip(tail, defaults)}
+
+    def test_metadata_fields_are_declared_as_form_fields(self):
+        """Without `Form(...)` FastAPI binds these as query parameters.
+
+        `src/app/api/omr/upload/route.ts` sends them as multipart form fields,
+        so every one was silently dropped and a score was stored under its PDF
+        filename instead of the title the user typed.
+        """
+        defaults = self._defaults_by_argument()
+
+        for field in ("title", "composer", "user_id"):
+            with self.subTest(field=field):
+                self.assertIn(field, defaults, f"{field} is not a declared parameter")
+                self.assertEqual(
+                    _default_call_name(defaults[field]),
+                    "Form",
+                    f"{field} must be declared with Form(...) or FastAPI reads it from the query string",
+                )
+
+    def test_sheet_music_id_is_accepted(self):
+        """`route.ts` sends `sheet_music_id`; app.py never declared it."""
+        defaults = self._defaults_by_argument()
+
+        self.assertIn("sheet_music_id", defaults)
+        self.assertEqual(_default_call_name(defaults["sheet_music_id"]), "Form")
+
+
+class LocalFallbackGuardTests(unittest.TestCase):
+    def test_fallback_is_refused_in_production(self):
+        with mock.patch.dict("os.environ", {"ENVIRONMENT": "production"}, clear=False):
+            with self.assertRaises(StorageUploadError):
+                assert_local_fallback_allowed()
+
+    def test_fallback_is_refused_when_environment_is_unset(self):
+        """An unset ENVIRONMENT must fail closed, not open."""
+        environ = {k: v for k, v in __import__("os").environ.items() if k != "ENVIRONMENT"}
+        with mock.patch.dict("os.environ", environ, clear=True):
+            with self.assertRaises(StorageUploadError):
+                assert_local_fallback_allowed()
+
+    def test_fallback_is_permitted_in_development(self):
+        with mock.patch.dict("os.environ", {"ENVIRONMENT": "development"}, clear=False):
+            assert_local_fallback_allowed()
+
+
+class StorageUploadHonestyTests(unittest.TestCase):
+    """A job must not report success when nothing was uploaded."""
+
+    def _upload(self, storage: SupabaseStorage):
+        return asyncio.run(
+            storage.upload_animation_data("job-1", {"notes": []}, "Title", "user-1")
+        )
+
+    def test_missing_credentials_fail_in_production(self):
+        with mock.patch.dict(
+            "os.environ",
+            {"ENVIRONMENT": "production", "SUPABASE_URL": "", "SUPABASE_ANON_KEY": ""},
+            clear=False,
+        ):
+            storage = SupabaseStorage()
+            with self.assertRaises(StorageUploadError):
+                self._upload(storage)
+
+    def test_rejected_upload_fails_instead_of_returning_a_local_path(self):
+        with mock.patch.dict(
+            "os.environ",
+            {
+                "ENVIRONMENT": "production",
+                "SUPABASE_URL": "https://example.supabase.co",
+                "SUPABASE_ANON_KEY": "anon-key",
+            },
+            clear=False,
+        ):
+            storage = SupabaseStorage()
+            response = mock.Mock(status_code=403, text="new row violates row-level security policy")
+            with mock.patch("omr.storage.httpx.AsyncClient") as client_cls:
+                client = client_cls.return_value.__aenter__.return_value
+                client.post = mock.AsyncMock(return_value=response)
+                with self.assertRaises(StorageUploadError) as caught:
+                    self._upload(storage)
+
+        self.assertIn("403", str(caught.exception))
+
+    def test_transport_error_is_not_swallowed(self):
+        """A deleted or paused Supabase project must fail the job.
+
+        On 2026-08-21 the project's host stopped resolving; the previous code
+        caught the exception, wrote a local file, and reported the job
+        completed.
+        """
+        with mock.patch.dict(
+            "os.environ",
+            {
+                "ENVIRONMENT": "production",
+                "SUPABASE_URL": "https://example.supabase.co",
+                "SUPABASE_ANON_KEY": "anon-key",
+            },
+            clear=False,
+        ):
+            storage = SupabaseStorage()
+            with mock.patch("omr.storage.httpx.AsyncClient") as client_cls:
+                client = client_cls.return_value.__aenter__.return_value
+                client.post = mock.AsyncMock(side_effect=OSError("Name or service not known"))
+                with self.assertRaises(StorageUploadError):
+                    self._upload(storage)
+
+    def test_successful_upload_returns_the_public_url(self):
+        with mock.patch.dict(
+            "os.environ",
+            {
+                "ENVIRONMENT": "production",
+                "SUPABASE_URL": "https://example.supabase.co",
+                "SUPABASE_ANON_KEY": "anon-key",
+            },
+            clear=False,
+        ):
+            storage = SupabaseStorage()
+            response = mock.Mock(status_code=200, text="")
+            with mock.patch("omr.storage.httpx.AsyncClient") as client_cls:
+                client = client_cls.return_value.__aenter__.return_value
+                client.post = mock.AsyncMock(return_value=response)
+                url = self._upload(storage)
+
+        self.assertTrue(url.startswith("https://example.supabase.co/storage/v1/object/public/"))
+        self.assertNotIn("file://", url)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

Running the OMR service against a real PDF for the first time (2026-08-21, on the NAVER Cloud VM) showed it returning **success in two situations where nothing had happened**. Both defects predate this work and are on `main` today.

Evidence: `docs/recovery/validation/2026-08-21-omr-service-first-run-defects.md`.

## Defect 1 — `/process` silently dropped every form field except the file

`title`, `composer`, and `user_id` were declared as plain scalars. FastAPI binds those to the **query string**; `src/app/api/omr/upload/route.ts:77-82` sends them as multipart form fields. Measured against a control:

| Sent as | `file_info` returned |
|---|---|
| multipart form fields | `{'title': None, 'composer': None, 'user_id': None}` |
| query string | `{'title': 'QueryTitle', 'composer': 'QueryComposer', 'user_id': 'query-user'}` |

`app.py:167`'s `title or file.filename` then stored the score under its **PDF filename** rather than the user's title. `sheet_music_id` — also sent by the route — was never declared at all, so a result could not be correlated back to its `SheetMusic` row.

## Defect 2 — a failed upload was reported as a completed job

`storage.py` fell back to a container-local file and a `file://` URL in **three** cases: missing credentials, a non-2xx upload response, and **any exception**. The job still reported `"Processing completed successfully"`.

This is `AGENTS.md` § 금지되는 완료 상태 verbatim, and it is not a development-only concern — while investigating, this project's own Supabase host stopped resolving (`NXDOMAIN` from two independent networks), which is precisely the third path. A user would have seen a successful upload and an unplayable score.

## What changed

- All four metadata fields are declared with `Form(...)`; `sheet_music_id` is accepted and recorded.
- `StorageUploadError` is raised on a rejected upload and on any transport failure.
- The local fallback survives **for development only**, behind `assert_local_fallback_allowed()`, which fails closed when `ENVIRONMENT` is unset — mirroring `assertDemoGenerationAllowed()` in `pdfParser.ts`.

## Verification

- 9 new contract tests; 18 passing with the existing suite. Each new test fails against the previous code.
- On the VM, the same PDF now binds all four fields: `{'title': 'WTK1 Prelude 1', 'composer': 'J.S. Bach', 'user_id': 'test-user', 'sheet_music_id': '42'}`.
- With `ENVIRONMENT=production` and no credentials the job now reaches `failed` at progress 80 with the guard's message, and `/tmp/results` stays empty.
- Control: an `ENVIRONMENT=development` container still completes with the `file://` URL, so the fallback is isolated rather than removed.

## Notes for review

- `app.py` cannot be imported where fastapi/aiofiles are absent, so its request contract is asserted from its AST — the same approach `test_audiveris_runtime.py` already uses for the Dockerfile.
- **`omr-service/tests/*.py` is not run by any CI workflow.** These tests, and PR #37's, only run when invoked by hand. Worth deciding separately whether to add that job.
- A real Supabase upload is still unverified — the project's Storage host was not resolving during this work.
- Depends on nothing in PR #37, but the runtime verification above used PR #37's image fix, without which the image does not build.