### PR TITLE
Restore the Security Audit gate that new advisories turned red

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1978,9 +1978,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5318,9 +5318,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5981,9 +5981,19 @@
       }
     },
     "node_modules/deepmerge-ts": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
-      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-8.0.1.tgz",
+      "integrity": "sha512-szCXE7YLCvLKR9bFPJcvsezOShdalctSvrgN/LM/QGUEPZQajwjmsMObZ6/DuANT5lxzM/wtO8Feubwdkz8myA==",
+      "funding": [
+        {
+          "type": "ko-fi",
+          "url": "https://ko-fi.com/rebeccastevens"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/deepmerge-ts"
+        }
+      ],
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=16.0.0"
@@ -9143,9 +9153,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -9816,9 +9826,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,15 @@
   "overrides": {
     "sharp": ">=0.35.0",
     "postcss": ">=8.5.12",
-    "brace-expansion": ">=5.0.8"
+    "brace-expansion": ">=5.0.9 <6",
+    "nanoid": ">=3.3.18 <4",
+    "deepmerge-ts": ">=8.0.1 <9",
+    "@eslint/eslintrc": {
+      "js-yaml": ">=4.3.1 <5"
+    },
+    "@istanbuljs/load-nyc-config": {
+      "js-yaml": ">=3.15.1 <4"
+    }
   },
   "dependencies": {
     "@napi-rs/canvas": "^0.1.76",


### PR DESCRIPTION
## Why

`Security Audit` was **green on `main` at `43a5b14` (2026-08-02)** and **red by 2026-08-21**, with no npm dependency change in between. `npm audit --audit-level high` is time-dependent, so six newly published advisories flipped it.

This is the **fifth occurrence** of the pattern PR #25, #27, and #31 each handled, and `HANDOFF.md` predicted it: *"this is a property of the time-dependent gate, not of any one dependency — expect it again."*

Because it is a required check, it currently blocks the merge button for **PR #37 and #38**, neither of which touches npm dependencies.

## What was red

| Package | Severity | Path |
|---|---|---|
| `js-yaml` 4.3.0 | high | `@eslint/eslintrc` |
| `js-yaml` 3.15.0 | high | `jest → @istanbuljs/load-nyc-config` |
| `nanoid` 3.3.16 | high | `@tailwindcss/postcss → postcss` |
| `brace-expansion` 5.0.8 | high | several (`minimatch`); prior override was `>=5.0.8`, now itself in range |
| `deepmerge-ts` 7.1.5 | high | `prisma → @prisma/config` |
| `@prisma/config` / `prisma` | high | same path |

## Why overrides rather than upgrades

- **`deepmerge-ts`**: `@prisma/config` pins it to *exactly* `7.1.5` in **every** published prisma, including `7.10.0-dev.58`. npm's only suggestion is a major **downgrade** to `prisma@6.12.0`.
- **`js-yaml`**: consumers are split across majors — `@eslint/eslintrc` on 4.x, `@istanbuljs/load-nyc-config` on 3.x. A single global pin would force one across a major boundary. `3.15.1` turns out to be a backported fix despite the advisory title saying otherwise, so **nested overrides** keep each consumer on its own line.

Every pin carries an upper bound (`<6`, `<4`, `<9`, `<5`) so a future resolution cannot silently cross a major.

## Verification

| Command | Result |
|---|---|
| `npm audit --audit-level high` | **exit 0** (was 6 high) |
| resolutions | `js-yaml@4.3.1` **and** `js-yaml@3.15.1` side by side, `nanoid@3.3.18`, `brace-expansion@5.0.9`, `deepmerge-ts@8.0.1` |
| `npx prisma generate` | exit 0 — the forced `deepmerge-ts` major does not break the CLI |
| `npx tsc --noEmit` | exit 0 |
| `npm run lint` | exit 0, no warnings |
| `npm test` | **42 suites / 389 tests passed** |
| `npm run build` | exit 0 |

`npx prisma validate` still reports `P1012` for an unset local `DATABASE_URL` — unchanged from before this commit and already recorded in the handoff.

Two moderate findings remain (`postcss`), below the gate's `high` threshold. Clearing them needs `--force` and `next@16.3.1`, a breaking change.