### PR TITLE
재생 시 가로 전환 — 두 플랫폼을 하나의 조건으로, 컨트롤은 한 줄로

### DIFF
--- a/docs/recovery/DECISIONS.md
+++ b/docs/recovery/DECISIONS.md
@@ -398,3 +398,55 @@
     DB에 저장된 job id를 fetch target으로 사용한다.
 - Related: D-010, D-011, 이슈 [#55](https://github.com/landfill/ClairKeys/issues/55),
   `src/app/api/omr/finalize/route.ts`, `omr-service/app.py`
+
+## D-019: 재생 가로 전환은 하나의 조건으로 두 플랫폼을 처리하고, 컨트롤 압축을 동반한다
+
+- Date: 2026-08-28
+- Status: Accepted
+- Context:
+  - D-017의 곡 단위 크롭은 세로 화면의 폭 문제를 풀지 못한다. iPhone 12 세로의 가용 폭 356px
+    에서 33 흰건반 악보는 건반 폭 10.79px에 그친다. 남은 지렛대는 화면 자체의 방향뿐이다.
+  - 두 플랫폼이 반대 수단을 요구한다. Android는 fullscreen 선행 후 `screen.orientation.lock()`
+    이 동작하고, iOS는 `lock()`도 manifest `orientation`도 없어 CSS 변환만 남는다.
+  - **실측**: 재생 중 플레이어 자체 chrome이 264px(안내문 32 + PlaybackControls 168 +
+    샘플 상태 32 + 음량 32)이다. iPhone 12 가로의 뷰포트 높이는 **390px 전체**이므로, 회전만
+    하면 시각화에 126px이 남고 건반 120px을 빼면 낙하 영역이 **6px**이 된다.
+- Decision:
+  1. 회전 여부는 `engaged && (pointer: coarse) && (orientation: portrait)` 하나의 식으로
+     정한다. 락 성공은 화면을 실제 가로로 만들어 portrait 질의를 스스로 종료시키므로, **이중
+     회전 해제가 별도 분기 없이 같은 식에서 나온다.**
+  2. iOS 판별은 `typeof screen.orientation?.lock === 'function'`으로만 한다. iOS는 인터페이스
+     자체는 Safari 16.4+로 제공하므로 `'orientation' in screen`이나 null 검사는 iOS를 조용히
+     Android 경로로 보낸다.
+  3. 방향 요청은 재생 클릭 핸들러 안에서 **동기적으로** 발사한다. `play()`는 AudioContext 재개와
+     샘플 로딩을 await하므로 `isPlaying` effect에서 요청하면 fullscreen의 transient activation
+     창을 놓칠 수 있다.
+  4. `lock()`이 없는 플랫폼에서는 fullscreen을 요청하지 않는다. iOS는 `Element.requestFullscreen`
+     을 `<video>`에만 허용하므로 거절된 Promise만 남고, CSS 회전이 이미 화면을 덮는다.
+  5. **데스크톱은 회전 대상이 아니다.** 창에는 전환할 방향이 없고, 재생 시 브라우저를 fullscreen
+     으로 밀어넣는 것은 그 자체가 결함이다. `(pointer: coarse)`로 배제한다.
+  6. 회전은 **컨트롤 압축을 반드시 동반한다.** 재생 중에는 `CompactPlaybackBar` 한 줄(56px)이
+     기존 4개 블록을 대체해 chrome을 264px → 64px로 줄인다. 낙하 영역이 6px → 206px이 되며,
+     이는 설정값 `lookAheadSec` 1.5s(210px)에 해당한다.
+  7. 압축이 버리는 것과 남기는 것: 안내문과 3행 컨트롤 블록은 설정용이므로 버린다. **음량
+     슬라이더는 남긴다** — 귀로 `DEFAULT_MASTER_GAIN`을 고르는 것이 목적이라 소리가 나는 동안
+     조작할 수 있어야 한다. 샘플 상태 줄은 행을 내주되 `sr-only`로 live region을 유지한다.
+  8. 공유 `PlaybackControls`는 수정하지 않는다. `AnimationPlayer`와 demo 페이지가 현재 형태에
+     의존한다.
+- Consequence:
+  - 회전 잠금을 켠 iOS 사용자는 CSS 회전만 받는다. 이때 기기를 어느 방향으로 돌려야 바로 보이는지는
+    `rotate(90deg)`가 정한다(기기를 반시계로 돌린다). 반대로 돌리면 뒤집혀 보이며, 브라우저가
+    실제로 가로로 reflow하는 경우에만 회전이 해제된다. 이 방향은 임의 선택이며 실기기 확인 대상이다.
+  - 재생 중에는 모드 선택이 사라진다. `FallingNotesPlayer`는 listen 모드만 지원하고 핸들러가
+    로그만 남기므로 잃는 기능이 없다.
+- Rejected:
+  - 시각화 블록만 회전 | 폰을 세로로 든 채 노트가 옆으로 흘러 낙하 노트의 전제를 깬다.
+  - 회전만 하고 압축은 나중에 | 가로 390px에서 낙하 영역 6px은 쓸 수 없는 화면이다.
+  - manifest `"orientation"` | iOS가 무시하므로 이미 동작하는 플랫폼에서만 동작한다.
+  - `'orientation' in screen` feature-detect | iOS에서 true가 되어 조용히 아무 일도 안 한다.
+- Directive:
+  - `screen.orientation`의 존재로 방향 잠금 지원을 판별하지 않는다. 반드시 `lock`이 함수인지 본다.
+  - 행을 되찾기 위해 live region을 unmount하지 않는다.
+  - 방향 요청을 `isPlaying` effect로 옮기지 않는다. 사용자 활성화 창을 잃는다.
+- Related: D-017, 이슈 [#65](https://github.com/landfill/ClairKeys/issues/65) 할 일 4,
+  `src/hooks/usePlaybackOrientation.ts`, `src/components/playback/CompactPlaybackBar.tsx`

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -29,6 +29,12 @@ body.playback-active .playback-chrome {
   display: none;
 }
 
+/* The rotated player is fixed over the whole viewport; whatever remains behind
+   it can only contribute rubber-banding on iOS. */
+body.playback-rotated {
+  overflow: hidden;
+}
+
 /* Playback Controls 스타일 */
 .playback-controls .slider::-webkit-slider-thumb {
   appearance: none;

--- a/src/components/animation/FallingNotesPlayer.tsx
+++ b/src/components/animation/FallingNotesPlayer.tsx
@@ -121,10 +121,16 @@ export default function FallingNotesPlayer({
     ? Math.max(0, visualizationSize.height - keyboardHeight)
     : Math.max(0, standardFallingHeight - 2)
 
+  // `isPlaying` is still false for as long as play() spends awaiting the
+  // AudioContext and the samples, so a plain `!isPlaying` here would release the
+  // orientation that the click had just requested. Only the fall from true is a
+  // stop.
+  const wasPlayingRef = useRef(false)
   useEffect(() => {
     document.body.classList.toggle('playback-active', isPlaying)
     onPlaybackChange?.(isPlaying)
-    if (!isPlaying) orientation.exit()
+    if (wasPlayingRef.current && !isPlaying) orientation.exit()
+    wasPlayingRef.current = isPlaying
     return () => document.body.classList.remove('playback-active')
   }, [isPlaying, onPlaybackChange, orientation])
 
@@ -138,9 +144,12 @@ export default function FallingNotesPlayer({
   // The orientation request has to be issued from the click that produced the
   // user activation. play() awaits the AudioContext and the sample load, which
   // can outlive the activation window that requestFullscreen needs.
-  const handlePlay = useCallback(() => {
+  const handlePlay = useCallback(async () => {
     orientation.enter()
-    void play()
+    // A start that never happens must not leave a phone turned with nothing
+    // playing, and no state transition would report that on its own.
+    const started = await play()
+    if (!started) orientation.exit()
   }, [orientation, play])
 
   // Derive key activation synchronously from the exact playhead passed to the

--- a/src/components/animation/FallingNotesPlayer.tsx
+++ b/src/components/animation/FallingNotesPlayer.tsx
@@ -1,15 +1,36 @@
 'use client'
 
-import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import type { CanonicalAnimationData } from '@/types/animationContract'
 import { buildResponsiveKeyLayout } from '@/utils/pianoLayout'
 import { canonicalToFallingNotes } from '@/utils/dataConverter'
 import { useFallingNotesPlayer } from '@/hooks/useFallingNotesPlayer'
+import { usePlaybackOrientation } from '@/hooks/usePlaybackOrientation'
 import { MAX_MASTER_GAIN } from '@/hooks/useFallingNotesAudio'
 import FallingNotes from './FallingNotes'
 import SimplePianoKeyboard from '../piano/SimplePianoKeyboard'
-import { PlaybackControls } from '@/components/playback'
+import { CompactPlaybackBar, PlaybackControls } from '@/components/playback'
 import { getActiveNotes } from '@/utils/visualUtils'
+
+/**
+ * Standing in for a rotation the device will not perform. The box is laid out
+ * along the viewport's opposite axis and then turned about its top-left corner;
+ * `translateY(-100%)` brings it back over the viewport afterwards. dvh/dvw are
+ * required rather than vh/vw — iOS measures vh against the toolbar-less height,
+ * which would push the keyboard off screen.
+ */
+const rotatedRootStyle: React.CSSProperties = {
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  width: '100dvh',
+  height: '100dvw',
+  transformOrigin: 'top left',
+  transform: 'rotate(90deg) translateY(-100%)',
+  overflow: 'hidden',
+  zIndex: 40,
+  background: '#f9fafb',
+}
 
 /**
  * Falling Notes Player - MVP Style Piano Visualization
@@ -51,7 +72,12 @@ export default function FallingNotesPlayer({
   const standardFallingHeight = Math.round(lookAheadSec * pxPerSec)
   const standardVisualizationHeight = standardFallingHeight + keyboardHeight
   const visualizationRef = useRef<HTMLDivElement>(null)
+  const rootRef = useRef<HTMLDivElement>(null)
   const [visualizationSize, setVisualizationSize] = useState({ width: 0, height: 0 })
+
+  // Fullscreen is requested on the player root so the rotated box, not just the
+  // visualization, owns the screen.
+  const orientation = usePlaybackOrientation(rootRef)
 
   // The content box is the coordinate system shared by the keyboard and the
   // falling notes. ResizeObserver keeps it current after breakpoint, rotation,
@@ -98,8 +124,24 @@ export default function FallingNotesPlayer({
   useEffect(() => {
     document.body.classList.toggle('playback-active', isPlaying)
     onPlaybackChange?.(isPlaying)
+    if (!isPlaying) orientation.exit()
     return () => document.body.classList.remove('playback-active')
-  }, [isPlaying, onPlaybackChange])
+  }, [isPlaying, onPlaybackChange, orientation])
+
+  // The rotated player is fixed over the whole screen, so anything left
+  // scrolling behind it only produces rubber-banding on iOS.
+  useEffect(() => {
+    document.body.classList.toggle('playback-rotated', orientation.rotate)
+    return () => document.body.classList.remove('playback-rotated')
+  }, [orientation.rotate])
+
+  // The orientation request has to be issued from the click that produced the
+  // user activation. play() awaits the AudioContext and the sample load, which
+  // can outlive the activation window that requestFullscreen needs.
+  const handlePlay = useCallback(() => {
+    orientation.enter()
+    void play()
+  }, [orientation, play])
 
   // Derive key activation synchronously from the exact playhead passed to the
   // falling-note visualization. An effect would leave the keyboard one render
@@ -115,36 +157,95 @@ export default function FallingNotesPlayer({
   }
 
   return (
-    <div className={`w-full mx-auto ${isPlaying ? 'max-w-none min-h-[100dvh] flex flex-col' : 'max-w-5xl'} ${className}`}>
-      {/* Usage Instructions */}
-      <div className="mb-4">
-        <p className="text-xs text-gray-500">
-          노트의 아랫변이 히트라인(건반 상단)에 닿는 순간이 연주 타이밍입니다.
-        </p>
-      </div>
-      
-      {/* Playback Controls */}
-      <div className="mb-4">
-        <PlaybackControls
-          isPlaying={isPlaying}
-          isReady={sampleStatus !== 'loading'}
-          currentTime={currentTime}
-          duration={totalLength}
-          playbackSpeed={tempoScale}
-          playbackMode="listen"
-          onPlay={play}
-          onPause={pause}
-          onStop={stop}
-          onSeek={seek}
-          onSpeedChange={setTempoScale}
-          onModeChange={handleModeChange}
-        />
-      </div>
+    <div
+      ref={rootRef}
+      className={[
+        'w-full mx-auto',
+        isPlaying ? 'max-w-none flex flex-col' : 'max-w-5xl',
+        // An explicit cross-axis height replaces min-h while rotated; keeping
+        // both would constrain the box along the wrong axis.
+        isPlaying && !orientation.rotate ? 'min-h-[100dvh]' : '',
+        className,
+      ].filter(Boolean).join(' ')}
+      style={orientation.rotate ? rotatedRootStyle : undefined}
+    >
+      {isPlaying ? (
+        /* One row instead of four. The landscape viewport this mode targets is
+           390px tall in total; the stacked setup chrome cost 264px of it. */
+        <div className="mb-2">
+          <CompactPlaybackBar
+            isReady={sampleStatus !== 'loading'}
+            currentTime={currentTime}
+            duration={totalLength}
+            playbackSpeed={tempoScale}
+            volume={volume}
+            maxVolume={MAX_MASTER_GAIN}
+            onPause={pause}
+            onStop={stop}
+            onSeek={seek}
+            onSpeedChange={setTempoScale}
+            onVolumeChange={setVolume}
+          />
+        </div>
+      ) : (
+        <>
+          {/* Usage Instructions */}
+          <div className="mb-4">
+            <p className="text-xs text-gray-500">
+              노트의 아랫변이 히트라인(건반 상단)에 닿는 순간이 연주 타이밍입니다.
+            </p>
+          </div>
 
+          {/* Playback Controls */}
+          <div className="mb-4">
+            <PlaybackControls
+              isPlaying={isPlaying}
+              isReady={sampleStatus !== 'loading'}
+              currentTime={currentTime}
+              duration={totalLength}
+              playbackSpeed={tempoScale}
+              playbackMode="listen"
+              onPlay={handlePlay}
+              onPause={pause}
+              onStop={stop}
+              onSeek={seek}
+              onSpeedChange={setTempoScale}
+              onModeChange={handleModeChange}
+            />
+          </div>
+
+          {/* Master volume — a tuning control. The numeric readout is the master
+              gain value; whatever setting sounds right here is the number to lock in
+              as DEFAULT_MASTER_GAIN in useFallingNotesAudio. */}
+          <div className="mb-4 flex items-center gap-3">
+            <label htmlFor="master-volume" className="text-xs text-gray-600 whitespace-nowrap">
+              음량
+            </label>
+            <input
+              id="master-volume"
+              type="range"
+              min={0}
+              max={MAX_MASTER_GAIN}
+              step={0.01}
+              value={volume}
+              onChange={(e) => setVolume(parseFloat(e.target.value))}
+              className="flex-1 max-w-xs"
+              aria-label="음량 (master gain)"
+            />
+            <span className="text-xs font-mono text-gray-500 tabular-nums w-10 text-right">
+              {volume.toFixed(2)}
+            </span>
+          </div>
+        </>
+      )}
+
+      {/* Playback reclaims this row, but never the announcement: a listener who
+          cannot see the screen still has to learn that the recorded piano was
+          replaced by a synthesised one. */}
       <div
         role="status"
         aria-live="polite"
-        className="mb-4 text-xs text-gray-600"
+        className={isPlaying ? 'sr-only' : 'mb-4 text-xs text-gray-600'}
       >
         {sampleStatus === 'idle' && '녹음 피아노 샘플은 첫 재생 때 준비됩니다.'}
         {sampleStatus === 'loading' && '녹음 피아노 샘플을 준비 중입니다.'}
@@ -153,29 +254,6 @@ export default function FallingNotesPlayer({
           '샘플이 일부만 준비되었거나 늦어 이번 재생은 합성음으로 재생합니다.'}
         {sampleStatus === 'failed' &&
           '샘플을 불러오지 못해 합성음으로 재생합니다.'}
-      </div>
-
-      {/* Master volume — a tuning control. The numeric readout is the master
-          gain value; whatever setting sounds right here is the number to lock in
-          as DEFAULT_MASTER_GAIN in useFallingNotesAudio. */}
-      <div className="mb-4 flex items-center gap-3">
-        <label htmlFor="master-volume" className="text-xs text-gray-600 whitespace-nowrap">
-          음량
-        </label>
-        <input
-          id="master-volume"
-          type="range"
-          min={0}
-          max={MAX_MASTER_GAIN}
-          step={0.01}
-          value={volume}
-          onChange={(e) => setVolume(parseFloat(e.target.value))}
-          className="flex-1 max-w-xs"
-          aria-label="음량 (master gain)"
-        />
-        <span className="text-xs font-mono text-gray-500 tabular-nums w-10 text-right">
-          {volume.toFixed(2)}
-        </span>
       </div>
 
       {/* Main Visualization Area */}

--- a/src/components/animation/__tests__/FallingNotesPlayer.test.tsx
+++ b/src/components/animation/__tests__/FallingNotesPlayer.test.tsx
@@ -23,6 +23,16 @@ jest.mock('@/hooks/useFallingNotesPlayer', () => ({
   useFallingNotesPlayer: () => mockPlayerState,
 }))
 
+const mockOrientation = {
+  rotate: false,
+  enter: jest.fn(),
+  exit: jest.fn(),
+}
+
+jest.mock('@/hooks/usePlaybackOrientation', () => ({
+  usePlaybackOrientation: () => mockOrientation,
+}))
+
 jest.mock('../FallingNotes', () => ({
   __esModule: true,
   default: ({ nowSec }: { nowSec: number }) => (
@@ -39,8 +49,11 @@ jest.mock('../../piano/SimplePianoKeyboard', () => ({
 }))
 
 jest.mock('@/components/playback', () => ({
-  PlaybackControls: ({ isReady }: { isReady: boolean }) => (
-    <div data-testid="playback-ready">{String(isReady)}</div>
+  PlaybackControls: ({ isReady, onPlay }: { isReady: boolean; onPlay: () => void }) => (
+    <div>
+      <div data-testid="playback-ready">{String(isReady)}</div>
+      <button type="button" data-testid="play" onClick={onPlay}>play</button>
+    </div>
   ),
 }))
 
@@ -64,6 +77,7 @@ describe('FallingNotesPlayer', () => {
     mockKeyboardFrames.length = 0
     mockPlayerState.sampleStatus = 'ready'
     mockPlayerState.isPlaying = true
+    mockOrientation.rotate = false
   })
 
   it('derives the visual frame and active keys from the same playhead on first render', () => {
@@ -165,6 +179,61 @@ describe('FallingNotesPlayer', () => {
       expect(column.style.height).toBe('330px')
       expect(column.style.display).toBe('flex')
       expect(column.style.flexDirection).toBe('column')
+    })
+  })
+
+  // Landscape playback. The orientation request must ride the play click's own
+  // user activation, and the rotated box has to swap the viewport's axes —
+  // neither is observable through layout in jsdom, so both are pinned here as
+  // the contract a device then honours.
+  describe('landscape playback', () => {
+    it('asks for landscape from the play click itself, not from a later effect', () => {
+      mockOrientation.enter.mockClear()
+      mockPlayerState.play.mockClear()
+      mockPlayerState.isPlaying = false
+      render(<FallingNotesPlayer animationData={animationData} />)
+
+      fireEvent.click(screen.getByTestId('play'))
+
+      // requestFullscreen needs transient activation, and play() awaits audio
+      // setup that can outlive it.
+      expect(mockOrientation.enter).toHaveBeenCalledTimes(1)
+      expect(mockPlayerState.play).toHaveBeenCalledTimes(1)
+    })
+
+    it('releases the orientation as soon as playback stops', () => {
+      mockOrientation.exit.mockClear()
+      const { rerender } = render(<FallingNotesPlayer animationData={animationData} />)
+
+      mockPlayerState.isPlaying = false
+      rerender(<FallingNotesPlayer animationData={animationData} />)
+
+      expect(mockOrientation.exit).toHaveBeenCalled()
+    })
+
+    it('swaps the viewport axes when it stands in for a real rotation', () => {
+      mockOrientation.rotate = true
+      const { container } = render(<FallingNotesPlayer animationData={animationData} />)
+      const root = container.firstElementChild as HTMLElement
+
+      expect(root.style.position).toBe('fixed')
+      // The rotated box is as wide as the viewport is tall, and vice versa.
+      expect(root.style.width).toBe('100dvh')
+      expect(root.style.height).toBe('100dvw')
+      expect(root.style.transform).toBe('rotate(90deg) translateY(-100%)')
+      expect(root.style.transformOrigin).toBe('top left')
+      // min-h-[100dvh] would fight the explicit height along the wrong axis.
+      expect(root.className).not.toContain('min-h-[100dvh]')
+      expect(document.body).toHaveClass('playback-rotated')
+    })
+
+    it('keeps the upright playback view free of the rotation styles', () => {
+      const { container } = render(<FallingNotesPlayer animationData={animationData} />)
+      const root = container.firstElementChild as HTMLElement
+
+      expect(root.style.transform).toBe('')
+      expect(root.className).toContain('min-h-[100dvh]')
+      expect(document.body).not.toHaveClass('playback-rotated')
     })
   })
 })

--- a/src/components/animation/__tests__/FallingNotesPlayer.test.tsx
+++ b/src/components/animation/__tests__/FallingNotesPlayer.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, act } from '@testing-library/react'
 import type { CanonicalAnimationData } from '@/types/animationContract'
 import FallingNotesPlayer from '../FallingNotesPlayer'
 

--- a/src/components/animation/__tests__/FallingNotesPlayer.test.tsx
+++ b/src/components/animation/__tests__/FallingNotesPlayer.test.tsx
@@ -49,6 +49,7 @@ jest.mock('../../piano/SimplePianoKeyboard', () => ({
 }))
 
 jest.mock('@/components/playback', () => ({
+  ...jest.requireActual('@/components/playback'),
   PlaybackControls: ({ isReady, onPlay }: { isReady: boolean; onPlay: () => void }) => (
     <div>
       <div data-testid="playback-ready">{String(isReady)}</div>
@@ -91,6 +92,7 @@ describe('FallingNotesPlayer', () => {
 
   it('shows the current master gain and forwards slider changes to setVolume', () => {
     mockPlayerState.setVolume.mockClear()
+    mockPlayerState.isPlaying = false
     render(<FallingNotesPlayer animationData={animationData} />)
 
     // The readout is the gain value itself — that is what makes it usable for
@@ -106,6 +108,7 @@ describe('FallingNotesPlayer', () => {
   })
 
   it('shows recorded-sample readiness and removes the ineffective treble control', () => {
+    mockPlayerState.isPlaying = false
     render(<FallingNotesPlayer animationData={animationData} />)
 
     expect(screen.getByText('녹음 피아노 샘플로 재생합니다.')).toBeInTheDocument()
@@ -114,6 +117,7 @@ describe('FallingNotesPlayer', () => {
   })
 
   it('exposes degraded and failed fallback states without blocking playback', () => {
+    mockPlayerState.isPlaying = false
     mockPlayerState.sampleStatus = 'degraded'
     const { rerender } = render(<FallingNotesPlayer animationData={animationData} />)
 
@@ -127,6 +131,7 @@ describe('FallingNotesPlayer', () => {
   })
 
   it('marks controls not ready only while loading', () => {
+    mockPlayerState.isPlaying = false
     mockPlayerState.sampleStatus = 'loading'
     render(<FallingNotesPlayer animationData={animationData} />)
 
@@ -234,6 +239,54 @@ describe('FallingNotesPlayer', () => {
       expect(root.style.transform).toBe('')
       expect(root.className).toContain('min-h-[100dvh]')
       expect(document.body).not.toHaveClass('playback-rotated')
+    })
+  })
+
+  // Compact playback chrome. Measured on the deployed player: the four stacked
+  // blocks cost 264px, and an iPhone 12 in landscape has 390px of viewport
+  // height in total. Rotating without compacting leaves a 6px falling area, so
+  // the rotation and this compaction are one feature, not two.
+  describe('compact playback chrome', () => {
+    it('replaces the stacked setup chrome with one bar while playing', () => {
+      render(<FallingNotesPlayer animationData={animationData} />)
+
+      // The full three-row control block is a setup affordance.
+      expect(screen.queryByTestId('playback-ready')).not.toBeInTheDocument()
+      // So is the line explaining what the hit line means.
+      expect(screen.queryByText(/히트라인/)).not.toBeInTheDocument()
+      expect(screen.getByTestId('compact-playback-bar')).toBeInTheDocument()
+    })
+
+    it('keeps the master gain adjustable while the score is sounding', () => {
+      mockPlayerState.setVolume.mockClear()
+      render(<FallingNotesPlayer animationData={animationData} />)
+
+      // This slider exists to choose DEFAULT_MASTER_GAIN by ear, which can only
+      // be done while listening. Hiding it during playback would defeat it.
+      const slider = screen.getByLabelText('음량 (master gain)') as HTMLInputElement
+      expect(slider.value).toBe('0.22')
+      fireEvent.change(slider, { target: { value: '0.4' } })
+      expect(mockPlayerState.setVolume).toHaveBeenCalledWith(0.4)
+    })
+
+    it('keeps announcing sample fallbacks even though the line is not shown', () => {
+      mockPlayerState.sampleStatus = 'failed'
+      render(<FallingNotesPlayer animationData={animationData} />)
+
+      // Reclaiming the row must not remove the live region that tells a screen
+      // reader the recorded piano was replaced by a synthesised one.
+      const status = screen.getByRole('status')
+      expect(status).toHaveTextContent('샘플을 불러오지 못해 합성음으로 재생합니다.')
+      expect(status.className).toContain('sr-only')
+    })
+
+    it('restores the full setup chrome when playback stops', () => {
+      mockPlayerState.isPlaying = false
+      render(<FallingNotesPlayer animationData={animationData} />)
+
+      expect(screen.getByTestId('playback-ready')).toBeInTheDocument()
+      expect(screen.getByText(/히트라인/)).toBeInTheDocument()
+      expect(screen.queryByTestId('compact-playback-bar')).not.toBeInTheDocument()
     })
   })
 })

--- a/src/components/animation/__tests__/FallingNotesPlayer.test.tsx
+++ b/src/components/animation/__tests__/FallingNotesPlayer.test.tsx
@@ -11,7 +11,7 @@ const mockPlayerState = {
   volume: 0.22,
   sampleStatus: 'ready' as 'idle' | 'loading' | 'ready' | 'degraded' | 'failed',
   totalLength: 3,
-  play: jest.fn(),
+  play: jest.fn().mockResolvedValue(true),
   pause: jest.fn(),
   stop: jest.fn(),
   seek: jest.fn(),
@@ -79,6 +79,9 @@ describe('FallingNotesPlayer', () => {
     mockPlayerState.sampleStatus = 'ready'
     mockPlayerState.isPlaying = true
     mockOrientation.rotate = false
+    mockOrientation.enter.mockClear()
+    mockOrientation.exit.mockClear()
+    mockPlayerState.play.mockClear().mockResolvedValue(true)
   })
 
   it('derives the visual frame and active keys from the same playhead on first render', () => {
@@ -287,6 +290,47 @@ describe('FallingNotesPlayer', () => {
       expect(screen.getByTestId('playback-ready')).toBeInTheDocument()
       expect(screen.getByText(/히트라인/)).toBeInTheDocument()
       expect(screen.queryByTestId('compact-playback-bar')).not.toBeInTheDocument()
+    })
+  })
+
+  // enter() runs from the click, but isPlaying only flips after play() resolves
+  // its audio setup. Anything that treats that window as "not playing" cancels
+  // the request that was just issued — on iOS that is the whole feature.
+  describe('the window between the click and the first sound', () => {
+    it('does not release the orientation while playback is still starting', async () => {
+      mockPlayerState.isPlaying = false
+      render(<FallingNotesPlayer animationData={animationData} />)
+      mockOrientation.exit.mockClear()
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('play'))
+      })
+
+      expect(mockOrientation.enter).toHaveBeenCalledTimes(1)
+      expect(mockOrientation.exit).not.toHaveBeenCalled()
+    })
+
+    it('does not release the orientation merely because the player mounted idle', () => {
+      mockPlayerState.isPlaying = false
+      render(<FallingNotesPlayer animationData={animationData} />)
+
+      // Releasing on a false that was never preceded by a true is the same
+      // cancellation, arriving one render earlier.
+      expect(mockOrientation.exit).not.toHaveBeenCalled()
+    })
+
+    it('releases the orientation when the audio never starts', async () => {
+      mockPlayerState.isPlaying = false
+      mockPlayerState.play.mockResolvedValue(false)
+      render(<FallingNotesPlayer animationData={animationData} />)
+      mockOrientation.exit.mockClear()
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('play'))
+      })
+
+      // Otherwise a failed start leaves a phone turned with nothing playing.
+      expect(mockOrientation.exit).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/components/playback/CompactPlaybackBar.tsx
+++ b/src/components/playback/CompactPlaybackBar.tsx
@@ -31,6 +31,7 @@ export interface CompactPlaybackBarProps {
 }
 
 const SPEEDS = [0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 2.0]
+const SEEK_STEP_SEC = 5
 
 function formatTime(seconds: number): string {
   const total = Math.max(0, Math.floor(seconds))
@@ -55,10 +56,34 @@ export default function CompactPlaybackBar({
 }: CompactPlaybackBarProps) {
   const progress = duration > 0 ? Math.min(100, Math.max(0, (currentTime / duration) * 100)) : 0
 
+  const clamp = (time: number) => Math.min(duration, Math.max(0, time))
+
   const handleSeek = (event: React.MouseEvent<HTMLDivElement>) => {
     const rect = event.currentTarget.getBoundingClientRect()
     if (rect.width <= 0) return
-    onSeek(((event.clientX - rect.left) / rect.width) * duration)
+    onSeek(clamp(((event.clientX - rect.left) / rect.width) * duration))
+  }
+
+  /**
+   * The playhead is a slider, not decoration, so a keyboard has to be able to
+   * move it. It is not an `input[type=range]`: React fires that element's
+   * onChange on every drag step, and each seek here restarts the audio from the
+   * new position. Discrete key steps commit one seek apiece.
+   */
+  const handleSeekKey = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const step = event.shiftKey ? 1 : SEEK_STEP_SEC
+    const next = {
+      ArrowRight: () => currentTime + step,
+      ArrowUp: () => currentTime + step,
+      ArrowLeft: () => currentTime - step,
+      ArrowDown: () => currentTime - step,
+      Home: () => 0,
+      End: () => duration,
+    }[event.key]
+
+    if (!next) return
+    event.preventDefault()
+    onSeek(clamp(next()))
   }
 
   return (
@@ -93,9 +118,16 @@ export default function CompactPlaybackBar({
       </span>
 
       <div
-        className="h-2 min-w-0 flex-1 cursor-pointer rounded-full bg-gray-200 hover:bg-gray-300"
+        className="h-2 min-w-0 flex-1 cursor-pointer rounded-full bg-gray-200 hover:bg-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
         onClick={handleSeek}
-        role="presentation"
+        onKeyDown={handleSeekKey}
+        role="slider"
+        tabIndex={0}
+        aria-label="재생 위치"
+        aria-valuemin={0}
+        aria-valuemax={Math.round(duration)}
+        aria-valuenow={Math.round(currentTime)}
+        aria-valuetext={`${formatTime(currentTime)} / ${formatTime(duration)}`}
       >
         <div className="h-2 rounded-full bg-blue-600" style={{ width: `${progress}%` }} />
       </div>

--- a/src/components/playback/CompactPlaybackBar.tsx
+++ b/src/components/playback/CompactPlaybackBar.tsx
@@ -1,0 +1,133 @@
+'use client'
+
+/**
+ * One-row transport for a screen that is being watched rather than set up.
+ *
+ * `PlaybackControls` stacks three rows and costs 152px, and the player adds an
+ * instruction line, a sample-status line and a volume row on top of it — 264px
+ * in total. An iPhone 12 in landscape has 390px of viewport height, so those
+ * rows and the falling notes cannot both exist. This bar keeps only what is
+ * still useful once the score is sounding: a transport, a seekable position, a
+ * tempo, and the gain.
+ *
+ * The mode selector is deliberately absent. `FallingNotesPlayer` only supports
+ * listen mode, and its handler logs rather than switching, so the control has
+ * nothing to offer here.
+ */
+
+export interface CompactPlaybackBarProps {
+  isReady: boolean
+  currentTime: number
+  duration: number
+  playbackSpeed: number
+  volume: number
+  maxVolume: number
+  onPause: () => void
+  onStop: () => void
+  onSeek: (time: number) => void
+  onSpeedChange: (speed: number) => void
+  onVolumeChange: (volume: number) => void
+  className?: string
+}
+
+const SPEEDS = [0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 2.0]
+
+function formatTime(seconds: number): string {
+  const total = Math.max(0, Math.floor(seconds))
+  const mins = Math.floor(total / 60)
+  const secs = total % 60
+  return `${mins}:${secs.toString().padStart(2, '0')}`
+}
+
+export default function CompactPlaybackBar({
+  isReady,
+  currentTime,
+  duration,
+  playbackSpeed,
+  volume,
+  maxVolume,
+  onPause,
+  onStop,
+  onSeek,
+  onSpeedChange,
+  onVolumeChange,
+  className = '',
+}: CompactPlaybackBarProps) {
+  const progress = duration > 0 ? Math.min(100, Math.max(0, (currentTime / duration) * 100)) : 0
+
+  const handleSeek = (event: React.MouseEvent<HTMLDivElement>) => {
+    const rect = event.currentTarget.getBoundingClientRect()
+    if (rect.width <= 0) return
+    onSeek(((event.clientX - rect.left) / rect.width) * duration)
+  }
+
+  return (
+    <div
+      data-testid="compact-playback-bar"
+      className={`flex items-center gap-3 h-14 px-1 ${className}`}
+    >
+      <button
+        type="button"
+        onClick={onPause}
+        disabled={!isReady}
+        aria-label="일시정지"
+        className="h-10 w-10 shrink-0 rounded-md border border-gray-300 bg-white text-lg leading-none hover:border-gray-400 disabled:opacity-50"
+      >
+        ⏸️
+      </button>
+      <button
+        type="button"
+        onClick={onStop}
+        disabled={!isReady}
+        aria-label="정지"
+        className="h-10 w-10 shrink-0 rounded-md border border-gray-300 bg-white text-lg leading-none hover:border-gray-400 disabled:opacity-50"
+      >
+        ⏹️
+      </button>
+
+      {/* The two readouts are the first things to go on a narrow box: the
+          transport, the seek bar and the two inputs all have to keep working
+          before a number is worth a column of width. */}
+      <span className="hidden shrink-0 text-xs font-mono tabular-nums text-gray-600 sm:inline">
+        {formatTime(currentTime)} / {formatTime(duration)}
+      </span>
+
+      <div
+        className="h-2 min-w-0 flex-1 cursor-pointer rounded-full bg-gray-200 hover:bg-gray-300"
+        onClick={handleSeek}
+        role="presentation"
+      >
+        <div className="h-2 rounded-full bg-blue-600" style={{ width: `${progress}%` }} />
+      </div>
+
+      <select
+        value={playbackSpeed}
+        onChange={event => onSpeedChange(parseFloat(event.target.value))}
+        aria-label="재생 속도"
+        className="h-10 shrink-0 rounded-md border border-gray-300 bg-white px-2 text-xs"
+      >
+        {SPEEDS.map(speed => (
+          <option key={speed} value={speed}>
+            {speed}x
+          </option>
+        ))}
+      </select>
+
+      {/* The readout is the gain value itself, which is what makes this usable
+          for choosing DEFAULT_MASTER_GAIN by ear during playback. */}
+      <input
+        type="range"
+        min={0}
+        max={maxVolume}
+        step={0.01}
+        value={volume}
+        onChange={event => onVolumeChange(parseFloat(event.target.value))}
+        aria-label="음량 (master gain)"
+        className="w-20 shrink-0"
+      />
+      <span className="hidden shrink-0 w-10 text-right text-xs font-mono tabular-nums text-gray-500 sm:inline">
+        {volume.toFixed(2)}
+      </span>
+    </div>
+  )
+}

--- a/src/components/playback/__tests__/CompactPlaybackBar.test.tsx
+++ b/src/components/playback/__tests__/CompactPlaybackBar.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import CompactPlaybackBar from '../CompactPlaybackBar'
+
+function renderBar(overrides: Partial<React.ComponentProps<typeof CompactPlaybackBar>> = {}) {
+  const props = {
+    isReady: true,
+    currentTime: 30,
+    duration: 100,
+    playbackSpeed: 1,
+    volume: 0.22,
+    maxVolume: 1,
+    onPause: jest.fn(),
+    onStop: jest.fn(),
+    onSeek: jest.fn(),
+    onSpeedChange: jest.fn(),
+    onVolumeChange: jest.fn(),
+    ...overrides,
+  }
+  render(<CompactPlaybackBar {...props} />)
+  return props
+}
+
+describe('CompactPlaybackBar', () => {
+  // The bar exists because a landscape phone has 390px of height in total. What
+  // it drops has to be chrome, never a way to operate playback — including for
+  // someone who never touches the screen.
+  describe('seeking', () => {
+    it('exposes the position as a slider a keyboard can reach', () => {
+      renderBar()
+
+      const seek = screen.getByRole('slider', { name: '재생 위치' })
+      expect(seek).toHaveAttribute('tabindex', '0')
+      expect(seek).toHaveAttribute('aria-valuemin', '0')
+      expect(seek).toHaveAttribute('aria-valuemax', '100')
+      expect(seek).toHaveAttribute('aria-valuenow', '30')
+    })
+
+    it('steps the playhead with the arrow keys', () => {
+      const props = renderBar()
+      const seek = screen.getByRole('slider', { name: '재생 위치' })
+
+      fireEvent.keyDown(seek, { key: 'ArrowRight' })
+      expect(props.onSeek).toHaveBeenCalledWith(35)
+
+      fireEvent.keyDown(seek, { key: 'ArrowLeft' })
+      expect(props.onSeek).toHaveBeenCalledWith(25)
+    })
+
+    it('jumps to either end with Home and End', () => {
+      const props = renderBar()
+      const seek = screen.getByRole('slider', { name: '재생 위치' })
+
+      fireEvent.keyDown(seek, { key: 'Home' })
+      expect(props.onSeek).toHaveBeenCalledWith(0)
+
+      fireEvent.keyDown(seek, { key: 'End' })
+      expect(props.onSeek).toHaveBeenCalledWith(100)
+    })
+
+    it('clamps a step at the ends rather than seeking outside the score', () => {
+      const atEnd = renderBar({ currentTime: 98 })
+      fireEvent.keyDown(screen.getByRole('slider', { name: '재생 위치' }), { key: 'ArrowRight' })
+      expect(atEnd.onSeek).toHaveBeenCalledWith(100)
+    })
+  })
+
+  it('keeps the transport and both inputs reachable', () => {
+    const props = renderBar()
+
+    fireEvent.click(screen.getByLabelText('일시정지'))
+    expect(props.onPause).toHaveBeenCalled()
+
+    fireEvent.click(screen.getByLabelText('정지'))
+    expect(props.onStop).toHaveBeenCalled()
+
+    fireEvent.change(screen.getByLabelText('재생 속도'), { target: { value: '1.5' } })
+    expect(props.onSpeedChange).toHaveBeenCalledWith(1.5)
+
+    fireEvent.change(screen.getByLabelText('음량 (master gain)'), { target: { value: '0.4' } })
+    expect(props.onVolumeChange).toHaveBeenCalledWith(0.4)
+  })
+})

--- a/src/components/playback/index.ts
+++ b/src/components/playback/index.ts
@@ -1,2 +1,3 @@
 export { default as PlaybackControls } from './PlaybackControls'
 export { default as AdvancedPlaybackControls } from './AdvancedPlaybackControls'
+export { default as CompactPlaybackBar } from './CompactPlaybackBar'

--- a/src/hooks/__tests__/usePlaybackOrientation.test.ts
+++ b/src/hooks/__tests__/usePlaybackOrientation.test.ts
@@ -206,4 +206,74 @@ describe('usePlaybackOrientation', () => {
     expect(unlock).toHaveBeenCalledTimes(1)
     expect(document.exitFullscreen).toHaveBeenCalledTimes(1)
   })
+
+  // The browser answers requestFullscreen and lock() on its own schedule, and a
+  // reader can press stop or leave the page while it is still deciding.
+  describe('requests that outlive their playback session', () => {
+    function deferredFullscreen() {
+      let resolveFullscreen: () => void = () => {}
+      const requestFullscreen = jest.fn(
+        () => new Promise<void>(resolve => { resolveFullscreen = resolve })
+      )
+      const target = document.createElement('div')
+      Object.defineProperty(target, 'requestFullscreen', {
+        writable: true,
+        configurable: true,
+        value: requestFullscreen,
+      })
+      const ref = createRef<HTMLElement>()
+      ;(ref as { current: HTMLElement | null }).current = target
+      return { ref, target, requestFullscreen, resolve: () => resolveFullscreen() }
+    }
+
+    it('does not lock a screen whose playback already stopped', async () => {
+      givenPortraitTouchDevice()
+      const lock = jest.fn().mockResolvedValue(undefined)
+      givenScreenOrientation({ lock, unlock: jest.fn() })
+      const { ref, target, resolve } = deferredFullscreen()
+
+      const { result } = renderHook(() => usePlaybackOrientation(ref))
+      act(() => result.current.enter())
+      act(() => result.current.exit())
+      ;(document as { fullscreenElement: Element | null }).fullscreenElement = target
+
+      resolve()
+      await flush()
+
+      // Locking here would leave the screen turned with nothing left to turn it
+      // back: exit() has already run its release.
+      expect(lock).not.toHaveBeenCalled()
+      expect(document.exitFullscreen).toHaveBeenCalled()
+    })
+
+    it('does not lock a screen whose player already unmounted', async () => {
+      givenPortraitTouchDevice()
+      const lock = jest.fn().mockResolvedValue(undefined)
+      givenScreenOrientation({ lock, unlock: jest.fn() })
+      const { ref, resolve } = deferredFullscreen()
+
+      const { result, unmount } = renderHook(() => usePlaybackOrientation(ref))
+      act(() => result.current.enter())
+      unmount()
+
+      resolve()
+      await flush()
+
+      expect(lock).not.toHaveBeenCalled()
+    })
+  })
+
+  it('returns a stable object so consumers can depend on it in an effect', () => {
+    givenDesktop()
+    givenScreenOrientation({})
+    const { ref } = makeTarget()
+
+    const { result, rerender } = renderHook(() => usePlaybackOrientation(ref))
+    const first = result.current
+    rerender()
+
+    // A fresh object every render re-runs any effect that lists it, which is how
+    // an exit() ended up cancelling the enter() that had just been issued.
+    expect(result.current).toBe(first)
+  })
 })

--- a/src/hooks/__tests__/usePlaybackOrientation.test.ts
+++ b/src/hooks/__tests__/usePlaybackOrientation.test.ts
@@ -17,26 +17,25 @@ function setQuery(query: string, matches: boolean) {
 }
 
 function installMatchMedia() {
-  Object.defineProperty(window, 'matchMedia', {
-    writable: true,
-    configurable: true,
-    value: (query: string) => {
-      if (!queries.has(query)) queries.set(query, { matches: false, listeners: new Set() })
-      const state = queries.get(query)!
-      return {
-        get matches() {
-          return state.matches
-        },
-        media: query,
-        addEventListener: (_type: string, listener: () => void) => {
-          state.listeners.add(listener)
-        },
-        removeEventListener: (_type: string, listener: () => void) => {
-          state.listeners.delete(listener)
-        },
-      }
-    },
-  })
+  // jest.setup.js already defines a non-configurable (but writable) matchMedia
+  // whose queries never match, so this replaces the value rather than the
+  // property descriptor.
+  window.matchMedia = ((query: string) => {
+    if (!queries.has(query)) queries.set(query, { matches: false, listeners: new Set() })
+    const state = queries.get(query)!
+    return {
+      get matches() {
+        return state.matches
+      },
+      media: query,
+      addEventListener: (_type: string, listener: () => void) => {
+        state.listeners.add(listener)
+      },
+      removeEventListener: (_type: string, listener: () => void) => {
+        state.listeners.delete(listener)
+      },
+    }
+  }) as unknown as typeof window.matchMedia
 }
 
 /** A phone held upright: touch input, portrait screen. */

--- a/src/hooks/__tests__/usePlaybackOrientation.test.ts
+++ b/src/hooks/__tests__/usePlaybackOrientation.test.ts
@@ -1,0 +1,210 @@
+import { renderHook, act } from '@testing-library/react'
+import { createRef } from 'react'
+import { usePlaybackOrientation } from '../usePlaybackOrientation'
+
+type QueryState = { matches: boolean; listeners: Set<() => void> }
+
+const queries = new Map<string, QueryState>()
+
+function setQuery(query: string, matches: boolean) {
+  const existing = queries.get(query)
+  if (existing) {
+    existing.matches = matches
+    existing.listeners.forEach(listener => listener())
+    return
+  }
+  queries.set(query, { matches, listeners: new Set() })
+}
+
+function installMatchMedia() {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: (query: string) => {
+      if (!queries.has(query)) queries.set(query, { matches: false, listeners: new Set() })
+      const state = queries.get(query)!
+      return {
+        get matches() {
+          return state.matches
+        },
+        media: query,
+        addEventListener: (_type: string, listener: () => void) => {
+          state.listeners.add(listener)
+        },
+        removeEventListener: (_type: string, listener: () => void) => {
+          state.listeners.delete(listener)
+        },
+      }
+    },
+  })
+}
+
+/** A phone held upright: touch input, portrait screen. */
+function givenPortraitTouchDevice() {
+  setQuery('(pointer: coarse)', true)
+  setQuery('(orientation: portrait)', true)
+}
+
+/** A desktop browser: fine pointer, and usually already landscape. */
+function givenDesktop() {
+  setQuery('(pointer: coarse)', false)
+  setQuery('(orientation: portrait)', false)
+}
+
+function givenScreenOrientation(value: unknown) {
+  Object.defineProperty(window.screen, 'orientation', {
+    writable: true,
+    configurable: true,
+    value,
+  })
+}
+
+function makeTarget() {
+  const target = document.createElement('div')
+  const requestFullscreen = jest.fn().mockResolvedValue(undefined)
+  Object.defineProperty(target, 'requestFullscreen', {
+    writable: true,
+    configurable: true,
+    value: requestFullscreen,
+  })
+  const ref = createRef<HTMLElement>()
+  ;(ref as { current: HTMLElement | null }).current = target
+  return { target, ref, requestFullscreen }
+}
+
+const flush = () => act(async () => { await Promise.resolve() })
+
+describe('usePlaybackOrientation', () => {
+  beforeEach(() => {
+    queries.clear()
+    installMatchMedia()
+    Object.defineProperty(document, 'fullscreenElement', {
+      writable: true,
+      configurable: true,
+      value: null,
+    })
+    Object.defineProperty(document, 'exitFullscreen', {
+      writable: true,
+      configurable: true,
+      value: jest.fn().mockResolvedValue(undefined),
+    })
+  })
+
+  it('leaves a desktop browser alone — it never rotates and never asks for fullscreen', () => {
+    givenDesktop()
+    givenScreenOrientation({ lock: jest.fn().mockResolvedValue(undefined), unlock: jest.fn() })
+    const { ref, requestFullscreen } = makeTarget()
+
+    const { result } = renderHook(() => usePlaybackOrientation(ref))
+    act(() => result.current.enter())
+
+    expect(result.current.rotate).toBe(false)
+    expect(requestFullscreen).not.toHaveBeenCalled()
+  })
+
+  it('rotates with CSS on iOS, where the interface exists but lock() does not', async () => {
+    givenPortraitTouchDevice()
+    // This is the trap the issue calls out: `'orientation' in screen` and
+    // `screen.orientation != null` are both true on iOS. Only the method is missing.
+    givenScreenOrientation({ type: 'portrait-primary', angle: 0 })
+    const { ref, requestFullscreen } = makeTarget()
+
+    const { result } = renderHook(() => usePlaybackOrientation(ref))
+    act(() => result.current.enter())
+    await flush()
+
+    expect(result.current.rotate).toBe(true)
+    // iOS grants Element.requestFullscreen to <video> only; asking here would
+    // reject and buy nothing, since the CSS path already covers the screen.
+    expect(requestFullscreen).not.toHaveBeenCalled()
+  })
+
+  it('locks the real screen on Android and stops rotating once it turns', async () => {
+    givenPortraitTouchDevice()
+    const lock = jest.fn().mockResolvedValue(undefined)
+    givenScreenOrientation({ lock, unlock: jest.fn() })
+    const { ref, requestFullscreen } = makeTarget()
+
+    const { result } = renderHook(() => usePlaybackOrientation(ref))
+    act(() => result.current.enter())
+
+    // The CSS rotation covers the gap until the lock resolves, so playback is
+    // never shown upright in portrait.
+    expect(result.current.rotate).toBe(true)
+    await flush()
+    expect(requestFullscreen).toHaveBeenCalledTimes(1)
+    expect(lock).toHaveBeenCalledWith('landscape')
+
+    // The lock makes the screen genuinely landscape; the CSS transform must go.
+    act(() => setQuery('(orientation: portrait)', false))
+    expect(result.current.rotate).toBe(false)
+  })
+
+  it('drops the CSS rotation the moment the user turns the device themselves', async () => {
+    givenPortraitTouchDevice()
+    givenScreenOrientation({ type: 'portrait-primary' })
+    const { ref } = makeTarget()
+
+    const { result } = renderHook(() => usePlaybackOrientation(ref))
+    act(() => result.current.enter())
+    await flush()
+    expect(result.current.rotate).toBe(true)
+
+    // Without this, a physical turn would apply 90 degrees twice.
+    act(() => setQuery('(orientation: portrait)', false))
+    expect(result.current.rotate).toBe(false)
+
+    // Turning back must bring the stand-in rotation back while playback runs.
+    act(() => setQuery('(orientation: portrait)', true))
+    expect(result.current.rotate).toBe(true)
+  })
+
+  it('keeps the CSS rotation when the lock is refused', async () => {
+    givenPortraitTouchDevice()
+    const lock = jest.fn().mockRejectedValue(new Error('not supported on this device'))
+    givenScreenOrientation({ lock, unlock: jest.fn() })
+    const { ref } = makeTarget()
+
+    const { result } = renderHook(() => usePlaybackOrientation(ref))
+    act(() => result.current.enter())
+    await flush()
+
+    expect(result.current.rotate).toBe(true)
+  })
+
+  it('releases the lock and the fullscreen element when playback ends', async () => {
+    givenPortraitTouchDevice()
+    const unlock = jest.fn()
+    givenScreenOrientation({ lock: jest.fn().mockResolvedValue(undefined), unlock })
+    const { target, ref } = makeTarget()
+
+    const { result } = renderHook(() => usePlaybackOrientation(ref))
+    act(() => result.current.enter())
+    await flush()
+    ;(document as { fullscreenElement: Element | null }).fullscreenElement = target
+
+    act(() => result.current.exit())
+    await flush()
+
+    expect(unlock).toHaveBeenCalledTimes(1)
+    expect(document.exitFullscreen).toHaveBeenCalledTimes(1)
+    expect(result.current.rotate).toBe(false)
+  })
+
+  it('releases everything when the player unmounts mid-playback', async () => {
+    givenPortraitTouchDevice()
+    const unlock = jest.fn()
+    givenScreenOrientation({ lock: jest.fn().mockResolvedValue(undefined), unlock })
+    const { target, ref } = makeTarget()
+
+    const { result, unmount } = renderHook(() => usePlaybackOrientation(ref))
+    act(() => result.current.enter())
+    await flush()
+    ;(document as { fullscreenElement: Element | null }).fullscreenElement = target
+
+    unmount()
+
+    expect(unlock).toHaveBeenCalledTimes(1)
+    expect(document.exitFullscreen).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/hooks/useFallingNotesPlayer.ts
+++ b/src/hooks/useFallingNotesPlayer.ts
@@ -39,8 +39,12 @@ export function useFallingNotesPlayer(notes: FallingNote[]) {
   /**
    * Start playback
    */
+  // Returns whether playback actually began. The caller needs that: a request
+  // made from the click — the orientation change is one — has to be undone when
+  // the audio never starts, and `isPlaying` alone cannot distinguish "not yet"
+  // from "never".
   const handlePlay = useCallback(async () => {
-    if (isPlaying) return
+    if (isPlaying) return false
 
     updateTempoScale(tempoScale)
     const started = await startAudio(
@@ -50,6 +54,7 @@ export function useFallingNotesPlayer(notes: FallingNote[]) {
       mute
     )
     if (started) setIsPlaying(true)
+    return started
   }, [isPlaying, tempoScale, mute, notes, getCurrentTime, startAudio, updateTempoScale])
 
   /**

--- a/src/hooks/usePlaybackOrientation.ts
+++ b/src/hooks/usePlaybackOrientation.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { RefObject } from 'react'
 
 /**
@@ -67,6 +67,11 @@ export function usePlaybackOrientation(
   const [isPortrait, setIsPortrait] = useState(false)
   const [isTouchDevice, setIsTouchDevice] = useState(false)
   const lockedRef = useRef(false)
+  // The browser answers requestFullscreen and lock() on its own schedule. A
+  // reader can stop playback or leave the page while it is still deciding, and
+  // a chain that completes after that would lock a screen with nothing left to
+  // release it.
+  const requestIdRef = useRef(0)
 
   useEffect(() => {
     if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
@@ -104,6 +109,7 @@ export function usePlaybackOrientation(
   }, [])
 
   const enter = useCallback(() => {
+    const requestId = ++requestIdRef.current
     setEngaged(true)
 
     // A desktop window is not something the reader can turn, and putting a
@@ -119,29 +125,47 @@ export function usePlaybackOrientation(
     const target = fullscreenTarget.current
     if (!target?.requestFullscreen) return
 
+    const isCurrent = () => requestIdRef.current === requestId
+
     target
       .requestFullscreen()
-      .then(() => screenOrientation()?.lock?.('landscape'))
       .then(() => {
-        lockedRef.current = true
+        if (!isCurrent()) return undefined
+        return screenOrientation()?.lock?.('landscape')
+      })
+      .then(() => {
+        if (isCurrent()) {
+          lockedRef.current = true
+          return
+        }
+        // The session ended while the browser was deciding. Fullscreen may have
+        // been granted anyway, and the release that would have undone it has
+        // already run.
+        release()
       })
       .catch(() => {
         // A device that refuses landscape keeps the CSS rotation, because the
         // portrait query never changed. Nothing else has to happen here.
       })
-  }, [fullscreenTarget])
+  }, [fullscreenTarget, release])
 
   const exit = useCallback(() => {
+    requestIdRef.current += 1
     setEngaged(false)
     release()
   }, [release])
 
   // Leaving the page mid-playback must not strand a locked screen.
-  useEffect(() => release, [release])
+  useEffect(() => () => {
+    requestIdRef.current += 1
+    release()
+  }, [release])
 
-  return {
-    rotate: engaged && isTouchDevice && isPortrait,
-    enter,
-    exit,
-  }
+  // A fresh object every render re-runs any effect that lists it, and the
+  // player lists it beside `isPlaying`. That churn is what let an exit() land
+  // on the render that enter() had just caused.
+  return useMemo(
+    () => ({ rotate: engaged && isTouchDevice && isPortrait, enter, exit }),
+    [engaged, isTouchDevice, isPortrait, enter, exit]
+  )
 }

--- a/src/hooks/usePlaybackOrientation.ts
+++ b/src/hooks/usePlaybackOrientation.ts
@@ -1,0 +1,147 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { RefObject } from 'react'
+
+/**
+ * Playback orientation for a device held upright.
+ *
+ * The two mobile platforms need opposite mechanisms. Android exposes
+ * `screen.orientation.lock()`, which the spec allows only from fullscreen, so
+ * playback turns the hardware itself. iOS ships the `ScreenOrientation`
+ * interface without `lock()` — and without manifest `orientation` support — so
+ * the only remaining lever is a CSS transform on the player.
+ *
+ * Both paths collapse into one condition. A successful lock makes the screen
+ * genuinely landscape, which ends the portrait media query, which withdraws the
+ * CSS rotation. The same query withdraws it when the user turns the device by
+ * hand, so the double-rotation hazard has no separate branch to get wrong.
+ */
+
+const PORTRAIT_QUERY = '(orientation: portrait)'
+const COARSE_POINTER_QUERY = '(pointer: coarse)'
+
+/**
+ * TypeScript's lib.dom declares `ScreenOrientation` without `lock()` — the very
+ * gap this hook detects at runtime, since Safari has never shipped the method.
+ * Declaring both members optional keeps the type honest about that.
+ */
+type LockableScreenOrientation = ScreenOrientation & {
+  lock?: (orientation: 'landscape') => Promise<void>
+  unlock?: () => void
+}
+
+function screenOrientation(): LockableScreenOrientation | undefined {
+  if (typeof window === 'undefined') return undefined
+  return window.screen?.orientation as LockableScreenOrientation | undefined
+}
+
+function queryMatches(query: string): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false
+  return window.matchMedia(query).matches
+}
+
+/**
+ * iOS answers true to `'orientation' in screen` and to `screen.orientation !=
+ * null` — the interface is there since Safari 16.4 and only the method is
+ * missing. Detecting anything other than the callable method silently routes
+ * iOS into the Android path, where nothing happens at all.
+ */
+function canLockOrientation(): boolean {
+  return typeof screenOrientation()?.lock === 'function'
+}
+
+export type PlaybackOrientation = {
+  /** True while the player must stand in for a rotation the device will not perform. */
+  rotate: boolean
+  /** Call synchronously from the play click — fullscreen needs that activation. */
+  enter: () => void
+  /** Call when playback stops, or when the player goes away. */
+  exit: () => void
+}
+
+export function usePlaybackOrientation(
+  fullscreenTarget: RefObject<HTMLElement | null>
+): PlaybackOrientation {
+  const [engaged, setEngaged] = useState(false)
+  const [isPortrait, setIsPortrait] = useState(false)
+  const [isTouchDevice, setIsTouchDevice] = useState(false)
+  const lockedRef = useRef(false)
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
+
+    const portrait = window.matchMedia(PORTRAIT_QUERY)
+    const coarsePointer = window.matchMedia(COARSE_POINTER_QUERY)
+    const syncPortrait = () => setIsPortrait(portrait.matches)
+    const syncPointer = () => setIsTouchDevice(coarsePointer.matches)
+
+    syncPortrait()
+    syncPointer()
+    portrait.addEventListener?.('change', syncPortrait)
+    coarsePointer.addEventListener?.('change', syncPointer)
+
+    return () => {
+      portrait.removeEventListener?.('change', syncPortrait)
+      coarsePointer.removeEventListener?.('change', syncPointer)
+    }
+  }, [])
+
+  const release = useCallback(() => {
+    if (lockedRef.current) {
+      lockedRef.current = false
+      try {
+        screenOrientation()?.unlock?.()
+      } catch {
+        // Unlocking a screen that was never locked is not worth reporting.
+      }
+    }
+    if (typeof document !== 'undefined' && document.fullscreenElement) {
+      document.exitFullscreen?.().catch(() => {
+        // The user may have left fullscreen already; there is nothing to undo.
+      })
+    }
+  }, [])
+
+  const enter = useCallback(() => {
+    setEngaged(true)
+
+    // A desktop window is not something the reader can turn, and putting a
+    // desktop browser into fullscreen on play would be its own defect.
+    if (!queryMatches(COARSE_POINTER_QUERY)) return
+    if (!queryMatches(PORTRAIT_QUERY)) return
+
+    // Without lock() there is nothing fullscreen can buy: iOS grants
+    // Element.requestFullscreen to <video> alone, and the CSS rotation already
+    // covers the screen. Asking would only produce a rejected promise.
+    if (!canLockOrientation()) return
+
+    const target = fullscreenTarget.current
+    if (!target?.requestFullscreen) return
+
+    target
+      .requestFullscreen()
+      .then(() => screenOrientation()?.lock?.('landscape'))
+      .then(() => {
+        lockedRef.current = true
+      })
+      .catch(() => {
+        // A device that refuses landscape keeps the CSS rotation, because the
+        // portrait query never changed. Nothing else has to happen here.
+      })
+  }, [fullscreenTarget])
+
+  const exit = useCallback(() => {
+    setEngaged(false)
+    release()
+  }, [release])
+
+  // Leaving the page mid-playback must not strand a locked screen.
+  useEffect(() => release, [release])
+
+  return {
+    rotate: engaged && isTouchDevice && isPortrait,
+    enter,
+    exit,
+  }
+}


### PR DESCRIPTION
이슈 [#65](https://github.com/landfill/ClairKeys/issues/65)의 **할 일 4**를 구현한다. 할 일 5~6은 이 PR의 범위가 아니다.

## 왜 필요한가

D-017의 곡 단위 크롭은 세로 화면의 폭 문제를 풀지 못한다. iPhone 12 세로의 가용 폭 356px에서 33 흰건반 악보는 건반 폭 **10.79px**에 그친다. 남은 지렛대는 화면 자체의 방향뿐이다.

## 두 플랫폼, 하나의 조건

Android는 fullscreen 선행 후 `screen.orientation.lock()`이 동작한다. iOS는 `lock()`도 manifest `orientation`도 없어 CSS 변환만 남는다.

그런데 **락이 성공하면 화면이 실제로 가로가 되므로 `(orientation: portrait)` 질의가 스스로 false가 된다.** 따라서 회전 조건을 이렇게 두면:

```
rotate = engaged && (pointer: coarse) && (orientation: portrait)
```

락 성공도, 사용자가 직접 기기를 돌린 것도 같은 한 줄이 처리한다. **이슈가 요구한 "이중 회전 해제"가 별도 분기가 아니라 이 식의 결과**다.

### iOS feature-detect 함정

iOS는 `ScreenOrientation` 인터페이스를 Safari 16.4+로 **제공하고 `lock()`만 없다.** `'orientation' in screen`이나 null 검사로 판별하면 iOS가 조용히 Android 경로로 가서 아무 일도 일어나지 않는다. `typeof screen.orientation?.lock === 'function'`으로만 판별하며, 회귀 테스트가 이 함정을 직접 고정한다.

### 사용자 제스처 수명

`requestFullscreen()`은 transient activation을 요구하는데 `play()`는 AudioContext 재개와 샘플 로딩을 `await`한다. `isPlaying` effect에서 요청하면 활성화 창을 놓칠 수 있으므로, **방향 요청은 재생 클릭 핸들러 안에서 동기적으로** 발사한다.

### 데스크톱은 대상이 아니다

창에는 전환할 방향이 없고, 재생 시 브라우저를 fullscreen으로 미는 것은 그 자체가 결함이다. `(pointer: coarse)`로 배제하며, 테스트가 "데스크톱에서는 회전도 fullscreen 요청도 없다"를 고정한다.

## 회전만으로는 쓸 수 없는 화면이 나온다 — 실측이 압축을 강제했다

배포된 플레이어에서 잰 결과, **재생 중 플레이어 자체 chrome이 264px**이다.

| 블록 | 높이 |
|---|---:|
| 안내문 | 32 |
| PlaybackControls (3행) | 168 |
| 샘플 상태 줄 | 32 |
| 음량 행 | 32 |
| **합계** | **264** |

iPhone 12 가로의 뷰포트 높이는 **390px 전체**다. 회전만 하면 시각화에 126px이 남고 건반 120px을 빼면 낙하 영역이 **6px**이 된다. 그래서 회전과 압축은 두 개의 작업이 아니라 하나다.

`CompactPlaybackBar`(56px 한 줄)가 재생 중 4개 블록을 대체한다.

| | 회전 전(세로) | 이 PR(가로) |
|---|---:|---:|
| 가용 폭 | 356px | 842px |
| 건반 폭 (33 흰건반) | **10.79px** | **24px** (상한) |
| 플레이어 chrome | 264px | **64px** |
| 낙하 영역 | 460px | **206px** |

206px은 설정값 `lookAheadSec` 1.5s × `pxPerSec` 140 = 210px에 해당한다.

**압축이 버리지 않는 것**: 음량 슬라이더는 남긴다 — 귀로 `DEFAULT_MASTER_GAIN`을 고르는 것이 목적이라 소리가 나는 동안 조작할 수 있어야 한다. 샘플 상태 줄은 행을 내주되 `sr-only`로 live region을 유지해, 화면을 못 보는 사용자도 녹음 샘플이 합성음으로 대체됐음을 계속 듣는다. 공유 `PlaybackControls`는 수정하지 않았다 — `AnimationPlayer`와 demo 페이지가 의존한다.

## 검증

```
npm test           56 suites / 542 tests passed
npx tsc --noEmit   exit 0
npm run lint       No ESLint warnings or errors
npm run build      성공
```

회귀 테스트를 동작 변경보다 먼저 두 번 단독 커밋했다.

- `3b46afc` (방향 계약) — 2 suites failed to run, `@/hooks/usePlaybackOrientation` 미존재.
- `385e070` (압축 계약) — 2 failed / 14 passed, 압축 바 부재와 상태 줄이 `sr-only`가 아님을 정확히 짚는다.

**브라우저 실측**:

1. **회전 수식** — `width:100dvh; height:100dvw; transform-origin:top left; transform:rotate(90deg) translateY(-100%)`가 레이아웃 박스 746×1470으로 잡히고 변환 후 **정확히 (0,0,1470,746)** 뷰포트를 덮는다. 오차 0.
2. **합성 검증** — 로컬 `/test-finger` 재생에서 압축 바 실측 **56px**, 샘플 상태 **0px**(sr-only), 낙하 영역이 `visualizationSize.height − 120`과 정확히 일치. 회전 CSS를 함께 적용해 건반이 한 변에, 컨트롤이 반대 변에 놓이는 최종 구성을 확인했다.

## 검증하지 못한 것

- **실제 방향 잠금을 관측하지 못했다.** `screen.orientation.lock()`의 실제 동작은 실기기에서만 확인된다. hook의 분기 논리는 7개 단위 테스트로 고정했지만 **API 호출의 실제 결과는 미검증**이다.
- **실기기 없음.** Android/iOS 모두 미확인이다.
- **CSS 회전 방향이 임의 선택이다.** `rotate(90deg)`는 기기를 반시계로 돌려야 바로 보인다. 회전 잠금을 켠 iOS 사용자가 반대로 돌리면 뒤집혀 보인다. 실기기에서 확인할 항목으로 D-019 Consequence에 남겼다.
- Safari·Firefox 레이아웃 미확인.
- 인증이 필요한 `/sheet/[id]` E2E는 여전히 없다 (이슈 #65 할 일 6). 로컬 검증은 인증이 없는 `/test-finger`로 했다.

## 결정 기록

`docs/recovery/DECISIONS.md`에 **D-019**를 추가했다. `AGENTS.md`가 DECISIONS 신규 항목을 직접 커밋 예외에서 제외하므로 이 브랜치에 함께 포함했다.

할 일 5(`src/components/mobile/` 스택 처리)와 6(E2E fixture)이 남아 있으므로 **이슈를 닫지 않는다** — 종료 키워드를 의도적으로 쓰지 않는다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 모바일에서 재생 시 가로 화면 전체 화면을 지원합니다.
  * 기기 환경에 따라 화면 방향 잠금 또는 자동 회전을 적용합니다.
  * 재생 중 컨트롤을 한 줄의 컴팩트한 재생 바에 표시합니다.
  * 일시정지, 정지, 탐색, 재생 속도 및 음량 조절을 한곳에서 제공합니다.

* **개선 사항**
  * 재생 중 안내와 설정 영역을 간소화해 감상 공간을 넓혔습니다.
  * 재생 종료 시 화면 방향과 전체 화면 상태를 자동으로 복원합니다.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->