### PR TITLE
재생 시 붕괴하는 낙하 영역을 고친다 — 백분율 높이가 flex 부모를 만난 자리

### DIFF
--- a/src/components/animation/FallingNotesPlayer.tsx
+++ b/src/components/animation/FallingNotesPlayer.tsx
@@ -179,59 +179,63 @@ export default function FallingNotesPlayer({
       </div>
 
       {/* Main Visualization Area */}
+      {/* The measured box is the column itself. An inner `height: 100%` wrapper
+          would resolve to `auto` while playback sizes this box with flex, which
+          collapses the falling area and lifts the keyboard to the top. */}
       <div
         ref={visualizationRef}
         className="w-full border rounded-2xl shadow overflow-hidden"
-        style={isPlaying
-          ? { flex: 1, minHeight: 0 }
-          : { height: standardVisualizationHeight }}
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          ...(isPlaying
+            ? { flex: 1, minHeight: 0 }
+            : { height: standardVisualizationHeight }),
+        }}
       >
+        {/* Falling Notes Area */}
         <div
           style={{
-            display: 'flex',
-            flexDirection: 'column',
-            height: '100%'
+            position: 'relative',
+            flex: 1,
+            minHeight: 0,
+            // The hit line is a boundary, not a decoration: a note that has
+            // already been played must not keep falling across the keys.
+            overflow: 'hidden',
+            background: '#0b0b0c'
           }}
         >
-          {/* Falling Notes Area */}
+          <FallingNotes
+            notes={notes}
+            nowSec={currentTime}
+            pxPerSec={pxPerSec}
+            height={fallingHeight}
+            layout={layout}
+          />
+
+          {/* Hit Line */}
           <div
+            className="absolute left-0 right-0"
             style={{
-              position: 'relative',
-              flex: 1,
-              background: '#0b0b0c'
+              bottom: 0,
+              height: 1,
+              background: '#1f2937'
             }}
-          >
-            <FallingNotes
-              notes={notes}
-              nowSec={currentTime}
-              pxPerSec={pxPerSec}
-              height={fallingHeight}
-              layout={layout}
-            />
-            
-            {/* Hit Line */}
-            <div
-              className="absolute left-0 right-0"
-              style={{
-                bottom: 0,
-                height: 1,
-                background: '#1f2937'
-              }}
-            />
-          </div>
-          
-          {/* Piano Keyboard */}
-          <div
-            style={{
-              height: keyboardHeight,
-              background: '#0f0f10'
-            }}
-          >
-            <SimplePianoKeyboard 
-              layout={layout} 
-              activeKeys={activeKeys}
-            />
-          </div>
+          />
+        </div>
+
+        {/* Piano Keyboard */}
+        <div
+          style={{
+            height: keyboardHeight,
+            flexShrink: 0,
+            background: '#0f0f10'
+          }}
+        >
+          <SimplePianoKeyboard
+            layout={layout}
+            activeKeys={activeKeys}
+          />
         </div>
       </div>
       

