### PR TITLE
Persist OMR results after the upload page is left

### DIFF
--- a/docs/recovery/DECISIONS.md
+++ b/docs/recovery/DECISIONS.md
@@ -366,3 +366,47 @@
   - 음역을 넓히기 위해 노트를 필터링하거나, 재생 시각을 레이아웃 계산에 넣지 않는다.
   - 새 운지 데이터를 생성하기 전까지 배지 임계값을 반응형 폭의 하한으로 오인하지 않는다.
 - Related: 이슈 [#65](https://github.com/landfill/ClairKeys/issues/65), `src/utils/pianoLayout.ts`, `src/components/animation/FallingNotesPlayer.tsx`
+
+## D-018: OMR 완료 저장은 생산자 callback이 트리거하고 브라우저 폴링은 fallback으로 둔다
+
+- Date: 2026-08-28
+- Status: Accepted
+- Context:
+  - D-011은 스토리지 자격증명을 OMR 서비스에서 제거하고 Next.js만 결과를 저장하게 했다. 그러나
+    저장 코드를 `/api/omr/status/[jobId]`에만 둬서, 완료 저장의 유일한 트리거가 브라우저의 5초
+    폴링이 됐다. 업로드 화면을 벗어나면 interval이 해제되고 VM이 변환을 끝내도 결과는 메모리에
+    남은 채 DB 행이 영구히 `processing`에 고착된다.
+  - OMR 서비스는 정확한 완료 시점과 job id를 이미 알고 있으며, 양쪽에는 `OMR_SHARED_SECRET`이
+    이미 배포되어 있다. 완료 사실만 알리는 데 새 자격증명이나 주기적 전수 조회가 필요하지 않다.
+- Decision:
+  1. Next.js 업로드 경로가 `/process` multipart에 canonical callback URL을 함께 보낸다. URL은
+     `NEXTAUTH_URL`을 우선하고 없으면 현재 요청 origin을 쓰며, 행을 만들기 전에 절대 URL로
+     검증한다.
+  2. OMR 서비스는 변환 완료 뒤 callback에 `{job_id}`를 POST하고 기존 공유 비밀을
+     `X-ClairKeys-Token`으로 보낸다. callback 실패는 지수 backoff로 12회 재시도한다.
+  3. callback은 공유 비밀을 constant-time으로 검증하고, job id로 DB 행을 찾아 `/result`를
+     수거한 뒤 Next.js에만 있는 service-role key로 저장한다. 저장 경로는 D-011의 job-derived
+     upsert를 그대로 사용한다.
+  4. 기존 사용자 세션 기반 status poll은 삭제하지 않는다. callback과 경합하거나 재호출돼도
+     이미 `animationDataUrl`이 있으면 즉시 성공하고, 같은 job은 같은 객체 키에 upsert하므로
+     브라우저·callback 모두 안전한 fallback이다.
+- Reason: 완료를 가장 먼저 아는 생산자가 정확히 한 job을 알리는 것이, 브라우저 수명주기나
+  모든 미완료 행을 훑는 주기 작업보다 직접적이다. 저장 권한과 저장 트리거를 분리해 D-011의
+  credential boundary도 유지한다.
+- Rejected:
+  - OMR 서비스가 Supabase에 직접 저장 | D-011을 되돌리고 공인 IP VM에 service-role key를 둔다.
+  - 브라우저 polling만 유지 | 화면 이탈이 저장 가능 여부를 결정하는 현재 결함을 보존한다.
+  - Vercel cron이 미완료 행을 주기적으로 전수 조회 | 정확한 완료 시점을 아는 생산자가 있는데도
+    지연과 불필요한 조회를 만들고, 배포 plan의 cron 주기 제약에 동작을 의존시킨다.
+- Consequence:
+  - callback 재시도와 job 결과는 여전히 OMR 프로세스 메모리에 있다. VM 재시작까지 견디는 영속
+    전달은 P1-B의 queue 범위이며, 이 결정은 화면 이탈 결함만 제거한다.
+  - 12회가 모두 실패하면 `delivery_status=failed`가 되지만 결과는 `/result/{job_id}`에 남아
+    브라우저 polling 또는 운영자 재수거가 가능하다. 이를 영속 큐 완료로 표현하지 않는다.
+- Directive:
+  - callback endpoint에 사용자 세션을 요구하지 않는다. 인증 경계는 OMR 공유 비밀이다.
+  - callback을 이유로 OMR 서비스에 스토리지 자격증명을 추가하지 않는다.
+  - callback URL을 행 생성 뒤에 처음 검증하지 않는다. 잘못된 URL로 job 없는 `processing` 행을
+    다시 만들게 된다.
+- Related: D-010, D-011, 이슈 [#55](https://github.com/landfill/ClairKeys/issues/55),
+  `src/app/api/omr/finalize/route.ts`, `omr-service/app.py`

--- a/docs/recovery/DECISIONS.md
+++ b/docs/recovery/DECISIONS.md
@@ -386,7 +386,8 @@
      `X-ClairKeys-Token`으로 보낸다. callback 실패는 지수 backoff로 12회 재시도한다.
   3. callback은 공유 비밀을 constant-time으로 검증하고, job id로 DB 행을 찾아 `/result`를
      수거한 뒤 Next.js에만 있는 service-role key로 저장한다. 저장 경로는 D-011의 job-derived
-     upsert를 그대로 사용한다.
+     upsert를 그대로 사용한다. request의 job id는 서비스 계약인 UUID만 허용하고, 실제
+     `/result` fetch에는 request 문자열이 아니라 DB에서 다시 읽은 `omrJobId`를 사용한다.
   4. 기존 사용자 세션 기반 status poll은 삭제하지 않는다. callback과 경합하거나 재호출돼도
      이미 `animationDataUrl`이 있으면 즉시 성공하고, 같은 job은 같은 객체 키에 upsert하므로
      브라우저·callback 모두 안전한 fallback이다.
@@ -408,5 +409,7 @@
   - callback을 이유로 OMR 서비스에 스토리지 자격증명을 추가하지 않는다.
   - callback URL을 행 생성 뒤에 처음 검증하지 않는다. 잘못된 URL로 job 없는 `processing` 행을
     다시 만들게 된다.
+  - request body의 문자열을 `/result` URL에 직접 이어 붙이지 않는다. UUID로 검증해 행을 찾은 뒤
+    DB에 저장된 job id를 fetch target으로 사용한다.
 - Related: D-010, D-011, 이슈 [#55](https://github.com/landfill/ClairKeys/issues/55),
   `src/app/api/omr/finalize/route.ts`, `omr-service/app.py`

--- a/omr-service/app.py
+++ b/omr-service/app.py
@@ -14,6 +14,7 @@ import aiofiles
 import asyncio
 from datetime import datetime
 import math
+import httpx
 import uuid
 from pathlib import Path
 import logging
@@ -121,6 +122,7 @@ async def process_pdf(
     user_id: Optional[str] = Form(None),
     sheet_music_id: Optional[str] = Form(None),
     tempo: Optional[float] = Form(None),
+    callback_url: Optional[str] = Form(None),
 ):
     """
     Process PDF sheet music to ClairKeys animation data
@@ -157,11 +159,12 @@ async def process_pdf(
             "user_id": user_id,
             "sheet_music_id": sheet_music_id,
             "tempo": tempo,
+            "callback_url": callback_url,
         }
     }
     
     # Start background processing
-    background_tasks.add_task(process_pdf_background, job_id, file, title, composer, user_id, tempo)
+    background_tasks.add_task(process_pdf_background, job_id, file, title, composer, user_id, tempo, callback_url)
     
     return {
         "job_id": job_id,
@@ -226,6 +229,64 @@ async def get_processing_result(
         "processed_at": job["result"]["processed_at"],
     }
 
+async def notify_completion(callback_url: Optional[str], job_id: str) -> None:
+    """Deliver completion until the Next.js side has persisted the result.
+
+    This is intentionally an in-process retry loop, matching the service's
+    existing in-memory job store. A process restart still loses both the job
+    and its delivery task, but browser navigation no longer does. The shared
+    secret authenticates the callback; storage credentials remain on Next.js.
+    """
+    if not callback_url:
+        logger.warning("No completion callback configured for job %s", job_id)
+        return
+
+    secret = (os.getenv("OMR_SHARED_SECRET") or "").strip()
+    if not secret:
+        logger.error("Cannot deliver completion for job %s without OMR_SHARED_SECRET", job_id)
+        return
+
+    delay_seconds = 1
+    max_attempts = 12
+    processing_jobs[job_id]["delivery_status"] = "pending"
+
+    for attempt in range(1, max_attempts + 1):
+        try:
+            async with httpx.AsyncClient(timeout=30.0) as client:
+                response = await client.post(
+                    callback_url,
+                    json={"job_id": job_id},
+                    headers={"X-ClairKeys-Token": secret},
+                )
+            if 200 <= response.status_code < 300:
+                processing_jobs[job_id]["delivery_status"] = "delivered"
+                logger.info("Delivered completed job %s to %s", job_id, callback_url)
+                return
+            logger.error(
+                "Completion callback for job %s returned %s: %s",
+                job_id,
+                response.status_code,
+                response.text,
+            )
+        except Exception as error:
+            logger.error("Completion callback for job %s failed: %s", job_id, error)
+
+        if attempt == max_attempts:
+            processing_jobs[job_id]["delivery_status"] = "failed"
+            logger.error(
+                "Giving up completion delivery for job %s after %s attempts; "
+                "the result remains available through GET /result/%s",
+                job_id,
+                max_attempts,
+                job_id,
+            )
+            return
+
+        processing_jobs[job_id]["delivery_status"] = "retrying"
+        await asyncio.sleep(delay_seconds)
+        delay_seconds = min(delay_seconds * 2, 60)
+
+
 async def process_pdf_background(
     job_id: str,
     file: UploadFile,
@@ -233,6 +294,7 @@ async def process_pdf_background(
     composer: Optional[str], 
     user_id: Optional[str],
     tempo: Optional[float],
+    callback_url: Optional[str],
 ):
     """Background task for processing PDF"""
     try:
@@ -291,6 +353,12 @@ async def process_pdf_background(
         shutil.rmtree(temp_dir, ignore_errors=True)
         
         logger.info(f"Successfully completed job {job_id}")
+
+        # The browser may have navigated away hours ago. Delivery is owned by
+        # the producer and retries across transient failures. If delivery is
+        # exhausted, the payload remains collectable through the existing
+        # browser/manual fallback.
+        await notify_completion(callback_url, job_id)
         
     except Exception as e:
         logger.error(f"Error processing job {job_id}: {str(e)}")

--- a/omr-service/app.py
+++ b/omr-service/app.py
@@ -26,6 +26,13 @@ logger = logging.getLogger(__name__)
 
 from omr.audiveris import AudiverisProcessor
 from omr.auth import SharedSecretError, verify_shared_secret
+from omr.delivery import (
+    CALLBACK_TIMEOUT_SECONDS,
+    INITIAL_BACKOFF_SECONDS,
+    MAX_DELIVERY_ATTEMPTS,
+    is_retryable_status,
+    next_backoff_seconds,
+)
 from omr.converter import MusicXMLToClairKeysConverter
 
 # Initialize FastAPI app
@@ -246,13 +253,12 @@ async def notify_completion(callback_url: Optional[str], job_id: str) -> None:
         logger.error("Cannot deliver completion for job %s without OMR_SHARED_SECRET", job_id)
         return
 
-    delay_seconds = 1
-    max_attempts = 12
+    delay_seconds = INITIAL_BACKOFF_SECONDS
     processing_jobs[job_id]["delivery_status"] = "pending"
 
-    for attempt in range(1, max_attempts + 1):
+    for attempt in range(1, MAX_DELIVERY_ATTEMPTS + 1):
         try:
-            async with httpx.AsyncClient(timeout=30.0) as client:
+            async with httpx.AsyncClient(timeout=CALLBACK_TIMEOUT_SECONDS) as client:
                 response = await client.post(
                     callback_url,
                     json={"job_id": job_id},
@@ -268,23 +274,37 @@ async def notify_completion(callback_url: Optional[str], job_id: str) -> None:
                 response.status_code,
                 response.text,
             )
+            if not is_retryable_status(response.status_code):
+                # The answer will not change. Say so now, in the log, rather
+                # than after ten minutes of backoff that only look like a
+                # network problem.
+                processing_jobs[job_id]["delivery_status"] = "failed"
+                logger.error(
+                    "Completion callback for job %s was rejected permanently "
+                    "with %s; not retrying. The result remains available "
+                    "through GET /result/%s",
+                    job_id,
+                    response.status_code,
+                    job_id,
+                )
+                return
         except Exception as error:
             logger.error("Completion callback for job %s failed: %s", job_id, error)
 
-        if attempt == max_attempts:
+        if attempt == MAX_DELIVERY_ATTEMPTS:
             processing_jobs[job_id]["delivery_status"] = "failed"
             logger.error(
                 "Giving up completion delivery for job %s after %s attempts; "
                 "the result remains available through GET /result/%s",
                 job_id,
-                max_attempts,
+                MAX_DELIVERY_ATTEMPTS,
                 job_id,
             )
             return
 
         processing_jobs[job_id]["delivery_status"] = "retrying"
         await asyncio.sleep(delay_seconds)
-        delay_seconds = min(delay_seconds * 2, 60)
+        delay_seconds = next_backoff_seconds(delay_seconds)
 
 
 async def process_pdf_background(
@@ -354,12 +374,6 @@ async def process_pdf_background(
         
         logger.info(f"Successfully completed job {job_id}")
 
-        # The browser may have navigated away hours ago. Delivery is owned by
-        # the producer and retries across transient failures. If delivery is
-        # exhausted, the payload remains collectable through the existing
-        # browser/manual fallback.
-        await notify_completion(callback_url, job_id)
-        
     except Exception as e:
         logger.error(f"Error processing job {job_id}: {str(e)}")
         processing_jobs[job_id]["status"] = ProcessingStatus.FAILED
@@ -371,6 +385,28 @@ async def process_pdf_background(
         if temp_dir.exists():
             import shutil
             shutil.rmtree(temp_dir, ignore_errors=True)
+
+    else:
+        # The browser may have navigated away hours ago. Delivery is owned by
+        # the producer and retries across transient failures. If delivery is
+        # exhausted, the payload remains collectable through the existing
+        # browser/manual fallback.
+        #
+        # This sits in `else`, not in the `try` above, and that placement is
+        # the point: the job is already COMPLETED with its animation_data in
+        # memory, so a fault while *announcing* it must not reach the handler
+        # that writes FAILED. A completed job that could not be announced is
+        # still a completed job, and the browser fallback — the thing that
+        # exists to catch a missed callback — would otherwise be shown a
+        # failure for a score that is sitting right here. `else` also runs only
+        # when the conversion raised nothing, so a failed job announces
+        # nothing.
+        try:
+            await notify_completion(callback_url, job_id)
+        except Exception as delivery_error:
+            logger.error(
+                "Completion delivery raised for job %s: %s", job_id, delivery_error
+            )
 
 if __name__ == "__main__":
     port = int(os.getenv("PORT", 8000))

--- a/omr-service/omr/delivery.py
+++ b/omr-service/omr/delivery.py
@@ -1,0 +1,54 @@
+"""Retry policy for delivering a completed conversion to Next.js.
+
+`app.py` owns the HTTP call itself. What lives here is the part of delivery
+that can be wrong in an interesting way — how long to wait, how many times, and
+which answers are worth asking again about.
+
+This module imports stdlib only, for the same reason `auth.py` does: `app.py`
+needs fastapi and aiofiles, so anything that exists only inside it can be
+asserted from its source text but never actually run. A retry policy read from
+a test rather than executed by one is a policy nobody has checked.
+"""
+
+# The conversion is already finished and its payload is already in memory by
+# the time any of this runs. Delivery is therefore allowed to be patient: the
+# cost of another attempt is one request, and the cost of giving up early is a
+# score the user can only recover by returning to the upload page — which is
+# the exact dependency this delivery path exists to remove.
+MAX_DELIVERY_ATTEMPTS = 12
+INITIAL_BACKOFF_SECONDS = 1
+MAX_BACKOFF_SECONDS = 60
+
+# `src/app/api/omr/finalize/route.ts` declares `maxDuration = 60`, and the
+# `/result` fetch inside it may take 30s on its own before Storage is touched.
+# A client that gives up at 30s abandons a finalize that is still working and
+# retries a second later, so the same job runs finalize twice concurrently: two
+# `/result` fetches, two Storage uploads, two row updates. The job-derived
+# upsert keeps that correct, but it doubles the work in exactly the case that
+# was already slow. Outlast the consumer instead.
+CALLBACK_TIMEOUT_SECONDS = 70.0
+
+# Answers that do not become different because we asked again.
+#
+# 400 means the job id is not a UUID — this service generated it, so no amount
+# of waiting will reshape it. 401 means the shared secret does not match, which
+# is deployment configuration. Retrying either spends the full backoff budget
+# to arrive at the answer already in hand, and buries a configuration fault
+# under ten quiet minutes instead of surfacing it in the log at once.
+#
+# 404 is deliberately absent. `/api/omr/upload` writes `omrJobId` only after
+# `/process` answers, so a conversion that finishes quickly can deliver before
+# the row carries the id the callback looks it up by. That window closes on its
+# own within a retry or two, and treating it as permanent would lose precisely
+# the fastest jobs.
+PERMANENT_STATUS_CODES = frozenset({400, 401, 403, 422})
+
+
+def is_retryable_status(status_code: int) -> bool:
+    """True when asking again could plausibly produce a different answer."""
+    return status_code not in PERMANENT_STATUS_CODES
+
+
+def next_backoff_seconds(current_delay: int) -> int:
+    """Double the wait, but never past the ceiling."""
+    return min(current_delay * 2, MAX_BACKOFF_SECONDS)

--- a/omr-service/tests/test_service_contract.py
+++ b/omr-service/tests/test_service_contract.py
@@ -75,7 +75,7 @@ class ProcessEndpointContractTests(unittest.TestCase):
         """
         defaults = self._defaults_by_argument()
 
-        for field in ("title", "composer", "user_id"):
+        for field in ("title", "composer", "user_id", "callback_url"):
             with self.subTest(field=field):
                 self.assertIn(field, defaults, f"{field} is not a declared parameter")
                 self.assertEqual(
@@ -111,6 +111,16 @@ class ProcessEndpointContractTests(unittest.TestCase):
             "converter.convert(musicxml_path, title, composer, tempo)",
             APP_SOURCE,
         )
+
+    def test_callback_is_forwarded_through_the_background_task(self):
+        """Completion delivery must not depend on a mounted browser poller."""
+        self.assertIn(
+            "process_pdf_background, job_id, file, title, composer, user_id, tempo, callback_url",
+            APP_SOURCE,
+        )
+        self.assertIn("await notify_completion(callback_url, job_id)", APP_SOURCE)
+        self.assertIn("max_attempts = 12", APP_SOURCE)
+        self.assertIn('processing_jobs[job_id]["delivery_status"] = "failed"', APP_SOURCE)
 
     def test_invalid_tempo_is_rejected_as_bad_request(self):
         """Bad numeric text and values outside 20..400 must both be HTTP 400."""

--- a/omr-service/tests/test_service_contract.py
+++ b/omr-service/tests/test_service_contract.py
@@ -19,6 +19,7 @@ text. `omr/auth.py` imports stdlib only, so it is exercised for real.
 
 import ast
 import asyncio
+import re
 import unittest
 import xml.etree.ElementTree as ET
 from pathlib import Path
@@ -31,6 +32,7 @@ import sys
 if str(OMR_SERVICE_ROOT) not in sys.path:
     sys.path.insert(0, str(OMR_SERVICE_ROOT))
 
+from omr import delivery
 from omr.auth import SharedSecretError, verify_shared_secret
 from omr.converter import MusicXMLToClairKeysConverter
 
@@ -43,6 +45,31 @@ def _process_pdf_signature() -> ast.arguments:
         if isinstance(node, ast.AsyncFunctionDef) and node.name == "process_pdf":
             return node.args
     raise AssertionError("process_pdf is not defined in app.py")
+
+
+def _async_function(name: str) -> ast.AsyncFunctionDef:
+    tree = ast.parse(APP_SOURCE)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"{name} is not defined in app.py")
+
+
+def _calls_within(node: ast.AST, callee: str) -> bool:
+    """True when `callee` is invoked anywhere inside `node`."""
+    for child in ast.walk(node):
+        if isinstance(child, ast.Call):
+            func = child.func
+            if isinstance(func, ast.Name) and func.id == callee:
+                return True
+            if isinstance(func, ast.Attribute) and func.attr == callee:
+                return True
+    return False
+
+
+def _calls_within_body(body, callee: str) -> bool:
+    """True when `callee` is invoked anywhere inside a list of statements."""
+    return any(_calls_within(stmt, callee) for stmt in body)
 
 
 def _default_call_name(default: ast.expr) -> str:
@@ -113,14 +140,23 @@ class ProcessEndpointContractTests(unittest.TestCase):
         )
 
     def test_callback_is_forwarded_through_the_background_task(self):
-        """Completion delivery must not depend on a mounted browser poller."""
+        """Completion delivery must not depend on a mounted browser poller.
+
+        Asserted from the AST rather than from source text: the earlier version
+        of this test matched the literal argument list, so reordering a
+        parameter or running a formatter broke it while a `notify_completion`
+        that sent nothing still passed.
+        """
+        background = _async_function("process_pdf_background")
         self.assertIn(
-            "process_pdf_background, job_id, file, title, composer, user_id, tempo, callback_url",
-            APP_SOURCE,
+            "callback_url",
+            [arg.arg for arg in background.args.args],
+            "the background task cannot deliver a callback it never receives",
         )
-        self.assertIn("await notify_completion(callback_url, job_id)", APP_SOURCE)
-        self.assertIn("max_attempts = 12", APP_SOURCE)
-        self.assertIn('processing_jobs[job_id]["delivery_status"] = "failed"', APP_SOURCE)
+        self.assertTrue(
+            _calls_within(background, "notify_completion"),
+            "process_pdf_background never invokes notify_completion",
+        )
 
     def test_invalid_tempo_is_rejected_as_bad_request(self):
         """Bad numeric text and values outside 20..400 must both be HTTP 400."""
@@ -334,6 +370,150 @@ class SharedSecretVerificationTests(unittest.TestCase):
         environ["ENVIRONMENT"] = "development"
         with mock.patch.dict("os.environ", environ, clear=True):
             verify_shared_secret(None)
+
+
+class CompletionDeliveryTests(unittest.TestCase):
+    """Delivering a completed job must not be able to un-complete it.
+
+    `process_pdf_background` marks a job COMPLETED, fills in `animation_data`,
+    and only then announces it. Announcing is a separate concern with its own
+    failure modes — an unreachable Next.js host, a secret that does not match,
+    a callback URL that no longer resolves. None of those change the fact that
+    the conversion succeeded and the payload is sitting in memory ready for
+    `GET /result/{job_id}`.
+
+    The delivery call therefore may not sit inside the `try` whose handler
+    writes `status = FAILED`. If it does, a delivery fault rewrites a finished
+    job as a failed one and the browser fallback — the very thing that is
+    supposed to catch a missed callback — shows the user a failure for a score
+    that exists.
+    """
+
+    def _background_try(self) -> ast.Try:
+        background = _async_function("process_pdf_background")
+        tries = [n for n in background.body if isinstance(n, ast.Try)]
+        self.assertEqual(
+            len(tries), 1, "process_pdf_background should have exactly one top-level try"
+        )
+        return tries[0]
+
+    def test_the_failure_handler_marks_the_job_failed(self):
+        """Guards the premise of the test below.
+
+        If the handler stops writing FAILED, the containment test underneath
+        would pass for the wrong reason.
+        """
+        handler_source = "\n".join(
+            ast.unparse(h) for h in self._background_try().handlers
+        )
+        self.assertIn("ProcessingStatus.FAILED", handler_source)
+
+    def test_delivery_is_not_inside_the_block_that_can_fail_the_job(self):
+        node = self._background_try()
+
+        self.assertFalse(
+            _calls_within_body(node.body, "notify_completion"),
+            "notify_completion is inside the try whose handler writes FAILED; a "
+            "delivery fault would rewrite a completed job as failed",
+        )
+        self.assertTrue(
+            _calls_within_body(node.orelse, "notify_completion")
+            or _calls_within(_async_function("process_pdf_background"), "notify_completion"),
+            "the background task must still deliver the completion",
+        )
+
+    def test_delivery_runs_only_when_the_conversion_succeeded(self):
+        """A failed conversion has nothing to announce.
+
+        `else` is the placement that satisfies both halves: it runs only when
+        the `try` raised nothing, and an exception it raises is not caught by
+        the handler above it.
+        """
+        node = self._background_try()
+        self.assertTrue(
+            _calls_within_body(node.orelse, "notify_completion"),
+            "notify_completion should sit in the try's `else`, so it runs after "
+            "a successful conversion and never after a failed one",
+        )
+
+    def test_the_callback_client_outlives_the_route_it_calls(self):
+        """The producer's timeout must exceed the consumer's own budget.
+
+        `src/app/api/omr/finalize/route.ts` declares `maxDuration = 60`, and the
+        `/result` fetch inside it alone may take 30s before Storage is even
+        touched. A client that gives up at 30s abandons a finalize that is still
+        working and retries a second later, so the same job runs finalize twice
+        concurrently: two `/result` fetches, two Storage uploads, two row
+        updates. The upsert keeps that correct, but it doubles the work in
+        exactly the case that was already slow.
+        """
+        finalize_route = (
+            OMR_SERVICE_ROOT.parent
+            / "src/app/api/omr/finalize/route.ts"
+        ).read_text(encoding="utf-8")
+        match = re.search(r"maxDuration\s*=\s*(\d+)", finalize_route)
+        self.assertIsNotNone(match, "finalize route no longer declares maxDuration")
+        max_duration = int(match.group(1))
+
+        self.assertGreater(
+            delivery.CALLBACK_TIMEOUT_SECONDS,
+            max_duration,
+            "the callback client would abandon a finalize that is still running",
+        )
+
+
+class DeliveryRetryPolicyTests(unittest.TestCase):
+    """The retry policy is exercised for real — `omr/delivery.py` is stdlib only.
+
+    This is the part of delivery that can be wrong in an interesting way, so it
+    lives outside `app.py` where a test can actually run it rather than read it.
+    """
+
+    def test_a_permanent_rejection_is_not_retried(self):
+        """400 and 401 do not become true because we asked twelve more times.
+
+        400 means the job id is not a UUID — this service generated it, so it
+        will not change. 401 means the shared secret does not match, which is
+        deployment configuration. Retrying either spends ten minutes of backoff
+        to reach the conclusion already in hand, and buries a configuration
+        fault under a long quiet period instead of surfacing it.
+        """
+        for status in (400, 401, 403, 422):
+            with self.subTest(status=status):
+                self.assertFalse(delivery.is_retryable_status(status))
+
+    def test_a_missing_row_is_retried(self):
+        """404 is the upload race, not a permanent answer.
+
+        `/api/omr/upload` writes `omrJobId` only after `/process` answers, so a
+        conversion that finishes quickly can deliver before the row carries the
+        id the callback looks it up by. That window closes on its own within a
+        retry or two, which is why 404 must stay outside the permanent set.
+        """
+        self.assertTrue(delivery.is_retryable_status(404))
+
+    def test_transient_server_faults_are_retried(self):
+        for status in (409, 500, 502, 503, 504):
+            with self.subTest(status=status):
+                self.assertTrue(delivery.is_retryable_status(status))
+
+    def test_backoff_grows_then_settles_at_the_ceiling(self):
+        delay = delivery.INITIAL_BACKOFF_SECONDS
+        seen = [delay]
+        for _ in range(delivery.MAX_DELIVERY_ATTEMPTS):
+            delay = delivery.next_backoff_seconds(delay)
+            seen.append(delay)
+
+        self.assertEqual(seen[:7], [1, 2, 4, 8, 16, 32, 60])
+        self.assertTrue(all(d <= delivery.MAX_BACKOFF_SECONDS for d in seen))
+
+    def test_app_uses_the_shared_policy_rather_than_its_own(self):
+        """A second copy of the rule in `app.py` is how the two drift apart."""
+        notify = _async_function("notify_completion")
+        self.assertTrue(
+            _calls_within(notify, "is_retryable_status"),
+            "notify_completion must consult the shared retry policy",
+        )
 
 
 if __name__ == "__main__":

--- a/src/app/api/omr/finalize/__tests__/route.test.ts
+++ b/src/app/api/omr/finalize/__tests__/route.test.ts
@@ -1,0 +1,158 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { FileStorageService } from '@/services/fileStorageService'
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    sheetMusic: {
+      findFirst: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}))
+jest.mock('@/services/fileStorageService', () => ({
+  FileStorageService: {
+    getInstance: jest.fn(),
+  },
+}))
+
+const mockFindFirst = prisma.sheetMusic.findFirst as jest.Mock
+const mockUpdate = prisma.sheetMusic.update as jest.Mock
+const mockGetInstance = FileStorageService.getInstance as jest.Mock
+
+const JOB_ID = 'job-callback'
+const ANIMATION = {
+  version: '1.0',
+  notes: [{ midi: 60, start: 0, duration: 1, velocity: 0.8 }],
+}
+
+function callbackRequest(token = 'shared-secret'): NextRequest {
+  return new NextRequest('http://localhost:3000/api/omr/finalize', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'X-ClairKeys-Token': token,
+    },
+    body: JSON.stringify({ job_id: JOB_ID }),
+  })
+}
+
+function row(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 17,
+    userId: 'user-1',
+    animationDataUrl: '',
+    processingStatus: 'processing',
+    omrJobId: JOB_ID,
+    ...overrides,
+  }
+}
+
+describe('POST /api/omr/finalize — server-owned completion trigger', () => {
+  const originalUrl = process.env.OMR_SERVICE_URL
+  const originalSecret = process.env.OMR_SHARED_SECRET
+  let fetchSpy: jest.SpyInstance
+  let uploadOmrAnimationData: jest.Mock
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env.OMR_SERVICE_URL = 'https://omr.example.invalid'
+    process.env.OMR_SHARED_SECRET = 'shared-secret'
+    fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ job_id: JOB_ID, animation_data: ANIMATION }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    )
+    uploadOmrAnimationData = jest.fn().mockResolvedValue({
+      success: true,
+      url: 'https://project.supabase.co/storage/v1/object/public/animation-data/user-1/omr_job-callback.json',
+    })
+    mockGetInstance.mockReturnValue({ uploadOmrAnimationData })
+    mockFindFirst.mockResolvedValue(row())
+    mockUpdate.mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({
+      ...row(),
+      ...data,
+    }))
+  })
+
+  afterEach(() => {
+    fetchSpy.mockRestore()
+    if (originalUrl === undefined) delete process.env.OMR_SERVICE_URL
+    else process.env.OMR_SERVICE_URL = originalUrl
+    if (originalSecret === undefined) delete process.env.OMR_SHARED_SECRET
+    else process.env.OMR_SHARED_SECRET = originalSecret
+  })
+
+  it('collects and stores a completed result without a user session', async () => {
+    const { POST } = await import('../route')
+    const response = await POST(callbackRequest())
+
+    expect(response.status).toBe(200)
+    expect(mockFindFirst).toHaveBeenCalledWith({ where: { omrJobId: JOB_ID } })
+    expect(uploadOmrAnimationData).toHaveBeenCalledWith(JOB_ID, 'user-1', ANIMATION)
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { id: 17 },
+      data: expect.objectContaining({
+        processingStatus: 'completed',
+        animationDataUrl: expect.stringContaining('/animation-data/'),
+      }),
+    })
+  })
+
+  it('rejects a caller that does not know the service secret', async () => {
+    const { POST } = await import('../route')
+    const response = await POST(callbackRequest('wrong-secret'))
+
+    expect(response.status).toBe(401)
+    expect(mockFindFirst).not.toHaveBeenCalled()
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when the callback secret is not configured', async () => {
+    delete process.env.OMR_SHARED_SECRET
+
+    const { POST } = await import('../route')
+    const response = await POST(callbackRequest())
+
+    expect(response.status).toBe(503)
+    expect(mockFindFirst).not.toHaveBeenCalled()
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('is idempotent after another trigger has stored the result', async () => {
+    mockFindFirst.mockResolvedValue(
+      row({
+        animationDataUrl:
+          'https://project.supabase.co/storage/v1/object/public/animation-data/user-1/omr_job-callback.json',
+        processingStatus: 'completed',
+      })
+    )
+
+    const { POST } = await import('../route')
+    const response = await POST(callbackRequest())
+
+    expect(response.status).toBe(200)
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(uploadOmrAnimationData).not.toHaveBeenCalled()
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  it('retries a row previously marked failed when storage becomes available', async () => {
+    mockFindFirst.mockResolvedValue(row({ processingStatus: 'failed' }))
+
+    const { POST } = await import('../route')
+    const response = await POST(callbackRequest())
+
+    expect(response.status).toBe(200)
+    expect(uploadOmrAnimationData).toHaveBeenCalledTimes(1)
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ processingStatus: 'completed' }),
+      })
+    )
+  })
+})

