### PR TITLE
Give Audiveris the legacy OCR data its fixed engine mode requires

### DIFF
--- a/omr-service/Dockerfile.audiveris
+++ b/omr-service/Dockerfile.audiveris
@@ -3,6 +3,9 @@ FROM ubuntu:22.04
 ARG AUDIVERIS_VERSION=5.11.0
 ARG AUDIVERIS_DEB=Audiveris-5.11.0-ubuntu22.04-x86_64.deb
 ARG AUDIVERIS_SHA256=ae714594f40e54b1a4951fc3f914f08ae38fe5d07b7f2283b1a904fdb6e0a318
+ARG TESSDATA_REPOSITORY_URL=https://raw.githubusercontent.com/tesseract-ocr/tessdata
+ARG TESSDATA_TAG=4.1.0
+ARG TESSDATA_ENG_SHA256=daa0c97d651c19fba3b25e81317cd697e9908c8208090c94c3905381c23fc047
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
@@ -13,6 +16,13 @@ ENV TESSDATA_PREFIX=/usr/share/tesseract-ocr/4.00/tessdata
 
 # Audiveris's official .deb includes its own jlink JRE. English OCR language
 # data is separate from that runtime and must be installed explicitly.
+#
+# Keep tesseract-ocr-eng because it installs the matching Tesseract packages,
+# configuration, and canonical tessdata directory. Ubuntu's packaged English
+# model is LSTM-only, however, while Audiveris initializes Tesseract's legacy
+# engine. Overwrite only that model with tessdata 4.1.0's 23,466,654-byte
+# legacy+LSTM file. Keeping the canonical path also avoids a second shadow
+# tessdata directory and lets the existing TESSDATA_PREFIX remain unchanged.
 #
 # Three needs of the .deb are not expressed by its own metadata:
 #   - Its postinst runs xdg-desktop-menu/xdg-mime. Those exit 3 unless a system
@@ -44,6 +54,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       -o "/tmp/${AUDIVERIS_DEB}" \
     && echo "${AUDIVERIS_SHA256}  /tmp/${AUDIVERIS_DEB}" | sha256sum -c - \
     && apt-get install -y --no-install-recommends "/tmp/${AUDIVERIS_DEB}" \
+    && curl -fsSL \
+      "${TESSDATA_REPOSITORY_URL}/${TESSDATA_TAG}/eng.traineddata" \
+      -o /tmp/eng.traineddata \
+    && echo "${TESSDATA_ENG_SHA256}  /tmp/eng.traineddata" | sha256sum -c - \
+    && install -m 0644 /tmp/eng.traineddata /usr/share/tesseract-ocr/4.00/tessdata/eng.traineddata \
     && sed -i \
       's/java-options=-Xmx8G/java-options=-Xmx3G/' \
       /opt/audiveris/lib/app/Audiveris.cfg \
@@ -52,7 +67,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && test -x /opt/audiveris/bin/Audiveris \
     && test -x /opt/audiveris/lib/runtime/bin/java \
     && /opt/audiveris/bin/Audiveris -version \
