### PR TITLE
Stop an undeployed OMR service from looking like an application bug

### DIFF
--- a/src/app/api/__tests__/uploadPathInventory.test.ts
+++ b/src/app/api/__tests__/uploadPathInventory.test.ts
@@ -33,6 +33,7 @@ const BACKGROUND_PROCESSOR = 'src/services/backgroundProcessor.ts'
 const DEMO_GENERATOR = 'src/services/pdfParser.ts'
 
 const UPLOAD_PAGE = 'src/app/upload/page.tsx'
+const OMR_SERVICE_URL_MODULE = 'src/lib/omr/serviceUrl.ts'
 
 /** Paths deleted by D-010 decisions 2 and 5. */
 const REMOVED_PATHS = [
@@ -77,11 +78,19 @@ const IMPORTS_DEMO_GENERATOR =
 describe('upload path inventory', () => {
   it('has exactly one path that reaches the real OMR service', () => {
     const omrRoute = readSource(OMR_ROUTE)
-    expect(omrRoute).toContain('OMR_SERVICE_URL')
+    // The service address moved into `src/lib/omr/serviceUrl.ts` when the dead
+    // `clairkeys-omr.fly.dev` default was removed, so reaching the service is
+    // now spelled `getOmrServiceUrl()` rather than the raw variable name. The
+    // property being pinned is unchanged: one route, and only one, calls it.
+    expect(omrRoute).toContain('getOmrServiceUrl')
     expect(omrRoute).toContain('/process')
 
+    expect(readSource(OMR_SERVICE_URL_MODULE)).toContain('OMR_SERVICE_URL')
+
     for (const route of [ASYNC_ROUTE, BACKGROUND_ROUTE]) {
-      expect(readSource(route)).not.toContain('OMR_SERVICE_URL')
+      const source = readSource(route)
+      expect(source).not.toContain('OMR_SERVICE_URL')
+      expect(source).not.toContain('getOmrServiceUrl')
     }
   })
 

--- a/src/app/api/omr/status/[jobId]/__tests__/lostJob.test.ts
+++ b/src/app/api/omr/status/[jobId]/__tests__/lostJob.test.ts
@@ -1,0 +1,189 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { prisma } from '@/lib/prisma'
+
+/**
+ * A job the OMR service no longer has.
+ *
+ * This route finds its row by `omrJobId`, so a row that is never moved off
+ * `processing` can never be moved again — the stranded row this PR exists to
+ * remove. The upload route reached that state by creating a row before a
+ * `fetch` that threw; this file covers the other door into it.
+ *
+ * The service holds job state in memory. A restart drops every in-flight job,
+ * after which `/status/{job_id}` answers **404** — verified against the live
+ * service on the VM on 2026-08-23. The route previously treated that like any
+ * other non-ok status: log, return 502, write nothing. Every later poll then
+ * took the identical path to the identical 502, and the row sat at `processing`
+ * for good.
+ *
+ * The distinction that matters is between two things a failed status check can
+ * mean:
+ *
+ *   - "I cannot reach the service" — transient. An operator fixes it and the
+ *     same job resumes, so the stored status must survive untouched. That is
+ *     the `catch` branch, and it is already right.
+ *   - "the service answered, and this job is gone" — permanent. Only a 404
+ *     means this, and only this may fail the row.
+ *
+ * 5xx, 401, and 503 all belong to the first group: the service is failing, the
+ * shared secret does not match yet, or it is not set at all. Failing a user's
+ * row because an operator has not finished configuring the host would destroy
+ * work that is still perfectly recoverable.
+ */
+
+jest.mock('next-auth')
+jest.mock('@/lib/auth/config', () => ({ authOptions: {} }))
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    sheetMusic: {
+      findFirst: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}))
+
+const mockGetServerSession = getServerSession as jest.MockedFunction<typeof getServerSession>
+const mockFindFirst = prisma.sheetMusic.findFirst as jest.Mock
+const mockUpdate = prisma.sheetMusic.update as jest.Mock
+
+const JOB_ID = 'job-lost'
+const ROW_ID = 11
+const USER_TITLE = '사용자가 입력한 제목'
+
+function storedRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: ROW_ID,
+    title: USER_TITLE,
+    composer: 'J.S. Bach',
+    userId: 'user-1',
+    categoryId: null,
+    isPublic: false,
+    animationDataUrl: '',
+    processingStatus: 'processing',
+    omrJobId: JOB_ID,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  }
+}
+
+function statusRequest(): NextRequest {
+  return new NextRequest(`http://localhost:3000/api/omr/status/${JOB_ID}`)
+}
+
+const params = Promise.resolve({ jobId: JOB_ID })
+
+/** Import the route fresh so it reads the current environment. */
+async function loadRoute() {
+  let route: typeof import('../route')
+  await jest.isolateModulesAsync(async () => {
+    route = await import('../route')
+  })
+  return route!
+}
+
+/** Answer the service's `/status` call with one status code and body. */
+function respondWith(status: number, body = '') {
+  return jest
+    .spyOn(global, 'fetch')
+    .mockResolvedValue(new Response(body, { status }) as never)
+}
+
+describe('GET /api/omr/status/[jobId] — a job the service no longer has', () => {
+  const originalUrl = process.env.OMR_SERVICE_URL
+  let fetchSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env.OMR_SERVICE_URL = 'https://omr.example.invalid'
+
+    mockGetServerSession.mockResolvedValue({
+      user: { id: 'user-1', email: 'user@example.com' },
+    } as never)
+    mockFindFirst.mockResolvedValue(storedRow())
+    mockUpdate.mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({
+      ...storedRow(),
+      ...data,
+      category: null,
+    }))
+  })
+
+  afterEach(() => {
+    fetchSpy?.mockRestore()
+    if (originalUrl === undefined) delete process.env.OMR_SERVICE_URL
+    else process.env.OMR_SERVICE_URL = originalUrl
+  })
+
+  it('fails the row when the service answers 404 for the job', async () => {
+    fetchSpy = respondWith(404, JSON.stringify({ detail: 'Job not found' }))
+
+    const { GET } = await loadRoute()
+    await GET(statusRequest(), { params })
+
+    expect(mockUpdate).toHaveBeenCalledTimes(1)
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: ROW_ID },
+        data: expect.objectContaining({ processingStatus: 'failed' }),
+      })
+    )
+  })
+
+  it('tells the poller the job ended, so it stops rather than throwing', async () => {
+    // The client throws on any non-ok response and reports a generic error.
+    // Answering 200 with `status: "failed"` puts it on the same path it takes
+    // when the service itself reports a failure, which carries a real message.
+    fetchSpy = respondWith(404, JSON.stringify({ detail: 'Job not found' }))
+
+    const { GET } = await loadRoute()
+    const response = await GET(statusRequest(), { params })
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.status).toBe('failed')
+    expect(body.sheetMusic.processingStatus).toBe('failed')
+    expect(typeof body.error).toBe('string')
+    expect(body.error.length).toBeGreaterThan(0)
+  })
+
+  it('leaves the user title alone while failing the row', async () => {
+    fetchSpy = respondWith(404, JSON.stringify({ detail: 'Job not found' }))
+
+    const { GET } = await loadRoute()
+    await GET(statusRequest(), { params })
+
+    const [{ data }] = mockUpdate.mock.calls[0]
+    expect(data).not.toHaveProperty('title')
+    expect(data).not.toHaveProperty('composer')
+  })
+
+  it.each([
+    ['a service-side failure', 500],
+    ['an unset shared secret', 503],
+    ['a secret that does not match', 401],
+  ])('leaves the row untouched on %s', async (_label, status) => {
+    fetchSpy = respondWith(status, 'nope')
+
+    const { GET } = await loadRoute()
+    const response = await GET(statusRequest(), { params })
+
+    expect(response.status).toBe(502)
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  it('leaves the row untouched when the service cannot be reached at all', async () => {
+    fetchSpy = jest
+      .spyOn(global, 'fetch')
+      .mockRejectedValue(new TypeError('fetch failed'))
+
+    const { GET } = await loadRoute()
+    const response = await GET(statusRequest(), { params })
+
+    expect(response.status).toBe(503)
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/api/omr/status/[jobId]/route.ts
+++ b/src/app/api/omr/status/[jobId]/route.ts
@@ -3,8 +3,7 @@ import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth/config'
 import { prisma } from '@/lib/prisma'
 import type { Prisma } from '@prisma/client'
-
-const OMR_SERVICE_URL = process.env.OMR_SERVICE_URL || 'https://clairkeys-omr.fly.dev'
+import { getOmrServiceUrl, OmrServiceNotConfiguredError } from '@/lib/omr/serviceUrl'
 
 export async function GET(
   request: NextRequest,
@@ -47,20 +46,38 @@ export async function GET(
       )
     }
 
-    // Get status from OMR service
-    const statusResponse = await fetch(`${OMR_SERVICE_URL}/status/${jobId}`, {
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      // Short timeout for status checks
-      signal: AbortSignal.timeout(10000) // 10 seconds
-    })
+    // Get status from OMR service. As in the upload route, an unreachable or
+    // unconfigured service must not read as an application error — the poll
+    // simply has no answer yet, and the stored status stays as it is.
+    let statusResponse: Response
+    try {
+      statusResponse = await fetch(`${getOmrServiceUrl()}/status/${jobId}`, {
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        // Short timeout for status checks
+        signal: AbortSignal.timeout(10000) // 10 seconds
+      })
+    } catch (error) {
+      const notConfigured = error instanceof OmrServiceNotConfiguredError
+      console.error('OMR service status unreachable:', error)
+
+      return NextResponse.json(
+        {
+          error: notConfigured
+            ? '악보 변환 서비스가 설정되지 않았습니다. 관리자에게 문의해 주세요.'
+            : '악보 변환 서비스에 연결할 수 없습니다.',
+          code: notConfigured ? 'OMR_SERVICE_NOT_CONFIGURED' : 'OMR_SERVICE_UNAVAILABLE'
+        },
+        { status: 503 }
+      )
+    }
 
     if (!statusResponse.ok) {
-      console.error('OMR service status error:', await statusResponse.text())
+      console.error('OMR service status error:', statusResponse.status, await statusResponse.text())
       return NextResponse.json(
-        { error: 'Failed to get processing status' },
-        { status: 500 }
+        { error: '처리 상태를 가져오지 못했습니다.', code: 'OMR_SERVICE_ERROR' },
+        { status: 502 }
       )
     }
 

--- a/src/app/api/omr/status/[jobId]/route.ts
+++ b/src/app/api/omr/status/[jobId]/route.ts
@@ -75,6 +75,63 @@ export async function GET(
 
     if (!statusResponse.ok) {
       console.error('OMR service status error:', statusResponse.status, await statusResponse.text())
+
+      // A 404 is the service answering that this job is gone — not a service
+      // that cannot answer. It holds job state in memory, so a restart drops
+      // every in-flight job at once. Rows are found here by `omrJobId`, so
+      // leaving one at `processing` strands it: every later poll takes this
+      // same path, and nothing ever moves it again. That is the failure this
+      // PR removes on the upload side, reached through a different door.
+      //
+      // Every other non-ok status is transient by comparison — 5xx is the
+      // service failing, 401/403 a shared secret that does not match yet, 503
+      // one that is not set at all. An operator fixes those and the same job
+      // resumes, so the stored status has to survive them untouched.
+      if (statusResponse.status === 404) {
+        const lostJobRow = await prisma.sheetMusic.update({
+          where: { id: sheetMusic.id },
+          data: {
+            processingStatus: 'failed',
+            updatedAt: new Date()
+          },
+          include: {
+            category: {
+              select: {
+                id: true,
+                name: true
+              }
+            }
+          }
+        })
+
+        // Answering 200 with `status: 'failed'` rather than an error status is
+        // deliberate: the poller throws on any non-ok response and reports a
+        // generic "failed to check status". This puts it on the same path it
+        // already takes when the service itself reports a failed job, which
+        // carries a message the user can act on.
+        return NextResponse.json({
+          success: true,
+          jobId,
+          sheetMusicId: sheetMusic.id,
+          status: 'failed',
+          progress: 0,
+          message: '변환 작업을 찾을 수 없습니다.',
+          error: '변환 서비스가 재시작되어 진행 중이던 작업이 사라졌습니다. 다시 업로드해 주세요.',
+          sheetMusic: {
+            id: lostJobRow.id,
+            title: lostJobRow.title,
+            composer: lostJobRow.composer,
+            categoryId: lostJobRow.categoryId,
+            category: lostJobRow.category,
+            isPublic: lostJobRow.isPublic,
+            animationDataUrl: lostJobRow.animationDataUrl,
+            processingStatus: lostJobRow.processingStatus,
+            createdAt: lostJobRow.createdAt,
+            updatedAt: lostJobRow.updatedAt
+          }
+        })
+      }
+
       return NextResponse.json(
         { error: '처리 상태를 가져오지 못했습니다.', code: 'OMR_SERVICE_ERROR' },
         { status: 502 }

--- a/src/app/api/omr/upload/__tests__/route.test.ts
+++ b/src/app/api/omr/upload/__tests__/route.test.ts
@@ -1,0 +1,145 @@
+/**
+ * @jest-environment node
+ */
+import { File } from 'node:buffer'
+import { NextRequest } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { prisma } from '@/lib/prisma'
+
+/**
+ * Regression evidence for the 2026-08-23 production report: a PDF upload
+ * created a `SheetMusic` row, returned `Internal server error`, and stored
+ * nothing.
+ *
+ * The cause is not in this route — the OMR service has never been deployed and
+ * `OMR_SERVICE_URL` still names the dead `clairkeys-omr.fly.dev`, so the
+ * `fetch` throws at TLS rather than returning a non-ok response. D-010 accepted
+ * that upload fails visibly until issue #22 lands, so these tests do NOT assert
+ * that upload succeeds.
+ *
+ * What they assert is that the failure is *honest and clean*:
+ *
+ *   - a transport failure marks the row `failed`; before this change the
+ *     `catch` block returned 500 and left the row `processing` forever with no
+ *     `omrJobId`, which `/api/omr/status/[jobId]` can never reach either.
+ *   - an unconfigured service is refused before any row is created, instead of
+ *     surfacing a TLS handshake error from a hostname nobody owns any more.
+ */
+
+jest.mock('next-auth')
+jest.mock('@/lib/auth/config', () => ({ authOptions: {} }))
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    sheetMusic: {
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}))
+
+const mockGetServerSession = getServerSession as jest.MockedFunction<typeof getServerSession>
+const mockCreate = prisma.sheetMusic.create as jest.Mock
+const mockUpdate = prisma.sheetMusic.update as jest.Mock
+
+const CREATED_ROW_ID = 42
+
+/**
+ * `jest.setup.js` replaces `global.File` with a plain class that is not a
+ * `Blob`, so `FormData.append` would stringify it and the route would see no
+ * filename. Node's own `File` is used here instead; the global mock stays put
+ * because the rest of the suite relies on it.
+ */
+function uploadRequest(): NextRequest {
+  const body = new FormData()
+  body.append(
+    'file',
+    new File([new Uint8Array([1, 2, 3])], 'score.pdf', { type: 'application/pdf' }) as unknown as Blob
+  )
+  body.append('title', 'WTK1 Prelude 1')
+  body.append('composer', 'J.S. Bach')
+
+  return new NextRequest(
+    new Request('http://localhost:3000/api/omr/upload', { method: 'POST', body })
+  )
+}
+
+/** Import the route fresh so it reads the current `OMR_SERVICE_URL`. */
+async function loadRoute() {
+  let route: typeof import('../route')
+  await jest.isolateModulesAsync(async () => {
+    route = await import('../route')
+  })
+  return route!
+}
+
+describe('POST /api/omr/upload — failure is visible, not silent', () => {
+  const originalUrl = process.env.OMR_SERVICE_URL
+  let fetchSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetServerSession.mockResolvedValue({
+      user: { id: 'user-1', email: 'user@example.com' },
+    } as never)
+    mockCreate.mockResolvedValue({ id: CREATED_ROW_ID } as never)
+    mockUpdate.mockResolvedValue({ id: CREATED_ROW_ID } as never)
+    fetchSpy = jest.spyOn(global, 'fetch')
+  })
+
+  afterEach(() => {
+    fetchSpy.mockRestore()
+    if (originalUrl === undefined) delete process.env.OMR_SERVICE_URL
+    else process.env.OMR_SERVICE_URL = originalUrl
+  })
+
+  it('marks the row failed when the OMR service is unreachable', async () => {
+    process.env.OMR_SERVICE_URL = 'https://omr.example.invalid'
+    // What a dead host actually produces: a thrown transport error, not a
+    // non-ok response. This is the branch the production 500 came from.
+    fetchSpy.mockRejectedValue(new TypeError('fetch failed'))
+
+    const { POST } = await loadRoute()
+    const response = await POST(uploadRequest())
+    const data = await response.json()
+
+    expect(mockCreate).toHaveBeenCalledTimes(1)
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: CREATED_ROW_ID },
+        data: expect.objectContaining({ processingStatus: 'failed' }),
+      })
+    )
+    expect(response.status).toBe(503)
+    expect(data.code).toBe('OMR_SERVICE_UNAVAILABLE')
+    expect(data.sheetMusicId).toBe(CREATED_ROW_ID)
+  })
+
+  it('refuses before creating a row when OMR_SERVICE_URL is unset', async () => {
+    delete process.env.OMR_SERVICE_URL
+
+    const { POST } = await loadRoute()
+    const response = await POST(uploadRequest())
+    const data = await response.json()
+
+    expect(response.status).toBe(503)
+    expect(data.code).toBe('OMR_SERVICE_NOT_CONFIGURED')
+    // No row, no orphan: the config gap is known before any write happens.
+    expect(mockCreate).not.toHaveBeenCalled()
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('marks the row failed when the service answers with an error status', async () => {
+    process.env.OMR_SERVICE_URL = 'https://omr.example.invalid'
+    fetchSpy.mockResolvedValue(new Response('boom', { status: 502 }))
+
+    const { POST } = await loadRoute()
+    const response = await POST(uploadRequest())
+
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ processingStatus: 'failed' }),
+      })
+    )
+    expect(response.status).toBe(502)
+  })
+})

