### PR TITLE
Fix 88-key black-key layout coordinates

### DIFF
--- a/src/components/piano/SimplePianoKeyboard.tsx
+++ b/src/components/piano/SimplePianoKeyboard.tsx
@@ -59,7 +59,7 @@ export default function SimplePianoKeyboard({
                 : 'bg-black hover:bg-gray-800'
             }`}
             style={{
-              left: pos.x + pos.w * 0.2,
+              left: pos.x,
               top: 0,
               width: pos.w,
               height: '64%',

--- a/src/components/piano/__tests__/SimplePianoKeyboard.test.tsx
+++ b/src/components/piano/__tests__/SimplePianoKeyboard.test.tsx
@@ -1,0 +1,25 @@
+import { render } from '@testing-library/react';
+import SimplePianoKeyboard from '../SimplePianoKeyboard';
+import { notesToVisualNotes } from '@/utils/visualUtils';
+import { buildKeyLayout } from '@/utils/pianoLayout';
+
+describe('SimplePianoKeyboard', () => {
+  it('uses the same canonical black-key x as falling notes', () => {
+    const layout = buildKeyLayout(20);
+    const blackKey = layout.byMidi.get(22); // A#0
+    const visualNote = notesToVisualNotes(
+      [{ midi: 22, start: 0, duration: 1 }],
+      0,
+      100,
+      400,
+      layout
+    )[0];
+    const { container } = render(<SimplePianoKeyboard layout={layout} />);
+    const renderedBlackKey = container.querySelector<HTMLElement>('.bg-black');
+
+    expect(blackKey).toBeDefined();
+    expect(renderedBlackKey).not.toBeNull();
+    expect(Number.parseFloat(renderedBlackKey!.style.left)).toBe(blackKey!.x);
+    expect(visualNote.x).toBe(blackKey!.x);
+  });
+});

--- a/src/components/piano/__tests__/SimplePianoKeyboard.test.tsx
+++ b/src/components/piano/__tests__/SimplePianoKeyboard.test.tsx
@@ -1,25 +1,55 @@
 import { render } from '@testing-library/react';
 import SimplePianoKeyboard from '../SimplePianoKeyboard';
 import { notesToVisualNotes } from '@/utils/visualUtils';
-import { buildKeyLayout } from '@/utils/pianoLayout';
+import { A0_MIDI, C8_MIDI, buildKeyLayout } from '@/utils/pianoLayout';
 
 describe('SimplePianoKeyboard', () => {
-  it('uses the same canonical black-key x as falling notes', () => {
-    const layout = buildKeyLayout(20);
-    const blackKey = layout.byMidi.get(22); // A#0
-    const visualNote = notesToVisualNotes(
-      [{ midi: 22, start: 0, duration: 1 }],
+  it('centers every falling note over its key while keys keep canonical x', () => {
+    const layout = buildKeyLayout(24);
+    const notes = Array.from(
+      { length: C8_MIDI - A0_MIDI + 1 },
+      (_, index) => ({
+        midi: A0_MIDI + index,
+        start: 0,
+        duration: 1
+      })
+    );
+    const visualNotes = notesToVisualNotes(
+      notes,
       0,
       100,
       400,
       layout
-    )[0];
+    );
     const { container } = render(<SimplePianoKeyboard layout={layout} />);
+    const renderedWhiteKey = container.querySelector<HTMLElement>('.bg-white');
     const renderedBlackKey = container.querySelector<HTMLElement>('.bg-black');
 
-    expect(blackKey).toBeDefined();
+    expect(visualNotes).toHaveLength(88);
+    expect(renderedWhiteKey).not.toBeNull();
     expect(renderedBlackKey).not.toBeNull();
-    expect(Number.parseFloat(renderedBlackKey!.style.left)).toBe(blackKey!.x);
-    expect(visualNote.x).toBe(blackKey!.x);
+    expect(Number.parseFloat(renderedWhiteKey!.style.left)).toBe(
+      layout.byMidi.get(A0_MIDI)!.x
+    );
+    expect(Number.parseFloat(renderedBlackKey!.style.left)).toBe(
+      layout.byMidi.get(A0_MIDI + 1)!.x
+    );
+
+    let centeredWhiteKeys = 0;
+    let centeredBlackKeys = 0;
+
+    notes.forEach((note, index) => {
+      const key = layout.byMidi.get(note.midi)!;
+      const visualNote = visualNotes[index];
+      const keyCenter = key.x + key.w / 2;
+      const noteCenter = visualNote.x + visualNote.w / 2;
+
+      expect(noteCenter).toBeCloseTo(keyCenter, 10);
+      if (key.black) centeredBlackKeys++;
+      else centeredWhiteKeys++;
+    });
+
+    expect(centeredWhiteKeys).toBe(52);
+    expect(centeredBlackKeys).toBe(36);
   });
 });

--- a/src/utils/__tests__/pianoLayout.test.ts
+++ b/src/utils/__tests__/pianoLayout.test.ts
@@ -1,0 +1,90 @@
+import { A0_MIDI, C8_MIDI, buildKeyLayout } from '../pianoLayout';
+
+const KEY_WIDTH = 20;
+const BLACK_KEY_PITCH_CLASSES = new Set([1, 3, 6, 8, 10]);
+
+describe('buildKeyLayout', () => {
+  const layout = buildKeyLayout(KEY_WIDTH);
+  const keys = [...layout.byMidi.entries()].map(([midi, position]) => ({
+    midi,
+    ...position
+  }));
+  const whiteKeys = keys.filter(key => !key.black);
+  const blackKeys = keys.filter(key => key.black);
+
+  it('builds all 88 piano keys from A0 through C8', () => {
+    expect(keys).toHaveLength(88);
+    expect(whiteKeys).toHaveLength(52);
+    expect(blackKeys).toHaveLength(36);
+    expect(Math.min(...keys.map(key => key.midi))).toBe(A0_MIDI);
+    expect(Math.max(...keys.map(key => key.midi))).toBe(C8_MIDI);
+  });
+
+  it('keeps left-to-right x order identical to ascending MIDI order', () => {
+    const midiByX = [...keys]
+      .sort((left, right) => left.x - right.x)
+      .map(key => key.midi);
+
+    expect(midiByX).toEqual(
+      Array.from({ length: 88 }, (_, index) => A0_MIDI + index)
+    );
+  });
+
+  it('centers every black key near the boundary of its adjacent white keys', () => {
+    for (const blackKey of blackKeys) {
+      const leftWhiteKey = layout.byMidi.get(blackKey.midi - 1);
+      const rightWhiteKey = layout.byMidi.get(blackKey.midi + 1);
+
+      expect(leftWhiteKey?.black).toBe(false);
+      expect(rightWhiteKey?.black).toBe(false);
+
+      const boundary = leftWhiteKey!.x + leftWhiteKey!.w;
+      const center = blackKey.x + blackKey.w / 2;
+      expect(Math.abs(center - boundary)).toBeLessThanOrEqual(
+        KEY_WIDTH * 0.35
+      );
+      expect(rightWhiteKey!.x).toBe(boundary);
+    }
+  });
+
+  it('does not overlap black keys', () => {
+    const blackKeysByX = [...blackKeys].sort((left, right) => left.x - right.x);
+
+    for (let index = 1; index < blackKeysByX.length; index++) {
+      const previous = blackKeysByX[index - 1];
+      const current = blackKeysByX[index];
+      expect(previous.x + previous.w).toBeLessThanOrEqual(current.x);
+    }
+  });
+
+  it('keeps every key inside the keyboard width', () => {
+    for (const key of keys) {
+      expect(key.x).toBeGreaterThanOrEqual(0);
+      expect(key.x + key.w).toBeLessThanOrEqual(layout.totalWidth);
+    }
+  });
+
+  it('does not place black keys between E-F or B-C', () => {
+    for (const key of keys) {
+      if (key.black) {
+        expect(BLACK_KEY_PITCH_CLASSES).toContain(key.midi % 12);
+      }
+
+      const pitchClass = key.midi % 12;
+      if (!key.black && (pitchClass === 4 || pitchClass === 11)) {
+        expect(layout.byMidi.get(key.midi + 1)?.black).toBe(false);
+      }
+    }
+  });
+
+  it('keeps the empty gap between adjacent black keys within 1.5 white-key widths', () => {
+    const blackKeysByX = [...blackKeys].sort((left, right) => left.x - right.x);
+
+    for (let index = 1; index < blackKeysByX.length; index++) {
+      const previous = blackKeysByX[index - 1];
+      const current = blackKeysByX[index];
+      const gap = current.x - (previous.x + previous.w);
+      expect(gap).toBeLessThanOrEqual(KEY_WIDTH * 1.5);
+    }
+  });
+});

--- a/src/utils/pianoLayout.ts
+++ b/src/utils/pianoLayout.ts
@@ -58,13 +58,13 @@ export function buildKeyLayout(keyWidth: number): KeyLayout {
       const leftWhiteIndex = leftWhiteKeys.length - 1;
       const baseX = Math.max(0, leftWhiteIndex) * keyWidth;
       
-      // Black key offset patterns within each octave
+      // Black key offsets relative to the white key on the left
       const offsets: Record<number, number> = {
         1: 0.65,  // C#
-        3: 1.6,   // D#
-        6: 3.65,  // F#
-        8: 4.6,   // G#
-        10: 5.6   // A#
+        3: 0.6,   // D#
+        6: 0.65,  // F#
+        8: 0.6,   // G#
+        10: 0.6   // A#
       };
       
       const x = baseX + (offsets[pitchClass] ?? 0.5) * keyWidth;

--- a/src/utils/visualUtils.ts
+++ b/src/utils/visualUtils.ts
@@ -46,8 +46,8 @@ export function notesToVisualNotes(
     if (!keyPos) continue; // Skip invalid MIDI numbers
     
     // Calculate visual properties
-    const x = keyPos.x;
     const width = keyPos.black ? keyPos.w * 0.75 : keyPos.w * 0.92;
+    const x = keyPos.x + (keyPos.w - width) / 2;
     const color = getHandColor(note.hand);
     const zIndex = keyPos.black ? 30 : 20; // Black key notes on top
     

--- a/src/utils/visualUtils.ts
+++ b/src/utils/visualUtils.ts
@@ -46,7 +46,7 @@ export function notesToVisualNotes(
     if (!keyPos) continue; // Skip invalid MIDI numbers
     
     // Calculate visual properties
-    const x = keyPos.x + (keyPos.black ? keyPos.w * 0.2 : 0);
+    const x = keyPos.x;
     const width = keyPos.black ? keyPos.w * 0.75 : keyPos.w * 0.92;
     const color = getHandColor(note.hand);
     const zIndex = keyPos.black ? 30 : 20; // Black key notes on top


### PR DESCRIPTION
## Purpose

88건반 레이아웃의 검은건반 좌표가 MIDI 순서와 흰건반 경계를 따르도록 수정하고, 폭이 더 좁은 낙하 노트를 해당 건반 중심에 맞춥니다.

Closes #56

## Recovery phase

- Phase: P1-A 후속 정확도 결함, bounded issue fix
- Phase document: `docs/recovery/phases/P1-A-upload-pipeline.md`

## Scope

- Included: 검은건반 상대 오프셋 교정, 건반/낙하 노트의 `* 0.2` 보정 제거, 낙하 노트 중심 정렬, 88건반 불변식 7개와 소비자 중심 계약 회귀 테스트
- Explicitly excluded: 실제 피아노의 정밀 비대칭 및 `PianoKeyboard.tsx`와의 통일(이슈 #58), 참조 없는 `EnhancedPianoKeyboard`, 오디오·타이밍·컨테이너 폭, package scripts와 README 명령 안내

## Key decisions

- 왼쪽 흰건반 기준 `0.65/0.6/0.65/0.6/0.6`은 최대 5칸 밀림을 없애는 근사값이다. 원래 표와 이 값은 실제 피아노 비대칭이 아니며, 커밋 `299951d`의 “keeps the original asymmetric placement” 표현은 부정확하다.
- 실제 중심 편차는 C# -0.10, D# +0.10, F# -0.15, G# 0.00, A# +0.15칸이지만 현재 값은 모두 -0.05~-0.10칸이다. 실제 좌변 오프셋 `0.611/0.806/0.563/0.709/0.854`, 검은건반 폭 0.583칸, `PianoKeyboard.tsx` 통일은 이슈 #58에서 다룬다.
- `KeyLayout.x`는 건반 좌변이다. 건반은 그 좌변에 렌더하고, 폭이 더 좁은 낙하 노트는 `keyPos.x + (keyPos.w - width) / 2`로 건반 중심에 맞춘다.
- 존재하지 않는 `npm run type-check` 스크립트는 이 PR의 단일 목적 밖이므로 추가하지 않고, 실제 타입 검사는 `npx tsc --noEmit`으로 수행한다.

## Validation

| Check | Result | Evidence record |
|---|---|---|
| Coordinate regression | 수정 전 2 suites failed, 5 failed / 3 passed; 수정 후 2 suites / 8 passed | `docs/recovery/validation/2026-08-24-issue-56-piano-black-key-layout.md` |
| Center regression | 구현 전 1 suite / 1 test FAIL(A0 중심 12px 대 11.04px); 구현 후 흰건반 52개와 검은건반 36개 모두 중심 일치 | 같은 validation record |
| Type check | `npm run type-check`는 script 부재; `npx tsc --noEmit` exit 0 | 같은 validation record |
| Lint | `npm run lint` PASS, warnings/errors 0 | 같은 validation record |
| Unit tests | `npm test -- --runInBand`: 50 suites / 457 passed | 같은 validation record |
| Hosted CI | head `db9801e` checks 17개 모두 PASS (E2E 두 작업 포함) | PR checks |
| Manual/E2E | 좌표 재계산 PASS; 브라우저 수동 스크린샷 비교는 미실행 | 같은 validation record |

## Baseline difference

- Fixed failures: x/MIDI 순서 위반 7쌍→0, 오른쪽 폭 초과→0, 최대 검은건반 빈 간격 49px→29px(`keyWidth=20`), 모든 88건반 낙하 노트 중심=건반 중심
- Remaining known differences: 실제 피아노 비대칭 정밀도와 `PianoKeyboard.tsx` 좌표계 통일은 #58; `README.md:446`은 package에 없는 `npm run type-check`를 안내함
- Evidence records: `docs/recovery/validation/2026-08-24-issue-56-piano-black-key-layout.md`, `docs/recovery/reviews/PR-57.md`
- New failures: 없음

## Risks and rollback

- Risks: 검은건반과 낙하 노트의 가로 위치만 바뀐다. 회귀 테스트는 MIDI 순서/범위/간격과 88개 노트의 중심 계약을 함께 고정한다.
- Rollback: `db9801e`와 `299951d`를 역순으로 revert하면 코드와 회귀 테스트가 함께 이전 상태로 복구된다.

## Review checklist

- [x] The PR contains one phase or one bounded objective.
- [x] The PR was created review-ready and is not a draft.
- [x] Existing user-owned changes are excluded.
- [x] Handoff and validation records are current.
- [x] Canonical handoff, validation, and review evidence are stored inside the project.
- [x] No type, lint, or test failure is hidden by configuration.
- [x] Every actionable review comment is tracked in `docs/recovery/reviews/`.
- [x] Merge is deferred until the user explicitly approves this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 검은 건반의 위치 계산을 조정해 건반과 음표가 정확히 정렬되도록 개선했습니다.
  * 모든 건반에서 falling note가 건반 폭의 중앙에 표시됩니다.

* **테스트**
  * 88건반 레이아웃, 건반 간격 및 음표 위치 정렬에 대한 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->