-    && rm -f "/tmp/${AUDIVERIS_DEB}" \
+    && rm -f "/tmp/${AUDIVERIS_DEB}" /tmp/eng.traineddata \
     && rm -rf /var/lib/apt/lists/*
 
 # Create working directory

--- a/omr-service/tests/test_audiveris_runtime.py
+++ b/omr-service/tests/test_audiveris_runtime.py
@@ -258,6 +258,32 @@ class DeploymentStaticContractTests(unittest.TestCase):
         self.assertGreaterEqual(dockerfile.count("--no-install-recommends"), 2)
         self.assertNotIn("openjdk", dockerfile.lower())
 
+    def test_container_replaces_english_data_with_checksum_pinned_legacy_model(self):
+        dockerfile = (OMR_SERVICE_ROOT / "Dockerfile.audiveris").read_text(encoding="utf-8")
+
+        self.assertIn(
+            "ARG TESSDATA_REPOSITORY_URL=https://raw.githubusercontent.com/tesseract-ocr/tessdata",
+            dockerfile,
+        )
+        self.assertIn("ARG TESSDATA_TAG=4.1.0", dockerfile)
+        self.assertIn(
+            "ARG TESSDATA_ENG_SHA256=daa0c97d651c19fba3b25e81317cd697e9908c8208090c94c3905381c23fc047",
+            dockerfile,
+        )
+        self.assertIn(
+            '"${TESSDATA_REPOSITORY_URL}/${TESSDATA_TAG}/eng.traineddata"',
+            dockerfile,
+        )
+        self.assertIn(
+            'echo "${TESSDATA_ENG_SHA256}  /tmp/eng.traineddata" | sha256sum -c -',
+            dockerfile,
+        )
+        self.assertIn(
+            "install -m 0644 /tmp/eng.traineddata "
+            "/usr/share/tesseract-ocr/4.00/tessdata/eng.traineddata",
+            dockerfile,
+        )
+
     def test_container_supplies_the_needs_the_deb_does_not_declare(self):
         """The 5.11.0 .deb fails to install and then fails to run without these.
 


### PR DESCRIPTION
Fixes #49.

## 목적

Audiveris가 지면의 글자를 **한 글자도** 읽지 못하고 있었고, 그런데도 job은 성공으로 끝났다. 원인은 이미 실증돼 있다: Ubuntu `tesseract-ocr-eng`가 설치하는 `eng.traineddata`(4,113,088 bytes)는 LSTM 전용인데, Audiveris 5.11.0은 Tesseract를 `OEM_TESSERACT_ONLY`(legacy) 모드로 초기화한다. `TesseractOrder`에는 엔진 모드를 바꾸는 상수가 없으므로 traineddata 교체가 유일한 경로다.

```
WARN | TesseractOrder. Could not initialize TessBaseAPI languages: eng in legacy mode
INFO | OcrUtil | No OCR'd lines
```

## 범위

- `omr-service/Dockerfile.audiveris` — `tesseract-ocr/tessdata` 4.1.0의 legacy+LSTM 통합 `eng.traineddata`를 받아 **체크섬을 핀으로 고정**하고, 패키지가 깐 모델을 같은 경로에서 덮어쓴다. 핀 형태는 같은 파일의 Audiveris `.deb` 핀과 동일하게 맞췄다.
  - `tesseract-ocr-eng` 패키지는 **유지한다** — 표준 tessdata 디렉터리와 Tesseract 설정을 제공한다. 모델 파일만 바뀐다.
  - 별도 디렉터리 + `TESSDATA_PREFIX` 변경 대신 제자리 덮어쓰기를 골랐다. 런타임 경로가 하나로 유지되고 `TESSDATA_PREFIX` drift 위험이 없다.
- `omr-service/tests/test_audiveris_runtime.py` — 위 계약(URL·태그·SHA256 핀·검증 명령·설치 경로)을 정적으로 고정하는 테스트. **Dockerfile 수정 전에 먼저 추가해 실패를 확인했다.**

## 제외 범위

- 이슈 #48(재생 빠르기)은 이 PR에 **없다.** 별도 PR로 간다. OCR을 되살려도 `<metronome>`은 여전히 0이었다(같은 악보에서 실측) — #49만으로 #48은 닫히지 않는다.
- 이슈 #46(작은 페이지가 SCALE에서 버려짐), #47(Java 스택 트레이스 노출)도 이 PR 밖이다.

## 검증

| 명령 | 결과 |
|---|---|
| `python3 -m unittest discover -s tests -p test_audiveris_runtime.py -v` (Dockerfile 수정 **전**) | Ran 12 tests — **FAILED (failures=1)** |
| 같은 명령 (수정 **후**) | Ran 12 tests — OK |
| `cd omr-service && python3 -m unittest discover -s tests -v` | Ran 26 tests — OK |
| 파일 직접 다운로드 후 `wc -c` / `shasum -a 256` | 23,466,654 bytes / `daa0c97d651c19fba3b25e81317cd697e9908c8208090c94c3905381c23fc047` — 핀과 일치 (코디네이터가 독립적으로 재확인) |
| `combine_tessdata` 분해 | legacy `inttemp`·`pffmtable`·`normproto`·`shapetable` + LSTM 데이터 동시 포함 확인 |

## 검증하지 못한 것 (중요)

- **Docker 이미지를 빌드하지 못했다.** 로컬 Docker 데몬 소켓이 없다(`unix:///Users/h0977/.docker/run/docker.sock`). 따라서 **교체된 모델로 Audiveris가 실제로 OCR에 성공하는지는 이 PR에서 검증되지 않았다.** 이슈 #49에 기록된 실증(같은 파일을 `TESSDATA_PREFIX`만 바꿔 재변환해 `<credit-words>` 4건을 정확히 읽음)이 근거이며, 이 PR은 그 실증을 이미지에 고정하는 변경이다.
- **`omr-service/tests`는 어떤 CI 워크플로에서도 실행되지 않는다.** `.github/workflows/` 전체에 python/pytest 단계가 없다. 여기 추가한 테스트는 자동으로 아무것도 지켜주지 않으며, 사람이 돌려야 한다.

## baseline 차이

`docs/recovery/BASELINE.md` 기준선 대비 새 실패 없음. 이미지 크기가 911 MB에서 약 19 MB 증가한다 — 감수하는 비용이다.

## 위험

- 배포 시 이미지 재빌드가 필요하다. 재빌드 전까지 프로덕션 OCR은 여전히 죽어 있다.
- 4.1.0 태그의 파일이 사라지면 빌드가 실패한다. 체크섬 핀은 내용 변조는 막지만 가용성은 보장하지 않는다.

## rollback

Dockerfile의 `curl` + `sha256sum -c` + `install` 세 줄과 세 `ARG`를 되돌리고 이미지를 재빌드하면 이전 동작(OCR 죽음)으로 돌아간다. 애플리케이션 코드는 바뀌지 않았다.