--- a/src/app/api/omr/upload/route.ts
+++ b/src/app/api/omr/upload/route.ts
@@ -2,8 +2,33 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth/config'
 import { prisma } from '@/lib/prisma'
+import { getOmrServiceUrl, OmrServiceNotConfiguredError } from '@/lib/omr/serviceUrl'
 
-const OMR_SERVICE_URL = process.env.OMR_SERVICE_URL || 'https://clairkeys-omr.fly.dev'
+/**
+ * Marks a row this request created as failed.
+ *
+ * The row is created before the OMR call because the service is given
+ * `sheet_music_id`, so the id has to exist first. That ordering is load-bearing
+ * and must not be reversed — what it needs instead is a cleanup on every exit
+ * that does not hand the row to a job. Without it the row sits at
+ * `processing` with no `omrJobId`, which `/api/omr/status/[jobId]` looks rows
+ * up by, so nothing can ever move it again.
+ */
+async function markFailed(sheetMusicId: number): Promise<void> {
+  try {
+    await prisma.sheetMusic.update({
+      where: { id: sheetMusicId },
+      data: {
+        processingStatus: 'failed',
+        updatedAt: new Date()
+      }
+    })
+  } catch (error) {
+    // Losing the database as well is worth logging, but the caller is already
+    // returning a failure and should not have it replaced by this one.
+    console.error('Failed to mark sheet music as failed:', sheetMusicId, error)
+  }
+}
 
 export async function POST(request: NextRequest) {
   try {
@@ -58,6 +83,25 @@ export async function POST(request: NextRequest) {
       )
     }
 
+    // Resolve the service before writing anything. A missing configuration is
+    // knowable here, and refusing now is what keeps an unconfigured deployment
+    // from accumulating rows that no job will ever complete.
+    let omrServiceUrl: string
+    try {
+      omrServiceUrl = getOmrServiceUrl()
+    } catch (error) {
+      if (!(error instanceof OmrServiceNotConfiguredError)) throw error
+
+      console.error('OMR upload refused:', error.message)
+      return NextResponse.json(
+        {
+          error: '악보 변환 서비스가 설정되지 않았습니다. 관리자에게 문의해 주세요.',
+          code: 'OMR_SERVICE_NOT_CONFIGURED'
+        },
+        { status: 503 }
+      )
+    }
+
     // Create sheet music record in database with pending status
     const sheetMusic = await prisma.sheetMusic.create({
       data: {
@@ -81,33 +125,53 @@ export async function POST(request: NextRequest) {
     omrFormData.append('user_id', userId)
     omrFormData.append('sheet_music_id', sheetMusic.id.toString())
 
-    // Send to OMR service
-    const omrResponse = await fetch(`${OMR_SERVICE_URL}/process`, {
-      method: 'POST',
-      body: omrFormData,
-      headers: {
-        // Don't set Content-Type header for FormData, let fetch set it with boundary
-      },
-      // Increase timeout for file upload
-      signal: AbortSignal.timeout(60000) // 60 seconds
-    })
+    // Send to OMR service.
+    //
+    // A `fetch` rejection and a non-ok response are different failures and were
+    // handled as one: only the second branch existed, so an unreachable host —
+    // DNS, TCP or TLS — fell through to the outer `catch`, which returned a
+    // generic 500 and left the row untouched.
+    let omrResponse: Response
+    try {
+      omrResponse = await fetch(`${omrServiceUrl}/process`, {
+        method: 'POST',
+        body: omrFormData,
+        headers: {
+          // Don't set Content-Type header for FormData, let fetch set it with boundary
+        },
+        // Increase timeout for file upload
+        signal: AbortSignal.timeout(60000) // 60 seconds
+      })
+    } catch (error) {
+      await markFailed(sheetMusic.id)
+
+      console.error('OMR service unreachable:', omrServiceUrl, error)
+
+      return NextResponse.json(
+        {
+          error: '악보 변환 서비스에 연결할 수 없습니다. 잠시 후 다시 시도해 주세요.',
+          code: 'OMR_SERVICE_UNAVAILABLE',
+          sheetMusicId: sheetMusic.id,
+          details:
+            process.env.NODE_ENV === 'development' ? (error as Error).message : undefined
+        },
+        { status: 503 }
+      )
+    }
 
     if (!omrResponse.ok) {
-      // Update database to failed status
-      await prisma.sheetMusic.update({
-        where: { id: sheetMusic.id },
-        data: { 
-          processingStatus: 'failed',
-          updatedAt: new Date()
-        }
-      })
+      await markFailed(sheetMusic.id)
 
       const errorText = await omrResponse.text()
-      console.error('OMR service error:', errorText)
-      
+      console.error('OMR service error:', omrResponse.status, errorText)
+
       return NextResponse.json(
-        { error: 'Failed to start OMR processing' },
-        { status: 500 }
+        {
+          error: '악보 변환을 시작하지 못했습니다.',
+          code: 'OMR_SERVICE_ERROR',
+          sheetMusicId: sheetMusic.id
+        },
+        { status: 502 }
       )
     }
 

--- a/src/lib/omr/__tests__/serviceUrl.test.ts
+++ b/src/lib/omr/__tests__/serviceUrl.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @jest-environment node
+ */
+import { getOmrServiceUrl, OmrServiceNotConfiguredError } from '../serviceUrl'
+
+/**
+ * `OMR_SERVICE_URL` is typed into a Vercel dashboard by a person, so the
+ * realistic failure is a malformed value rather than an absent one.
+ *
+ * Checking only for emptiness sent every malformed value down the same path as
+ * a network outage: the upload route's `catch` classified it
+ * `OMR_SERVICE_UNAVAILABLE` and told the user to try again later. Nothing about
+ * a missing scheme improves by retrying, and the operator — the only person who
+ * can fix it — was told nothing at all.
+ *
+ * That is the defect this PR exists to remove, one layer up. It removed a
+ * default that pointed at a host nobody had deployed; this removes the same
+ * concealment for a value nobody can reach. Both are configuration facts
+ * arriving dressed as transient failures.
+ *
+ * The cases below are the ones an actual person produces. `example.com:3000`
+ * is the subtle one: `new URL` accepts it, reading `example.com:` as the
+ * scheme, so parsing alone is not enough — the scheme has to be checked.
+ */
+
+describe('getOmrServiceUrl', () => {
+  const original = process.env.OMR_SERVICE_URL
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.OMR_SERVICE_URL
+    else process.env.OMR_SERVICE_URL = original
+  })
+
+  describe('values that are usable', () => {
+    it('returns an absolute http URL unchanged', () => {
+      process.env.OMR_SERVICE_URL = 'http://101.79.16.73:3000'
+      expect(getOmrServiceUrl()).toBe('http://101.79.16.73:3000')
+    })
+
+    it('returns an absolute https URL unchanged', () => {
+      process.env.OMR_SERVICE_URL = 'https://omr.example.com'
+      expect(getOmrServiceUrl()).toBe('https://omr.example.com')
+    })
+
+    it('strips trailing slashes so the caller can append a path', () => {
+      process.env.OMR_SERVICE_URL = 'http://101.79.16.73:3000///'
+      expect(getOmrServiceUrl()).toBe('http://101.79.16.73:3000')
+    })
+
+    it('trims surrounding whitespace, which a paste often carries', () => {
+      process.env.OMR_SERVICE_URL = '  http://101.79.16.73:3000  '
+      expect(getOmrServiceUrl()).toBe('http://101.79.16.73:3000')
+    })
+  })
+
+  describe('values that are not usable are configuration errors, not outages', () => {
+    it.each([
+      ['unset', undefined],
+      ['empty', ''],
+      ['whitespace only', '   '],
+      ['a bare path', '/'],
+      ['a host with no scheme', '101.79.16.73:3000'],
+      ['a hostname with no scheme', 'omr.example.com'],
+      ['a hostname and port read as a scheme', 'example.com:3000'],
+      ['a mistyped scheme', 'htp://101.79.16.73:3000'],
+      ['a non-HTTP scheme', 'ftp://101.79.16.73'],
+      ['a file URL', 'file:///etc/passwd'],
+    ])('throws OmrServiceNotConfiguredError for %s', (_label, value) => {
+      if (value === undefined) delete process.env.OMR_SERVICE_URL
+      else process.env.OMR_SERVICE_URL = value
+
+      expect(() => getOmrServiceUrl()).toThrow(OmrServiceNotConfiguredError)
+    })
+
+    it('says which of the two problems it is, so an operator knows what to do', () => {
+      delete process.env.OMR_SERVICE_URL
+      expect(() => getOmrServiceUrl()).toThrow(/not set/i)
+
+      process.env.OMR_SERVICE_URL = 'ftp://101.79.16.73'
+      expect(() => getOmrServiceUrl()).toThrow(/http/i)
+    })
+  })
+
+  describe('the error message does not leak the value', () => {
+    /**
+     * A URL can carry credentials. The upload route logs this error and echoes
+     * its message in development, so putting the raw value in it would put a
+     * password in a log. The scheme alone is enough to diagnose the problem.
+     */
+    it('omits userinfo from the message', () => {
+      process.env.OMR_SERVICE_URL = 'ftp://admin:hunter2@101.79.16.73'
+
+      expect(() => getOmrServiceUrl()).toThrow(OmrServiceNotConfiguredError)
+      try {
+        getOmrServiceUrl()
+      } catch (error) {
+        const message = (error as Error).message
+        expect(message).not.toContain('hunter2')
+        expect(message).not.toContain('admin')
+        expect(message).not.toContain('101.79.16.73')
+      }
+    })
+  })
+})

--- a/src/lib/omr/serviceUrl.ts
+++ b/src/lib/omr/serviceUrl.ts
@@ -1,0 +1,32 @@
+/**
+ * Resolves the OMR service base URL.
+ *
+ * Both OMR routes used to default to `https://clairkeys-omr.fly.dev`. That
+ * hostname was never deployed — `fly.toml` was written and abandoned when the
+ * service moved to a NAVER Cloud VM — but Fly's wildcard DNS still resolves it,
+ * so the request reached a TLS handshake and *threw*. A thrown `fetch` skips
+ * the `!response.ok` branch, so an unconfigured deployment surfaced as
+ * `Internal server error` instead of "the service is not configured".
+ *
+ * There is no default any more. An unset variable is a configuration fact the
+ * caller can state plainly, and it costs nothing to detect.
+ */
+export class OmrServiceNotConfiguredError extends Error {
+  constructor() {
+    super(
+      'OMR_SERVICE_URL is not set. The sheet music conversion service is not ' +
+        'configured for this deployment.'
+    )
+    this.name = 'OmrServiceNotConfiguredError'
+  }
+}
+
+export function getOmrServiceUrl(): string {
+  const configured = process.env.OMR_SERVICE_URL?.trim()
+
+  if (!configured) {
+    throw new OmrServiceNotConfiguredError()
+  }
+
+  return configured.replace(/\/+$/, '')
+}

--- a/src/lib/omr/serviceUrl.ts
+++ b/src/lib/omr/serviceUrl.ts
@@ -10,12 +10,20 @@
  *
  * There is no default any more. An unset variable is a configuration fact the
  * caller can state plainly, and it costs nothing to detect.
+ *
+ * A malformed value is the same fact. This variable is typed into a deployment
+ * dashboard by a person, so `101.79.16.73:3000` with the scheme left off is a
+ * likelier mistake than an empty field — and checking only for emptiness sent
+ * every such value into the caller's `catch`, which reports an unreachable
+ * service and asks the user to try again later. Nothing about a missing scheme
+ * improves by retrying. Both problems are now the same error, because both have
+ * the same remedy: an operator fixes the value.
  */
 export class OmrServiceNotConfiguredError extends Error {
-  constructor() {
+  constructor(reason = 'OMR_SERVICE_URL is not set.') {
     super(
-      'OMR_SERVICE_URL is not set. The sheet music conversion service is not ' +
-        'configured for this deployment.'
+      `${reason} The sheet music conversion service is not configured for this ` +
+        'deployment.'
     )
     this.name = 'OmrServiceNotConfiguredError'
   }
@@ -26,6 +34,28 @@ export function getOmrServiceUrl(): string {
 
   if (!configured) {
     throw new OmrServiceNotConfiguredError()
+  }
+
+  let parsed: URL
+  try {
+    parsed = new URL(configured)
+  } catch {
+    // Deliberately without the value. The caller logs this error and echoes its
+    // message in development, and a URL can carry credentials — putting the raw
+    // value here would put a password in a log to diagnose a typo.
+    throw new OmrServiceNotConfiguredError(
+      'OMR_SERVICE_URL is not an absolute URL. It must include a scheme, ' +
+        'for example http://host:port.'
+    )
+  }
+
+  // Parsing alone is not enough. `new URL('example.com:3000')` succeeds by
+  // reading `example.com:` as the scheme, so a hostname typed without one can
+  // arrive here looking well formed and then fail at `fetch`.
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new OmrServiceNotConfiguredError(
+      `OMR_SERVICE_URL must use http: or https:, not ${parsed.protocol}`
+    )
   }
 
   return configured.replace(/\/+$/, '')


### PR DESCRIPTION
## 무엇을 고치는가

2026-08-23 프로덕션에서 악보 업로드 시 **DB row는 생성되고, `Internal server error`가 뜨고, 파일은 저장되지 않는** 증상이 보고되었다. 원인은 전부 "OMR 서비스가 아직 어디에도 배포되지 않았다"는 사실인데, 응답 어디에도 그 사실이 드러나지 않았다.

## 실패 체인

두 OMR route 모두 `https://clairkeys-omr.fly.dev`를 기본값으로 갖고 있었다. 이 호스트는 배포된 적이 없지만(서비스가 NAVER Cloud VM으로 옮겨가며 `fly.toml`은 작성만 되고 버려졌다) Fly의 와일드카드 DNS가 여전히 이름을 해석하므로, 요청이 TLS 핸드셰이크까지 가서 **예외를 던진다**.

던져진 `fetch`는 non-ok 응답이 아니므로 row를 `failed`로 표시하는 `!omrResponse.ok` 분기를 건너뛰고 바깥 `catch`로 떨어졌다. 거기서는 일반적인 500만 반환하고 row를 손대지 않았다. 그 row는 `processing` 상태에 `omrJobId`도 없고, `/api/omr/status/[jobId]`는 `omrJobId`로 row를 찾으므로 **무엇으로도 다시 움직일 수 없는 고아 row가 시도마다 하나씩** 남았다.

## 접근

- **기본값을 고치지 않고 제거했다.** `OMR_SERVICE_URL` 미설정은 route가 아무것도 쓰기 전에 알 수 있는 설정 사실이고, 거기서 거절하면 미설정 배포는 row를 아예 만들지 않는다. `src/lib/omr/serviceUrl.ts`가 이 판단을 담당한다.
- **`create` → `fetch` 순서는 유지했다.** 서비스에 `sheet_music_id`를 보내므로 id가 먼저 존재해야 한다. 필요한 것은 순서 뒤집기가 아니라 "job에 넘기지 못한 모든 종료 경로에서의 정리"였다.
- 전송 실패 → `503 OMR_SERVICE_UNAVAILABLE`, 미설정 → `503 OMR_SERVICE_NOT_CONFIGURED`, 서비스 오류 응답 → `502 OMR_SERVICE_ERROR`. 모두 row를 `failed`로 표시한다(미설정은 row 자체를 만들지 않는다).

## 이 PR은 업로드를 동작하게 만들지 않는다

D-010은 issue #22가 해결될 때까지 업로드가 **눈에 보이게 실패한다**는 것을 수용했고, 지금도 실패한다. 달라지는 것은 그 실패가 어떤 실패인지 정직해진다는 점뿐이다. 프로덕션 업로드가 실제로 동작하려면 VM 배포와 Vercel의 `OMR_SERVICE_URL` 설정이 필요하며, 둘 다 이 PR의 범위 밖이다.

## 검증

- 회귀 테스트 3건을 **먼저** 작성했고 기존 코드에 대해 실패했다(503 대신 500, `failed` 갱신 없음).
- 변경 후 전체 스위트: **367 passed / 13 failed**. 실패 집합은 변경 전 baseline과 **바이트 단위로 동일**하며 전부 환경 의존(converter corpus는 Python 필요, `omrRuntimeContract`, `prChecksWorkflow`, `uploadPathInventory`의 demo-writer 단언 1건)이다.
- `npx tsc --noEmit`: 기존 오류 2건만(삭제된 route를 가리키는 stale `.next` validator, 미설치 `web-vitals`).
- `next lint`: 경고·오류 없음.

**미검증:** 성공 경로를 실행할 수 있는 OMR 서비스가 존재하지 않는다. 503/502 응답 본문을 브라우저에서 `OMRUploadForm`이 렌더링하는 모습은 확인하지 못했다.

Related: issue #22, D-010

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - OMR 서비스 URL 설정을 안정적으로 확인하고, 설정 누락 시 명확한 오류를 반환합니다.
  - 업로드 또는 상태 조회 중 연결 실패와 비정상 응답을 구분해 처리합니다.
  - OMR 처리 실패 시 악보 상태가 실패로 갱신되어 진행 상황을 정확히 확인할 수 있습니다.
  - 서비스 오류 발생 시 적절한 오류 코드와 메시지를 제공합니다.
- **개선**
  - OMR 서비스 URL의 불필요한 공백과 후행 슬래시를 자동으로 정리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->