--- a/src/app/api/omr/finalize/__tests__/route.test.ts
+++ b/src/app/api/omr/finalize/__tests__/route.test.ts
@@ -23,7 +23,7 @@ const mockFindFirst = prisma.sheetMusic.findFirst as jest.Mock
 const mockUpdate = prisma.sheetMusic.update as jest.Mock
 const mockGetInstance = FileStorageService.getInstance as jest.Mock
 
-const JOB_ID = 'job-callback'
+const JOB_ID = '123e4567-e89b-42d3-a456-426614174000'
 const ANIMATION = {
   version: '1.0',
   notes: [{ midi: 60, start: 0, duration: 1, velocity: 0.8 }],
@@ -69,7 +69,7 @@ describe('POST /api/omr/finalize — server-owned completion trigger', () => {
     )
     uploadOmrAnimationData = jest.fn().mockResolvedValue({
       success: true,
-      url: 'https://project.supabase.co/storage/v1/object/public/animation-data/user-1/omr_job-callback.json',
+      url: `https://project.supabase.co/storage/v1/object/public/animation-data/user-1/omr_${JOB_ID}.json`,
     })
     mockGetInstance.mockReturnValue({ uploadOmrAnimationData })
     mockFindFirst.mockResolvedValue(row())
@@ -112,6 +112,24 @@ describe('POST /api/omr/finalize — server-owned completion trigger', () => {
     expect(fetchSpy).not.toHaveBeenCalled()
   })
 
+  it('rejects a job identifier outside the service UUID contract', async () => {
+    const request = new NextRequest('http://localhost:3000/api/omr/finalize', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'X-ClairKeys-Token': 'shared-secret',
+      },
+      body: JSON.stringify({ job_id: '../status/other-job' }),
+    })
+
+    const { POST } = await import('../route')
+    const response = await POST(request)
+
+    expect(response.status).toBe(400)
+    expect(mockFindFirst).not.toHaveBeenCalled()
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
   it('fails closed when the callback secret is not configured', async () => {
     delete process.env.OMR_SHARED_SECRET
 
@@ -127,7 +145,7 @@ describe('POST /api/omr/finalize — server-owned completion trigger', () => {
     mockFindFirst.mockResolvedValue(
       row({
         animationDataUrl:
-          'https://project.supabase.co/storage/v1/object/public/animation-data/user-1/omr_job-callback.json',
+          `https://project.supabase.co/storage/v1/object/public/animation-data/user-1/omr_${JOB_ID}.json`,
         processingStatus: 'completed',
       })
     )

--- a/src/app/api/omr/finalize/route.ts
+++ b/src/app/api/omr/finalize/route.ts
@@ -1,0 +1,114 @@
+import { timingSafeEqual } from 'node:crypto'
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import {
+  fetchAndStoreOmrResult,
+  OmrFinalizationError,
+} from '@/lib/omr/finalizeJob'
+
+export const maxDuration = 60
+
+function callbackIsAuthorized(request: NextRequest): 'authorized' | 'missing-config' | 'unauthorized' {
+  const expected = process.env.OMR_SHARED_SECRET?.trim()
+  if (!expected) return 'missing-config'
+
+  const received = request.headers.get('X-ClairKeys-Token') ?? ''
+  const expectedBytes = Buffer.from(expected)
+  const receivedBytes = Buffer.from(received)
+
+  if (expectedBytes.length !== receivedBytes.length) return 'unauthorized'
+  return timingSafeEqual(expectedBytes, receivedBytes) ? 'authorized' : 'unauthorized'
+}
+
+/**
+ * Server-owned completion trigger for issue 55.
+ *
+ * The OMR service calls this after conversion. It carries no storage
+ * credential; this route collects `/result` and performs the D-011 write. The
+ * browser status route remains a fallback, but navigating away no longer
+ * removes the only trigger that can persist the score.
+ */
+export async function POST(request: NextRequest) {
+  const authorization = callbackIsAuthorized(request)
+  if (authorization === 'missing-config') {
+    return NextResponse.json(
+      { error: 'OMR callback authentication is not configured.' },
+      { status: 503 }
+    )
+  }
+  if (authorization === 'unauthorized') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'A JSON body is required.' }, { status: 400 })
+  }
+
+  const jobId =
+    typeof body === 'object' && body !== null && typeof (body as { job_id?: unknown }).job_id === 'string'
+      ? (body as { job_id: string }).job_id.trim()
+      : ''
+
+  if (!jobId) {
+    return NextResponse.json({ error: 'job_id is required.' }, { status: 400 })
+  }
+
+  const sheetMusic = await prisma.sheetMusic.findFirst({
+    where: { omrJobId: jobId },
+  })
+
+  if (!sheetMusic) {
+    return NextResponse.json({ error: 'Job not found.' }, { status: 404 })
+  }
+
+  if (sheetMusic.animationDataUrl) {
+    return NextResponse.json({
+      success: true,
+      jobId,
+      sheetMusicId: sheetMusic.id,
+      status: 'completed',
+      animationDataUrl: sheetMusic.animationDataUrl,
+      alreadyStored: true,
+    })
+  }
+
+  try {
+    const animationDataUrl = await fetchAndStoreOmrResult(jobId, sheetMusic.userId)
+    await prisma.sheetMusic.update({
+      where: { id: sheetMusic.id },
+      data: {
+        animationDataUrl,
+        processingStatus: 'completed',
+        updatedAt: new Date(),
+      },
+    })
+
+    return NextResponse.json({
+      success: true,
+      jobId,
+      sheetMusicId: sheetMusic.id,
+      status: 'completed',
+      animationDataUrl,
+      alreadyStored: false,
+    })
+  } catch (error) {
+    if (error instanceof OmrFinalizationError) {
+      if (error.code === 'ANIMATION_STORAGE_FAILED') {
+        await prisma.sheetMusic.update({
+          where: { id: sheetMusic.id },
+          data: { processingStatus: 'failed', updatedAt: new Date() },
+        })
+      }
+      return NextResponse.json(
+        { error: error.message, code: error.code },
+        { status: error.status }
+      )
+    }
+
+    console.error('OMR callback finalization failed:', jobId, error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/omr/finalize/route.ts
+++ b/src/app/api/omr/finalize/route.ts
@@ -8,6 +8,8 @@ import {
 
 export const maxDuration = 60
 
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
 function callbackIsAuthorized(request: NextRequest): 'authorized' | 'missing-config' | 'unauthorized' {
   const expected = process.env.OMR_SHARED_SECRET?.trim()
   if (!expected) return 'missing-config'
@@ -52,8 +54,8 @@ export async function POST(request: NextRequest) {
       ? (body as { job_id: string }).job_id.trim()
       : ''
 
-  if (!jobId) {
-    return NextResponse.json({ error: 'job_id is required.' }, { status: 400 })
+  if (!jobId || !UUID_PATTERN.test(jobId)) {
+    return NextResponse.json({ error: 'A valid job_id UUID is required.' }, { status: 400 })
   }
 
   const sheetMusic = await prisma.sheetMusic.findFirst({
@@ -62,6 +64,11 @@ export async function POST(request: NextRequest) {
 
   if (!sheetMusic) {
     return NextResponse.json({ error: 'Job not found.' }, { status: 404 })
+  }
+
+  const storedJobId = sheetMusic.omrJobId
+  if (!storedJobId) {
+    return NextResponse.json({ error: 'Stored job identifier is missing.' }, { status: 409 })
   }
 
   if (sheetMusic.animationDataUrl) {
@@ -76,7 +83,9 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const animationDataUrl = await fetchAndStoreOmrResult(jobId, sheetMusic.userId)
+    // Use the identifier read back from the database, not request input, for
+    // the server-side fetch target. The request value is only a lookup key.
+    const animationDataUrl = await fetchAndStoreOmrResult(storedJobId, sheetMusic.userId)
     await prisma.sheetMusic.update({
       where: { id: sheetMusic.id },
       data: {

--- a/src/app/api/omr/status/[jobId]/__tests__/route.test.ts
+++ b/src/app/api/omr/status/[jobId]/__tests__/route.test.ts
@@ -189,6 +189,36 @@ describe('GET /api/omr/status/[jobId] — the D-011 store', () => {
     }
   })
 
+  it('encodes the job id it puts in both service URLs', async () => {
+    // D-018 records the rule that closed the CodeQL alert on the `/result`
+    // call: a request-supplied string may not be pasted into a server-side
+    // fetch target unencoded. `/status` is the sibling call in this same
+    // handler and was left on the old shape, so the rule held for one of the
+    // two URLs this route builds.
+    //
+    // The value is constrained today — it has to match a row's `omrJobId`,
+    // which the service generates as a uuid4 — so this is the invariant, not a
+    // live hole. Pinning it here is what stops the next edit from widening it.
+    const AWKWARD = 'a/b?c#d'
+    mockFindFirst.mockResolvedValue(storedRow({ omrJobId: AWKWARD }))
+    respondCompleted()
+
+    const { GET } = await loadRoute()
+    await GET(
+      new NextRequest(`http://localhost:3000/api/omr/status/${encodeURIComponent(AWKWARD)}`),
+      { params: Promise.resolve({ jobId: AWKWARD }) }
+    )
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+    for (const call of fetchSpy.mock.calls) {
+      const url = new URL(String(call[0]))
+      // One segment, not four: the separators are data, not structure.
+      expect(url.pathname.split('/').filter(Boolean)).toHaveLength(2)
+      expect(url.pathname).toContain(encodeURIComponent(AWKWARD))
+      expect(url.search).toBe('')
+    }
+  })
+
   it('stores once when a second poll arrives after the first stored it', async () => {
     // Polling is a loop; the second poll sees a row that already has its URL.
     mockFindFirst.mockResolvedValue(

--- a/src/app/api/omr/status/[jobId]/route.ts
+++ b/src/app/api/omr/status/[jobId]/route.ts
@@ -70,7 +70,11 @@ export async function GET(
     // simply has no answer yet, and the stored status stays as it is.
     let statusResponse: Response
     try {
-      statusResponse = await fetch(`${getOmrServiceUrl()}/status/${jobId}`, {
+      // The identifier read back from the row, encoded as one path segment.
+      // D-018 records this rule for the `/result` call below; this is the
+      // sibling call in the same handler, and it was left on the old shape.
+      const statusUrl = `${getOmrServiceUrl()}/status/${encodeURIComponent(storedJobId)}`
+      statusResponse = await fetch(statusUrl, {
         headers: {
           'Content-Type': 'application/json',
           ...omrAuthHeaders()

--- a/src/app/api/omr/status/[jobId]/route.ts
+++ b/src/app/api/omr/status/[jobId]/route.ts
@@ -4,7 +4,7 @@ import { authOptions } from '@/lib/auth/config'
 import { prisma } from '@/lib/prisma'
 import type { Prisma } from '@prisma/client'
 import { getOmrServiceUrl, omrAuthHeaders, OmrServiceNotConfiguredError } from '@/lib/omr/serviceUrl'
-import { FileStorageService } from '@/services/fileStorageService'
+import { fetchAndStoreOmrResult, OmrFinalizationError } from '@/lib/omr/finalizeJob'
 
 /**
  * The completing poll does more than poll: it fetches the score from the OMR
@@ -170,62 +170,26 @@ export async function GET(
         // twice is normal, not an error.
         updateData.processingStatus = 'completed'
       } else {
-        let resultResponse: Response
         try {
-          resultResponse = await fetch(`${getOmrServiceUrl()}/result/${jobId}`, {
-            headers: {
-              'Content-Type': 'application/json',
-              ...omrAuthHeaders()
-            },
-            // The payload is a whole score, so this is not a status-poll timeout.
-            signal: AbortSignal.timeout(30000)
-          })
+          updateData.animationDataUrl = await fetchAndStoreOmrResult(jobId, userId)
+          updateData.processingStatus = 'completed'
         } catch (error) {
-          console.error('OMR result fetch failed:', jobId, error)
-          return NextResponse.json(
-            {
-              error: '변환 결과를 가져오지 못했습니다.',
-              code: 'OMR_RESULT_UNAVAILABLE'
-            },
-            { status: 503 }
-          )
+          if (error instanceof OmrFinalizationError) {
+            if (error.code === 'ANIMATION_STORAGE_FAILED') {
+              // A later service callback can retry this idempotent write and
+              // return the row to completed when storage recovers.
+              await prisma.sheetMusic.update({
+                where: { id: sheetMusic.id },
+                data: { processingStatus: 'failed', updatedAt: new Date() }
+              })
+            }
+            return NextResponse.json(
+              { error: error.message, code: error.code },
+              { status: error.status }
+            )
+          }
+          throw error
         }
-
-        if (!resultResponse.ok) {
-          console.error('OMR result error:', resultResponse.status, await resultResponse.text())
-          return NextResponse.json(
-            { error: '변환 결과를 가져오지 못했습니다.', code: 'OMR_RESULT_ERROR' },
-            { status: 502 }
-          )
-        }
-
-        const resultPayload = await resultResponse.json()
-
-        const stored = await FileStorageService.getInstance().uploadOmrAnimationData(
-          jobId,
-          userId,
-          resultPayload.animation_data
-        )
-
-        if (!stored.success || !stored.url) {
-          // Storage is the last step, and a job whose result cannot be stored has
-          // produced nothing a client can play. Fail it rather than leave it
-          // 'processing' forever against a service that will drop the payload.
-          await prisma.sheetMusic.update({
-            where: { id: sheetMusic.id },
-            data: { processingStatus: 'failed', updatedAt: new Date() }
-          })
-
-          console.error('OMR result storage failed:', jobId, stored.error)
-
-          return NextResponse.json(
-            { error: '변환 결과를 저장하지 못했습니다.', code: 'ANIMATION_STORAGE_FAILED' },
-            { status: 502 }
-          )
-        }
-
-        updateData.animationDataUrl = stored.url
-        updateData.processingStatus = 'completed'
       }
     } else if (omrStatus.status === 'failed') {
       // OMR processing failed

--- a/src/app/api/omr/status/[jobId]/route.ts
+++ b/src/app/api/omr/status/[jobId]/route.ts
@@ -57,6 +57,14 @@ export async function GET(
       )
     }
 
+    const storedJobId = sheetMusic.omrJobId
+    if (!storedJobId) {
+      return NextResponse.json(
+        { error: 'Stored job identifier is missing.' },
+        { status: 409 }
+      )
+    }
+
     // Get status from OMR service. As in the upload route, an unreachable or
     // unconfigured service must not read as an application error — the poll
     // simply has no answer yet, and the stored status stays as it is.
@@ -171,7 +179,7 @@ export async function GET(
         updateData.processingStatus = 'completed'
       } else {
         try {
-          updateData.animationDataUrl = await fetchAndStoreOmrResult(jobId, userId)
+          updateData.animationDataUrl = await fetchAndStoreOmrResult(storedJobId, userId)
           updateData.processingStatus = 'completed'
         } catch (error) {
           if (error instanceof OmrFinalizationError) {

--- a/src/app/api/omr/upload/__tests__/route.test.ts
+++ b/src/app/api/omr/upload/__tests__/route.test.ts
@@ -75,6 +75,7 @@ async function loadRoute() {
 
 describe('POST /api/omr/upload — failure is visible, not silent', () => {
   const originalUrl = process.env.OMR_SERVICE_URL
+  const originalNextAuthUrl = process.env.NEXTAUTH_URL
   let fetchSpy: jest.SpyInstance
 
   beforeEach(() => {
@@ -91,6 +92,8 @@ describe('POST /api/omr/upload — failure is visible, not silent', () => {
     fetchSpy.mockRestore()
     if (originalUrl === undefined) delete process.env.OMR_SERVICE_URL
     else process.env.OMR_SERVICE_URL = originalUrl
+    if (originalNextAuthUrl === undefined) delete process.env.NEXTAUTH_URL
+    else process.env.NEXTAUTH_URL = originalNextAuthUrl
   })
 
   it('marks the row failed when the OMR service is unreachable', async () => {
@@ -180,5 +183,38 @@ describe('POST /api/omr/upload — failure is visible, not silent', () => {
     expect(response.status).toBe(200)
     const [, requestInit] = fetchSpy.mock.calls[0]
     expect((requestInit?.body as FormData).get('tempo')).toBe('72')
+  })
+
+  it('gives the service a server callback that survives browser navigation', async () => {
+    process.env.OMR_SERVICE_URL = 'https://omr.example.invalid'
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ job_id: 'job-1', status: 'processing' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+
+    const { POST } = await loadRoute()
+    const response = await POST(uploadRequest())
+
+    expect(response.status).toBe(200)
+    const [, requestInit] = fetchSpy.mock.calls[0]
+    expect((requestInit?.body as FormData).get('callback_url')).toBe(
+      'http://localhost:3000/api/omr/finalize'
+    )
+  })
+
+  it('refuses an invalid public app URL before creating a row', async () => {
+    process.env.OMR_SERVICE_URL = 'https://omr.example.invalid'
+    process.env.NEXTAUTH_URL = 'not an absolute URL'
+
+    const { POST } = await loadRoute()
+    const response = await POST(uploadRequest())
+    const data = await response.json()
+
+    expect(response.status).toBe(503)
+    expect(data.code).toBe('OMR_CALLBACK_NOT_CONFIGURED')
+    expect(mockCreate).not.toHaveBeenCalled()
+    expect(fetchSpy).not.toHaveBeenCalled()
   })
 })

--- a/src/app/api/omr/upload/route.ts
+++ b/src/app/api/omr/upload/route.ts
@@ -125,6 +125,24 @@ export async function POST(request: NextRequest) {
       )
     }
 
+    // Resolve the callback before creating a row for the same reason as the
+    // service URL above: a malformed deployment URL is knowable now, while a
+    // row created first would have no job and no trigger capable of moving it.
+    let callbackUrl: string
+    try {
+      const callbackBaseUrl = process.env.NEXTAUTH_URL?.trim() || request.nextUrl.origin
+      callbackUrl = new URL('/api/omr/finalize', callbackBaseUrl).toString()
+    } catch (error) {
+      console.error('OMR callback refused: public application URL is invalid', error)
+      return NextResponse.json(
+        {
+          error: '완료 알림 주소가 설정되지 않았습니다. 관리자에게 문의해 주세요.',
+          code: 'OMR_CALLBACK_NOT_CONFIGURED'
+        },
+        { status: 503 }
+      )
+    }
+
     // Create sheet music record in database with pending status
     const sheetMusic = await prisma.sheetMusic.create({
       data: {
@@ -148,6 +166,7 @@ export async function POST(request: NextRequest) {
     if (tempo !== null) omrFormData.append('tempo', tempo.toString())
     omrFormData.append('user_id', userId)
     omrFormData.append('sheet_music_id', sheetMusic.id.toString())
+    omrFormData.append('callback_url', callbackUrl)
 
     // Send to OMR service.
     //

--- a/src/lib/omr/finalizeJob.ts
+++ b/src/lib/omr/finalizeJob.ts
@@ -1,0 +1,71 @@
+import { FileStorageService } from '@/services/fileStorageService'
+import { getOmrServiceUrl, omrAuthHeaders } from '@/lib/omr/serviceUrl'
+
+export class OmrFinalizationError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+    public readonly status: number
+  ) {
+    super(message)
+    this.name = 'OmrFinalizationError'
+  }
+}
+
+/**
+ * Collect a completed conversion and store it with the credential that remains
+ * on the Next.js side under D-011.
+ *
+ * Both the browser status poll and the OMR service callback use this boundary.
+ * The storage path is job-derived and upserted, so concurrent triggers write
+ * the same bytes to the same object rather than orphaning one of two objects.
+ */
+export async function fetchAndStoreOmrResult(
+  jobId: string,
+  userId: string
+): Promise<string> {
+  let resultResponse: Response
+  try {
+    resultResponse = await fetch(`${getOmrServiceUrl()}/result/${jobId}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        ...omrAuthHeaders(),
+      },
+      signal: AbortSignal.timeout(30000),
+    })
+  } catch (error) {
+    console.error('OMR result fetch failed:', jobId, error)
+    throw new OmrFinalizationError(
+      '변환 결과를 가져오지 못했습니다.',
+      'OMR_RESULT_UNAVAILABLE',
+      503
+    )
+  }
+
+  if (!resultResponse.ok) {
+    console.error('OMR result error:', resultResponse.status, await resultResponse.text())
+    throw new OmrFinalizationError(
+      '변환 결과를 가져오지 못했습니다.',
+      'OMR_RESULT_ERROR',
+      502
+    )
+  }
+
+  const resultPayload = await resultResponse.json()
+  const stored = await FileStorageService.getInstance().uploadOmrAnimationData(
+    jobId,
+    userId,
+    resultPayload.animation_data
+  )
+
+  if (!stored.success || !stored.url) {
+    console.error('OMR result storage failed:', jobId, stored.error)
+    throw new OmrFinalizationError(
+      '변환 결과를 저장하지 못했습니다.',
+      'ANIMATION_STORAGE_FAILED',
+      502
+    )
+  }
+
+  return stored.url
+}

--- a/src/lib/omr/finalizeJob.ts
+++ b/src/lib/omr/finalizeJob.ts
@@ -26,7 +26,8 @@ export async function fetchAndStoreOmrResult(
 ): Promise<string> {
   let resultResponse: Response
   try {
-    resultResponse = await fetch(`${getOmrServiceUrl()}/result/${jobId}`, {
+    const resultUrl = `${getOmrServiceUrl()}/result/${encodeURIComponent(jobId)}`
+    resultResponse = await fetch(resultUrl, {
       headers: {
         'Content-Type': 'application/json',
         ...omrAuthHeaders(),


### PR DESCRIPTION
## Purpose

Move OMR completion delivery off the browser lifecycle so a conversion can be stored after the upload page unmounts. Related issue #55.

## Scope

- pass a canonical Next.js callback URL to the OMR service
- notify that callback after conversion with bounded retries
- authenticate the callback with the existing shared secret
- keep Supabase storage credentials only on Next.js
- share the idempotent result collection path with the existing browser poll
- record D-018

## Out of scope

- durable queue or restart recovery
- deploying the OMR service or changing VM configuration
- live PDF verification before deployment

## Risk

Moderate. This changes the OMR/Next.js completion contract. Callback authentication fails closed; browser polling remains a fallback; storage uses the existing job-derived upsert key.

## Validation

- regression before implementation: 4 Jest assertions and 2 Python contract assertions failed
- `npm test -- --runInBand`: 55 suites / 522 tests passed
- `python3 -m unittest discover -s tests` from `omr-service/`: 34 passed
- `npx tsc --noEmit`: passed
- `npm run lint`: passed
- `npm run build`: passed

## Baseline difference

No baseline failure remains. Build still reports its configured type/lint skipping, so those gates were run separately and passed.

## Rollback

Revert the two branch commits. The existing browser status poll then becomes the sole completion trigger again; no schema or stored-data migration is involved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * OMR 변환이 완료되면 자동 콜백으로 결과를 저장합니다.
  * 콜백 전달 실패 시 최대 12회 재시도하며, 기존 상태 확인 방식도 대체 수단으로 유지됩니다.
  * 변환 결과를 자동으로 저장하고 완료 상태로 갱신합니다.

* **버그 수정**
  * 콜백 URL과 보안 키를 검증해 잘못된 요청을 안전하게 처리합니다.
  * 이미 완료된 작업의 중복 저장을 방지하고, 일시적 저장 실패 후 재처리를 지원합니다.

* **테스트**
  * 성공, 인증 오류, 설정 누락, 재시도 및 중복 처리 시나리오를 보강했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->