### PR TITLE
Stop Playwright's output being mistaken for meaningful worktree state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,7 @@ next-env.d.ts
 # Python bytecode cache (omr-service)
 __pycache__/
 *.pyc
+
+# Playwright artifacts
+/playwright-report/
+/test-results/


### PR DESCRIPTION
## Why

`playwright-report/` and `test-results/` are regenerated by every Playwright run, but neither was ignored. Untracked files are treated as user-owned by this repository's cleanup protocol, so these two directories were read as state that must not be touched.

That reading has already cost real work:

- **2026-07-26** — work branch cleanup was blocked because "user-owned uncommitted state is present"; the state was these two directories.
- **2026-08-02** — the handoff recorded them as gone and used that to justify deleting the branch. The claim stopped being true the next time the suite ran, which is exactly what had happened by 2026-08-21.
- **2026-08-21** — they blocked branch cleanup again after PRs #37/#38/#39 merged.

Ignoring them removes the ambiguity instead of restating it every session.

## Detail

```
# Playwright artifacts
/playwright-report/
/test-results/
```

Both are anchored to the repository root with a leading `/`, so a same-named directory under `omr-service/` or any other subtree is not silently ignored.

## Verification

`git check-ignore -v` matches both directories against `.gitignore:62-63`, and `git status --short` no longer lists them. No code changed.