### PR TITLE
src/utils 변경이 빌드·접근성 검사를 건너뛰던 path filter 구멍을 막는다

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -14,6 +14,7 @@ jobs:
       backend: ${{ steps.changes.outputs.backend }}
       tests: ${{ steps.changes.outputs.tests }}
       docs: ${{ steps.changes.outputs.docs }}
+      core: ${{ steps.changes.outputs.core }}
     
     steps:
       - name: Checkout code
@@ -48,6 +49,20 @@ jobs:
             docs:
               - '*.md'
               - 'docs/**'
+            # Everything the other filters do not name but every job depends on.
+            # src/utils holds the render geometry and the data contract, so a
+            # change there reaches the built bundle and the rendered DOM even
+            # though it is neither a component nor an API route.
+            core:
+              - 'src/utils/**'
+              - 'src/types/**'
+              - 'src/middleware.ts'
+              - 'middleware.ts'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'next.config.js'
+              - 'tsconfig.json'
+              - '.github/workflows/**'
 
   lint-and-type-check:
     name: Lint and Type Check
@@ -76,7 +91,7 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.frontend == 'true' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true'
+    if: needs.changes.outputs.frontend == 'true' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true' || needs.changes.outputs.core == 'true'
 
     services:
       postgres:
@@ -132,7 +147,7 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.frontend == 'true' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true'
+    if: needs.changes.outputs.frontend == 'true' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.tests == 'true' || needs.changes.outputs.core == 'true'
 
     services:
       postgres:
@@ -194,7 +209,7 @@ jobs:
     name: Security Scan
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true'
+    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true' || needs.changes.outputs.core == 'true'
 
     steps:
       - name: Checkout code
@@ -224,7 +239,7 @@ jobs:
     name: Build Check
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.frontend == 'true' || needs.changes.outputs.backend == 'true'
+    if: needs.changes.outputs.frontend == 'true' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.core == 'true'
 
     steps:
       - name: Checkout code
@@ -263,7 +278,7 @@ jobs:
     name: Accessibility Check
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.frontend == 'true'
+    if: needs.changes.outputs.frontend == 'true' || needs.changes.outputs.core == 'true'
 
     env:
       NEXTAUTH_SECRET: test-secret


### PR DESCRIPTION
PR [#77](https://github.com/landfill/ClairKeys/pull/77) 작업 중 발견했다. 그 PR은 `src/utils/pianoLayout.ts`만 바꿨는데 **Build Check · Security Scan · Accessibility Check가 `skipping`**으로 나왔다.

## 원인

`pr-checks.yml`의 path filter가 `src/utils/**`를 **어느 필터에도 넣지 않았다.**

| 필터 | 포함 경로 |
|---|---|
| `frontend` | `src/components/**`, `src/app/**`, `src/hooks/**`, `public/**`, `*.css`, `tailwind.config.js` |
| `backend` | `src/lib/**`, `src/services/**`, `prisma/**`, `src/app/api/**` |
| `tests` | `**/*.test.*`, `**/*.spec.*`, jest/playwright 설정, `e2e/**` |

`src/utils/`에는 `pianoLayout.ts`(모든 건반 위치와 노트 x 좌표), `visualUtils.ts`, `dataConverter.ts`, `animationContract.ts`가 있다. 컴포넌트도 API 라우트도 아니지만 **빌드 산출물과 렌더된 DOM에 그대로 도달한다.**

## 구멍이 세 잡보다 넓다

PR #77에서 Unit Tests와 E2E가 돈 것은 **테스트 파일을 함께 바꿔 `tests` 필터가 걸렸기 때문**이다. `src/utils/`만 바꾸고 테스트를 건드리지 않은 PR은 **`Lint and Type Check` 하나만 돌고 나머지가 전부 skip된다.** `src/types/**`, middleware, 빌드 설정(`package.json`, `next.config.js`, `tsconfig.json`)도 같은 구멍이다.

## 접근

`core` 필터를 신설하고, 기존에 `frontend`/`backend`로 게이팅하던 잡들이 `core`도 받아들이게 했다.

```yaml
core:
  - 'src/utils/**'
  - 'src/types/**'
  - 'src/middleware.ts'
  - 'middleware.ts'
  - 'package.json'
  - 'package-lock.json'
  - 'next.config.js'
  - 'tsconfig.json'
  - '.github/workflows/**'
```

**접근성 검사에 특히 필요하다.** `src/utils/` 변경은 렌더된 DOM에 도달한다 — PR #77은 그려지는 건반 개수와 옥타브 라벨 수를 바꾼다 — 그리고 이 저장소에서 axe가 건반 관련 결함을 실제로 잡은 전력이 있다(PR #67).

## 기각한 것

- **`src/utils/**`를 `frontend`에 넣기** — utils는 frontend도 backend도 아니고, `src/types`와 빌드 설정도 같은 처리가 필요하다. 이름이 거짓말을 하게 된다.
- **모든 잡을 무조건 실행** — 문서 전용 PR을 싸게 유지하는 필터링의 목적 자체를 버린다.

## 검증

이 PR은 **스스로가 증거다.** `.github/workflows/**`를 `core`에 넣었으므로 이 변경 자체가 전체 잡을 트리거한다. 수정 전 필터였다면 `.github/workflows/`는 어느 필터에도 없어 이 PR도 대부분 skip됐을 것이다.

렌더된 필터 블록과 잡 조건 5곳을 모두 확인했다.

## 후속

PR #77은 이 변경 이후 브랜치를 갱신해야 Build/Security/Accessibility가 실제로 돈다. #77의 빌드는 로컬에서 통과했지만 **CI가 검증하지는 않았다.**