--- a/src/components/animation/__tests__/FallingNotesPlayer.test.tsx
+++ b/src/components/animation/__tests__/FallingNotesPlayer.test.tsx
@@ -63,6 +63,7 @@ describe('FallingNotesPlayer', () => {
   beforeEach(() => {
     mockKeyboardFrames.length = 0
     mockPlayerState.sampleStatus = 'ready'
+    mockPlayerState.isPlaying = true
   })
 
   it('derives the visual frame and active keys from the same playhead on first render', () => {
@@ -117,5 +118,53 @@ describe('FallingNotesPlayer', () => {
 
     expect(screen.getByText('녹음 피아노 샘플을 준비 중입니다.')).toBeInTheDocument()
     expect(screen.getByTestId('playback-ready')).toHaveTextContent('false')
+  })
+
+  // Playback geometry. jsdom performs no layout, so these assertions pin the
+  // structural contract that a browser then resolves: the element whose height
+  // playback controls must be the same element that lays the falling area and
+  // the keyboard out as a column. A separate `height: 100%` wrapper reads as
+  // `auto` the moment its parent is sized by flex instead of a pixel height,
+  // which collapses the falling area to 0 and lifts the keyboard to the top.
+  describe('playback geometry', () => {
+    const readColumn = () => {
+      const fallingArea = screen.getByTestId('visual-playhead').parentElement!
+      const keyboardWrapper = screen.getByTestId('active-keys').parentElement!
+      return { fallingArea, keyboardWrapper, column: fallingArea.parentElement! }
+    }
+
+    it('lays out the falling area and the keyboard on the measured element itself', () => {
+      render(<FallingNotesPlayer animationData={animationData} />)
+      const { fallingArea, keyboardWrapper, column } = readColumn()
+
+      expect(keyboardWrapper.parentElement).toBe(column)
+      expect(column).toHaveClass('overflow-hidden')
+      expect(column.style.display).toBe('flex')
+      expect(column.style.flexDirection).toBe('column')
+
+      // No percentage height may sit between the flex-sized box and the two
+      // stacked areas — that is exactly the dependency that broke.
+      expect(column.style.height).toBe('')
+      expect(fallingArea.style.height).toBe('')
+      expect(keyboardWrapper.style.height).toBe('120px')
+    })
+
+    it('clips the falling area at the hit line so notes cannot draw over the keys', () => {
+      render(<FallingNotesPlayer animationData={animationData} />)
+      const { fallingArea } = readColumn()
+
+      expect(fallingArea.style.overflow).toBe('hidden')
+    })
+
+    it('keeps the idle player at its standard pixel height', () => {
+      mockPlayerState.isPlaying = false
+      render(<FallingNotesPlayer animationData={animationData} />)
+      const { column } = readColumn()
+
+      // lookAheadSec 1.5 * 140 px/s + 120 px keyboard
+      expect(column.style.height).toBe('330px')
+      expect(column.style.display).toBe('flex')
+      expect(column.style.flexDirection).toBe('column')
+    })
   })
 })


### PR DESCRIPTION
PR #67 병합 이후 재생 애니메이션이 깨졌다. 사용자가 `/sheet/2`에서 보고했고, 배포본에서 결정적으로 재현했다.

## 증상

재생 버튼을 누르면 **건반이 시각화 블록 맨 위로 올라가고**, 노트가 낙하 공간 없이 건반에서 시작해 그 아래 빈 공간으로 떨어진다. PC·모바일 동일.

## 원인 — 백분율 높이는 부모가 높이를 말해줄 때만 풀린다

시각화 박스 안에는 `height: '100%'`인 flex 컬럼 래퍼가 있다. 이 래퍼는 PR #67 **이전에도 있었고**, 그때는 부모가 `style={{ height: 330 }}`로 픽셀 높이를 명시했기 때문에 100%가 328px로 풀렸다.

PR #67이 재생 중 부모를 `{ flex: 1, minHeight: 0 }`로 바꾸면서 부모에 지정된 높이가 사라졌다. 부모의 높이는 flex 계산 결과일 뿐 선언된 값이 아니므로 Chrome은 래퍼의 `height: 100%`를 `auto`로 처리한다. 그러면 래퍼 높이는 in-flow 자식 중 유일하게 높이를 가진 건반(120px)이 되고, `flex: 1`인 낙하 영역은 **0px로 붕괴**한다.

낙하 영역이 0이 되어도 `FallingNotes`는 JS로 계산한 `fallingHeight`(= 측정 높이 − 120)를 좌표계로 쓰므로, 노트는 붕괴된 지점(=건반 위치)에서 시작해 360px 아래까지 그려진다.

**Chrome 1470×746, 배포본 `/sheet/2` 실측:**

| 요소 | 수정 전 | 수정 후 |
|---|---:|---:|
| 시각화 박스 (측정 대상) | 482.5px | 482.5px |
| 안쪽 컬럼 | **120px** | 480.5px |
| 낙하 영역 | **0px** | **360.5px** |
| 건반 위치 (viewport y) | **264.5 (최상단)** | 625 (최하단) |
| `FallingNotes`에 전달된 height | 360.5px | 360.5px |

수정 후 낙하 영역 실측 높이 360.5px가 JS가 계산한 `fallingHeight`와 **정확히 일치**한다 — 이게 좌표계 일관성의 판정 기준이다.

## 접근

측정 대상 박스 자체를 flex 컬럼으로 만들고 래퍼 div를 제거했다. 백분율이 사라지므로 "부모가 높이를 선언했는가"에 대한 의존 자체가 없어진다. 유휴 상태(픽셀 높이)와 재생 상태(flex) 모두 같은 구조를 쓴다.

## 함께 고친 것 — 노트가 건반을 통과하던 문제

사용자가 함께 보고한 "건반을 통과해서 아래쪽까지 보여짐"은 **PR #67 이전부터 있던 별개 결함**이다. 낙하 영역에 `overflow: hidden`이 없어, 히트라인을 지나 지속되는 노트가 계속 그려졌다. 흰건반(`z-index: 10`)과 노트(`z-index: 20`)는 같은 stacking context에 있으므로 노트가 건반 위에 얹혔다.

히트라인은 노트가 연주되는 지점이고, 따라서 노트가 그려지기를 멈추는 지점이기도 하다. 낙하 영역을 `overflow: hidden`으로 잘랐다.

## 회귀 테스트

jsdom은 레이아웃을 계산하지 않으므로 붕괴 자체를 관측할 수 없다. 대신 브라우저가 그 뒤에 해석할 **구조 계약**을 고정했다: 측정 대상 요소가 곧 flex 컬럼이어야 하고, 그것과 두 영역 사이에 백분율 높이가 없어야 하며, 낙하 영역이 히트라인에서 잘려야 한다. 유휴 상태의 330px 고정 높이도 함께 고정했다.

테스트를 동작 변경보다 먼저 단독 커밋했다(`1d1d07b`). 그 시점 결과는 **3 failed / 5 passed**이고, 실패 중 하나가 유휴 높이에 대해 `"330px"` 대신 **`"100%"`**를 보고하며 결함을 정확히 짚는다.

## 검증

```
npx jest FallingNotesPlayer.test.tsx   테스트 선행 커밋 시점: 3 failed / 5 passed
npm test                               55 suites / 527 tests passed
npx tsc --noEmit                       exit 0
npm run lint                           No ESLint warnings or errors
npm run build                          성공
```

**브라우저 실측**: 배포본 `/sheet/2`에서 수정 전 상태를 결정적으로 재현하고(새로고침 후 첫 재생), 수정 후와 동일한 결과를 만드는 CSS를 주입해 위 표의 수치와 히트라인 클리핑을 확인했다.

## 검증하지 못한 것

- **실기기 없음.** 수치는 데스크톱 Chrome 1470×746 실측이며 실제 휴대폰에서 관측하지 않았다.
- Safari·Firefox 레이아웃 미확인. 백분율 높이 해석은 엔진마다 다를 수 있으나, 이 변경은 백분율을 없애므로 방향은 안전한 쪽이다.
- 인증이 필요한 `/sheet/[id]` E2E는 여전히 없다 (이슈 #65 할 일 6).

## 이 PR이 하지 않는 것

**모바일 가로모드 전환은 여전히 미구현이다.** 이슈 #65의 할 일 4이고 PR #67도 명시적으로 범위 밖이라고 기록했다. iOS는 `screen.orientation.lock()`이 없고 Android는 fullscreen 선행이 필요해 별도 단계가 필요하다. 이 PR은 그것을 대신하지 않는다.

이슈 #65는 계속 열어둔다 — 종료 키워드를 의도적으로 쓰지 않는다.
