### PR TITLE
Complete P1-A legacy score provenance migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "seed": "tsx prisma/seed.ts",
     "db:seed": "tsx prisma/seed.ts",
     "db:test": "tsx scripts/test-db-connection.ts",
+    "backfill:sheet-provenance": "tsx scripts/backfill-sheet-provenance.ts",
     "init-storage": "tsx scripts/init-storage.js",
     "check-data-status": "tsx scripts/check-data-status.js",
     "migrate-storage-data": "tsx scripts/migrate-storage-data.js",

--- a/prisma/migrations/20260829012000_add_sheet_provenance/migration.sql
+++ b/prisma/migrations/20260829012000_add_sheet_provenance/migration.sql
@@ -1,0 +1,6 @@
+CREATE TYPE "SheetMusicProvenance" AS ENUM ('omr', 'demo', 'unknown');
+
+ALTER TABLE "SheetMusic"
+ADD COLUMN "provenance" "SheetMusicProvenance" NOT NULL DEFAULT 'unknown';
+
+CREATE INDEX "SheetMusic_provenance_idx" ON "SheetMusic"("provenance");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -76,11 +76,20 @@ model SheetMusic {
   animationDataUrl String
   processingStatus String            @default("pending") // pending, processing, completed, failed
   omrJobId         String?           // OMR service job ID for tracking
+  provenance       SheetMusicProvenance @default(unknown)
   createdAt        DateTime          @default(now())
   updatedAt        DateTime          @updatedAt
   practiceSessions PracticeSession[]
   category         Category?         @relation(fields: [categoryId], references: [id])
   user             User              @relation(fields: [userId], references: [id])
+
+  @@index([provenance])
+}
+
+enum SheetMusicProvenance {
+  omr
+  demo
+  unknown
 }
 
 model PracticeSession {

--- a/scripts/backfill-sheet-provenance.ts
+++ b/scripts/backfill-sheet-provenance.ts
@@ -1,9 +1,6 @@
 import { config } from 'dotenv'
-import { PrismaClient, type SheetMusicProvenance } from '@prisma/client'
-import {
-  classifySheetProvenance,
-  type ProvenanceClassification,
-} from '../src/services/sheetProvenanceBackfill'
+import { PrismaClient } from '@prisma/client'
+import { runSheetProvenanceBackfill } from '../src/services/sheetProvenanceBackfill'
 
 config({ path: '.env.local' })
 config()
@@ -16,7 +13,11 @@ function allowedStorageOrigin(): string {
   if (!configured) {
     throw new Error('NEXT_PUBLIC_SUPABASE_URL is required to constrain animation downloads')
   }
-  return new URL(configured).origin
+  const url = new URL(configured)
+  if (url.protocol !== 'https:') {
+    throw new Error('NEXT_PUBLIC_SUPABASE_URL must use HTTPS')
+  }
+  return url.origin
 }
 
 async function loadAnimation(animationDataUrl: string): Promise<unknown> {
@@ -31,51 +32,43 @@ async function loadAnimation(animationDataUrl: string): Promise<unknown> {
 }
 
 async function main() {
-  const rows = await prisma.sheetMusic.findMany({
-    select: {
-      id: true,
-      omrJobId: true,
-      animationDataUrl: true,
-    },
-    orderBy: { id: 'asc' },
-  })
+  const result = await runSheetProvenanceBackfill({
+    listRows: () => prisma.sheetMusic.findMany({
+      select: {
+        id: true,
+        omrJobId: true,
+        animationDataUrl: true,
+      },
+      orderBy: { id: 'asc' },
+    }),
+    loadAnimation,
+    validateAnimationStorage: allowedStorageOrigin,
+    updateProvenance: ({ omrIds, demoIds }) => prisma.$transaction([
+      prisma.sheetMusic.updateMany({
+        where: { id: { in: omrIds } },
+        data: { provenance: 'omr' },
+      }),
+      prisma.sheetMusic.updateMany({
+        where: { id: { in: demoIds } },
+        data: { provenance: 'demo' },
+      }),
+    ]),
+  }, apply)
 
-  const classifications: ProvenanceClassification[] = []
-  for (const row of rows) {
-    const classification = await classifySheetProvenance(row, loadAnimation)
-    if (classification.fetchFailed) console.error(`SheetMusic ${row.id}: animation could not be classified`)
-    classifications.push(classification)
+  for (const classification of result.classifications) {
+    if (classification.fetchFailed) {
+      console.error(`SheetMusic ${classification.id}: animation could not be classified`)
+    }
   }
-
-  const idsByProvenance = (provenance: SheetMusicProvenance) =>
-    classifications.filter((item) => item.provenance === provenance).map((item) => item.id)
-
-  const omrIds = idsByProvenance('omr')
-  const demoIds = idsByProvenance('demo')
-  const unknownIds = idsByProvenance('unknown')
-  const fetchFailures = classifications.filter((item) => item.fetchFailed).length
 
   console.log(JSON.stringify({
     mode: apply ? 'apply' : 'dry-run',
-    total: rows.length,
-    omr: omrIds.length,
-    demo: demoIds.length,
-    unknown: unknownIds.length,
-    fetchFailures,
+    total: result.classifications.length,
+    omr: result.omrIds.length,
+    demo: result.demoIds.length,
+    unknown: result.unknownIds.length,
+    fetchFailures: result.fetchFailures,
   }, null, 2))
-
-  if (!apply) return
-
-  await prisma.$transaction([
-    prisma.sheetMusic.updateMany({
-      where: { id: { in: omrIds } },
-      data: { provenance: 'omr' },
-    }),
-    prisma.sheetMusic.updateMany({
-      where: { id: { in: demoIds } },
-      data: { provenance: 'demo' },
-    }),
-  ])
 }
 
 main()

--- a/scripts/backfill-sheet-provenance.ts
+++ b/scripts/backfill-sheet-provenance.ts
@@ -1,0 +1,88 @@
+import { config } from 'dotenv'
+import { PrismaClient, type SheetMusicProvenance } from '@prisma/client'
+import {
+  classifySheetProvenance,
+  type ProvenanceClassification,
+} from '../src/services/sheetProvenanceBackfill'
+
+config({ path: '.env.local' })
+config()
+
+const prisma = new PrismaClient()
+const apply = process.argv.includes('--apply')
+
+function allowedStorageOrigin(): string {
+  const configured = process.env.NEXT_PUBLIC_SUPABASE_URL?.trim()
+  if (!configured) {
+    throw new Error('NEXT_PUBLIC_SUPABASE_URL is required to constrain animation downloads')
+  }
+  return new URL(configured).origin
+}
+
+async function loadAnimation(animationDataUrl: string): Promise<unknown> {
+  const url = new URL(animationDataUrl)
+  if (url.protocol !== 'https:' || url.origin !== allowedStorageOrigin()) {
+    throw new Error('animationDataUrl is outside the configured Supabase origin')
+  }
+
+  const response = await fetch(url, { signal: AbortSignal.timeout(15_000) })
+  if (!response.ok) throw new Error(`animation fetch returned ${response.status}`)
+  return response.json()
+}
+
+async function main() {
+  const rows = await prisma.sheetMusic.findMany({
+    select: {
+      id: true,
+      omrJobId: true,
+      animationDataUrl: true,
+    },
+    orderBy: { id: 'asc' },
+  })
+
+  const classifications: ProvenanceClassification[] = []
+  for (const row of rows) {
+    const classification = await classifySheetProvenance(row, loadAnimation)
+    if (classification.fetchFailed) console.error(`SheetMusic ${row.id}: animation could not be classified`)
+    classifications.push(classification)
+  }
+
+  const idsByProvenance = (provenance: SheetMusicProvenance) =>
+    classifications.filter((item) => item.provenance === provenance).map((item) => item.id)
+
+  const omrIds = idsByProvenance('omr')
+  const demoIds = idsByProvenance('demo')
+  const unknownIds = idsByProvenance('unknown')
+  const fetchFailures = classifications.filter((item) => item.fetchFailed).length
+
+  console.log(JSON.stringify({
+    mode: apply ? 'apply' : 'dry-run',
+    total: rows.length,
+    omr: omrIds.length,
+    demo: demoIds.length,
+    unknown: unknownIds.length,
+    fetchFailures,
+  }, null, 2))
+
+  if (!apply) return
+
+  await prisma.$transaction([
+    prisma.sheetMusic.updateMany({
+      where: { id: { in: omrIds } },
+      data: { provenance: 'omr' },
+    }),
+    prisma.sheetMusic.updateMany({
+      where: { id: { in: demoIds } },
+      data: { provenance: 'demo' },
+    }),
+  ])
+}
+
+main()
+  .catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
+  })

--- a/src/app/api/__tests__/uploadPathInventory.test.ts
+++ b/src/app/api/__tests__/uploadPathInventory.test.ts
@@ -17,7 +17,7 @@ import { join } from 'node:path'
  *     the tests that replaced the earlier "defects P1-A removes" block; that
  *     block described the old behaviour and went red here, as its own header
  *     predicted.
- *   - "provenance identifiers" — what a later migration needs in order to
+ *   - "provenance identifiers" — what the P1-A closing migration uses to
  *     classify rows that were already stored before this landed.
  */
 
@@ -31,6 +31,7 @@ const BACKGROUND_ROUTE = 'src/app/api/processing/route.ts'
 const ASYNC_PROCESSOR = 'src/services/asyncUploadProcessor.ts'
 const BACKGROUND_PROCESSOR = 'src/services/backgroundProcessor.ts'
 const DEMO_GENERATOR = 'src/services/pdfParser.ts'
+const DEMO_PROVENANCE = 'src/utils/demoProvenance.ts'
 
 const UPLOAD_PAGE = 'src/app/upload/page.tsx'
 const OMR_SERVICE_URL_MODULE = 'src/lib/omr/serviceUrl.ts'
@@ -183,9 +184,11 @@ describe('provenance identifiers for rows stored before this landed', () => {
     // database carry one of these literals; changing them breaks the only
     // reliable way to classify those rows.
     const generator = readSource(DEMO_GENERATOR)
+    const evidence = readSource(DEMO_PROVENANCE)
     expect(generator).toContain('melodyVariations')
     expect(generator).toMatch(/tempo:\s*120/)
     expect(generator).toMatch(/timeSignature:\s*'4\/4'/)
-    expect(generator).toMatch(/note:\s*'C4',\s*startTime:\s*0/)
+    expect(generator).toContain('HISTORICAL_DEMO_NOTE_SEQUENCES')
+    expect(evidence).toMatch(/note:\s*'C4',\s*startTime:\s*0/)
   })
 })

--- a/src/app/api/omr/upload/__tests__/route.test.ts
+++ b/src/app/api/omr/upload/__tests__/route.test.ts
@@ -184,6 +184,33 @@ describe('POST /api/omr/upload — failure is visible, not silent', () => {
     expect((requestInit?.body as FormData).get('tempo')).toBe('72')
   })
 
+  it('marks a row as OMR only after the service returns a job identifier', async () => {
+    process.env.OMR_SERVICE_URL = 'https://omr.example.invalid'
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ job_id: 'job-1', status: 'processing' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+
+    const { POST } = await loadRoute()
+    const response = await POST(uploadRequest())
+
+    expect(response.status).toBe(200)
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.not.objectContaining({ provenance: 'omr' }),
+      })
+    )
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { id: CREATED_ROW_ID },
+      data: expect.objectContaining({
+        omrJobId: 'job-1',
+        provenance: 'omr',
+      }),
+    })
+  })
+
   it('gives the service a server callback that survives browser navigation', async () => {
     process.env.OMR_SERVICE_URL = 'https://omr.example.invalid'
     fetchSpy.mockResolvedValue(

--- a/src/app/api/omr/upload/route.ts
+++ b/src/app/api/omr/upload/route.ts
@@ -226,6 +226,7 @@ export async function POST(request: NextRequest) {
       where: { id: sheetMusic.id },
       data: {
         omrJobId: omrResult.job_id,
+        provenance: 'omr',
         updatedAt: new Date()
       }
     })

--- a/src/app/api/sheet/[id]/__tests__/route.test.ts
+++ b/src/app/api/sheet/[id]/__tests__/route.test.ts
@@ -42,6 +42,7 @@ describe('/api/sheet/[id]', () => {
         composer: 'Test Composer',
         userId: 'user1',
         isPublic: false,
+        provenance: 'demo',
         animationDataUrl: 'http://example.com/data.json',
         createdAt: new Date(),
         updatedAt: new Date(),
@@ -57,6 +58,7 @@ describe('/api/sheet/[id]', () => {
       expect(response.status).toBe(200)
       expect(data.success).toBe(true)
       expect(data.sheetMusic.title).toBe('Test Song')
+      expect(data.sheetMusic.provenance).toBe('demo')
       expect(data.sheetMusic.owner).toBeTruthy()
     })
 

--- a/src/app/api/sheet/[id]/route.ts
+++ b/src/app/api/sheet/[id]/route.ts
@@ -69,6 +69,7 @@ export async function GET(
         categoryId: sheetMusic.categoryId,
         category: sheetMusic.category?.name || null,
         isPublic: sheetMusic.isPublic,
+        provenance: sheetMusic.provenance,
         createdAt: sheetMusic.createdAt,
         updatedAt: sheetMusic.updatedAt,
         animationDataUrl: sheetMusic.animationDataUrl,

--- a/src/app/api/sheet/public/__tests__/route.test.ts
+++ b/src/app/api/sheet/public/__tests__/route.test.ts
@@ -1,0 +1,46 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { GET } from '../route'
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    sheetMusic: {
+      findMany: jest.fn(),
+      count: jest.fn(),
+    },
+  },
+}))
+
+const mockFindMany = prisma.sheetMusic.findMany as jest.Mock
+const mockCount = prisma.sheetMusic.count as jest.Mock
+
+describe('GET /api/sheet/public provenance filter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockFindMany.mockResolvedValue([])
+    mockCount.mockResolvedValue(0)
+  })
+
+  it('excludes only confirmed demo rows from both the page and total', async () => {
+    const response = await GET(new NextRequest('http://localhost/api/sheet/public'))
+
+    expect(response.status).toBe(200)
+    expect(mockFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          isPublic: true,
+          provenance: { not: 'demo' },
+        },
+      })
+    )
+    expect(mockCount).toHaveBeenCalledWith({
+      where: {
+        isPublic: true,
+        provenance: { not: 'demo' },
+      },
+    })
+  })
+})

--- a/src/app/api/sheet/public/route.ts
+++ b/src/app/api/sheet/public/route.ts
@@ -14,7 +14,8 @@ export async function GET(request: NextRequest) {
 
     // Build where clause for public sheets only
     const where: Prisma.SheetMusicWhereInput = {
-      isPublic: true
+      isPublic: true,
+      provenance: { not: 'demo' }
     }
 
     if (search) {

--- a/src/app/sheet/[id]/page.tsx
+++ b/src/app/sheet/[id]/page.tsx
@@ -181,7 +181,10 @@ export default function SheetMusicPage() {
         )}
         
         <Container className={isPlaybackActive ? 'px-0 py-0 sm:px-0 lg:px-0' : 'py-8'} size={isPlaybackActive ? 'full' : 'lg'}>
-          {!isPlaybackActive && <DemoProvenanceNotice provenance={sheetMusic.provenance} />}
+          <DemoProvenanceNotice
+            provenance={sheetMusic.provenance}
+            isPlaybackActive={isPlaybackActive}
+          />
 
           {/* Falling Notes Player - MVP Style */}
           <FallingNotesPlayer 

--- a/src/app/sheet/[id]/page.tsx
+++ b/src/app/sheet/[id]/page.tsx
@@ -6,6 +6,8 @@ import { MainLayout, PageHeader, Container } from '@/components/layout'
 import { Card, Loading } from '@/components/ui'
 import AuthGuard from '@/components/auth/AuthGuard'
 import FallingNotesPlayer from '@/components/animation/FallingNotesPlayer'
+import DemoProvenanceNotice from '@/components/sheet/DemoProvenanceNotice'
+import type { SheetMusicProvenance } from '@prisma/client'
 import type { CanonicalAnimationData } from '@/types/animationContract'
 import { normalizeAnimationData, AnimationContractError } from '@/utils/animationContract'
 
@@ -15,6 +17,7 @@ interface SheetMusic {
   composer: string
   category: string | null
   isPublic: boolean
+  provenance: SheetMusicProvenance
   createdAt: string
   animationData: string
 }
@@ -178,6 +181,8 @@ export default function SheetMusicPage() {
         )}
         
         <Container className={isPlaybackActive ? 'px-0 py-0 sm:px-0 lg:px-0' : 'py-8'} size={isPlaybackActive ? 'full' : 'lg'}>
+          {!isPlaybackActive && <DemoProvenanceNotice provenance={sheetMusic.provenance} />}
+
           {/* Falling Notes Player - MVP Style */}
           <FallingNotesPlayer 
             animationData={animationData} 

--- a/src/components/sheet/DemoProvenanceNotice.tsx
+++ b/src/components/sheet/DemoProvenanceNotice.tsx
@@ -1,0 +1,22 @@
+import type { SheetMusicProvenance } from '@prisma/client'
+
+interface DemoProvenanceNoticeProps {
+  provenance: SheetMusicProvenance
+}
+
+export default function DemoProvenanceNotice({ provenance }: DemoProvenanceNoticeProps) {
+  if (provenance !== 'demo') return null
+
+  return (
+    <div
+      role="alert"
+      className="mb-4 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-950"
+    >
+      <p className="font-semibold">실제 악보 변환 결과가 아닙니다.</p>
+      <p className="mt-1">
+        이전 데모 업로드 경로에서 생성된 연습용 멜로디입니다. 원본 PDF의 음표를 인식한 결과로
+        사용하지 마세요.
+      </p>
+    </div>
+  )
+}

--- a/src/components/sheet/DemoProvenanceNotice.tsx
+++ b/src/components/sheet/DemoProvenanceNotice.tsx
@@ -1,16 +1,22 @@
 import type { SheetMusicProvenance } from '@prisma/client'
 
-interface DemoProvenanceNoticeProps {
+export interface DemoProvenanceNoticeProps {
   provenance: SheetMusicProvenance
+  isPlaybackActive?: boolean
 }
 
-export default function DemoProvenanceNotice({ provenance }: DemoProvenanceNoticeProps) {
+export default function DemoProvenanceNotice({
+  provenance,
+  isPlaybackActive = false,
+}: DemoProvenanceNoticeProps) {
   if (provenance !== 'demo') return null
 
   return (
     <div
       role="alert"
-      className="mb-4 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-950"
+      className={isPlaybackActive
+        ? 'fixed left-2 right-2 top-2 z-50 mx-auto max-w-2xl rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-950 shadow-lg'
+        : 'mb-4 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-950'}
     >
       <p className="font-semibold">실제 악보 변환 결과가 아닙니다.</p>
       <p className="mt-1">

--- a/src/components/sheet/__tests__/DemoProvenanceNotice.test.tsx
+++ b/src/components/sheet/__tests__/DemoProvenanceNotice.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react'
+import DemoProvenanceNotice from '../DemoProvenanceNotice'
+
+describe('DemoProvenanceNotice', () => {
+  it('warns that a confirmed demo is not the uploaded score conversion', () => {
+    render(<DemoProvenanceNotice provenance="demo" />)
+
+    expect(screen.getByRole('alert')).toHaveTextContent('실제 악보 변환 결과가 아닙니다')
+  })
+
+  it.each(['omr', 'unknown'] as const)('renders nothing for %s provenance', (provenance) => {
+    const { container } = render(<DemoProvenanceNotice provenance={provenance} />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/src/components/sheet/__tests__/DemoProvenanceNotice.test.tsx
+++ b/src/components/sheet/__tests__/DemoProvenanceNotice.test.tsx
@@ -8,6 +8,13 @@ describe('DemoProvenanceNotice', () => {
     expect(screen.getByRole('alert')).toHaveTextContent('실제 악보 변환 결과가 아닙니다')
   })
 
+  it('remains visible as an overlay during active playback', () => {
+    render(<DemoProvenanceNotice provenance="demo" isPlaybackActive />)
+
+    expect(screen.getByRole('alert')).toHaveClass('fixed')
+    expect(screen.getByRole('alert')).toHaveTextContent('실제 악보 변환 결과가 아닙니다')
+  })
+
   it.each(['omr', 'unknown'] as const)('renders nothing for %s provenance', (provenance) => {
     const { container } = render(<DemoProvenanceNotice provenance={provenance} />)
 

--- a/src/hooks/__tests__/useSheetMusicSearch.test.ts
+++ b/src/hooks/__tests__/useSheetMusicSearch.test.ts
@@ -10,6 +10,7 @@ const makeSheetMusic = (id: number): SheetMusicWithOwner => ({
   categoryId: null,
   isPublic: true,
   animationDataUrl: `/scores/${id}.json`,
+  provenance: 'omr',
   createdAt: new Date(2026, 0, id),
   updatedAt: new Date(2026, 0, id),
   category: null,

--- a/src/repositories/SheetMusicRepository.ts
+++ b/src/repositories/SheetMusicRepository.ts
@@ -124,7 +124,10 @@ export class SheetMusicRepository implements ISheetMusicRepository {
     total: number
     hasMore: boolean
   }> {
-    const where: Prisma.SheetMusicWhereInput = { isPublic: true }
+    const where: Prisma.SheetMusicWhereInput = {
+      isPublic: true,
+      provenance: { not: 'demo' }
+    }
     
     if (params?.search) {
       where.OR = [

--- a/src/services/__tests__/sheetProvenanceBackfill.test.ts
+++ b/src/services/__tests__/sheetProvenanceBackfill.test.ts
@@ -1,0 +1,55 @@
+import { classifySheetProvenance } from '../sheetProvenanceBackfill'
+
+const demo = {
+  tempo: 120,
+  timeSignature: '4/4',
+  notes: [
+    { note: 'G4', startTime: 0, duration: 0.5, velocity: 0.8 },
+    { note: 'A4', startTime: 0.5, duration: 0.5, velocity: 0.8 },
+    { note: 'B4', startTime: 1, duration: 1, velocity: 0.8 },
+    { note: 'C5', startTime: 2, duration: 1, velocity: 0.9 },
+  ],
+}
+
+describe('D-010 provenance classification', () => {
+  it('classifies an OMR job without fetching its animation', async () => {
+    const load = jest.fn()
+
+    await expect(classifySheetProvenance({
+      id: 1,
+      omrJobId: 'job-1',
+      animationDataUrl: 'https://storage/score.json',
+    }, load)).resolves.toEqual({ id: 1, provenance: 'omr', fetchFailed: false })
+    expect(load).not.toHaveBeenCalled()
+  })
+
+  it('classifies only an exact historical payload as demo', async () => {
+    await expect(classifySheetProvenance({
+      id: 2,
+      omrJobId: null,
+      animationDataUrl: 'https://storage/demo.json',
+    }, async () => demo)).resolves.toEqual({ id: 2, provenance: 'demo', fetchFailed: false })
+  })
+
+  it('keeps ambiguous and unreadable rows unknown', async () => {
+    await expect(classifySheetProvenance({
+      id: 3,
+      omrJobId: null,
+      animationDataUrl: 'https://storage/score.json',
+    }, async () => ({ ...demo, tempo: 60 }))).resolves.toEqual({
+      id: 3,
+      provenance: 'unknown',
+      fetchFailed: false,
+    })
+
+    await expect(classifySheetProvenance({
+      id: 4,
+      omrJobId: null,
+      animationDataUrl: 'https://storage/missing.json',
+    }, async () => { throw new Error('missing') })).resolves.toEqual({
+      id: 4,
+      provenance: 'unknown',
+      fetchFailed: true,
+    })
+  })
+})

--- a/src/services/__tests__/sheetProvenanceBackfill.test.ts
+++ b/src/services/__tests__/sheetProvenanceBackfill.test.ts
@@ -1,4 +1,7 @@
-import { classifySheetProvenance } from '../sheetProvenanceBackfill'
+import {
+  classifySheetProvenance,
+  runSheetProvenanceBackfill,
+} from '../sheetProvenanceBackfill'
 
 const demo = {
   tempo: 120,
@@ -12,6 +15,26 @@ const demo = {
 }
 
 describe('D-010 provenance classification', () => {
+  it('fails configuration validation before fetching or updating any row', async () => {
+    const loadAnimation = jest.fn()
+    const updateProvenance = jest.fn()
+
+    await expect(runSheetProvenanceBackfill({
+      listRows: async () => [
+        { id: 1, omrJobId: 'job-1', animationDataUrl: 'https://storage/omr.json' },
+        { id: 2, omrJobId: null, animationDataUrl: 'https://storage/candidate.json' },
+      ],
+      loadAnimation,
+      validateAnimationStorage: () => {
+        throw new Error('NEXT_PUBLIC_SUPABASE_URL is required')
+      },
+      updateProvenance,
+    }, true)).rejects.toThrow('NEXT_PUBLIC_SUPABASE_URL is required')
+
+    expect(loadAnimation).not.toHaveBeenCalled()
+    expect(updateProvenance).not.toHaveBeenCalled()
+  })
+
   it('classifies an OMR job without fetching its animation', async () => {
     const load = jest.fn()
 

--- a/src/services/pdfParser.ts
+++ b/src/services/pdfParser.ts
@@ -16,6 +16,7 @@
 // migration plan before changing them.
 
 import { Jimp } from 'jimp';
+import { HISTORICAL_DEMO_NOTE_SEQUENCES } from '@/utils/demoProvenance'
 type JimpType = Awaited<ReturnType<typeof Jimp.read>>;
 
 const jimpUtils = Jimp as unknown as { intToRGBA: (color: number) => { r: number; g: number; b: number; a: number } };
@@ -467,40 +468,11 @@ export class PDFParserService {
     console.log('PDFParserService: Creating enhanced demo with PDF-based variations')
     
     // Create different melodies based on file characteristics
-    const melodyVariations = [
-      // C Major Scale (default)
-      [
-        { note: 'C4', startTime: 0, duration: 0.5, velocity: 0.8 },
-        { note: 'D4', startTime: 0.5, duration: 0.5, velocity: 0.8 },
-        { note: 'E4', startTime: 1.0, duration: 0.5, velocity: 0.8 },
-        { note: 'F4', startTime: 1.5, duration: 0.5, velocity: 0.8 },
-        { note: 'G4', startTime: 2.0, duration: 0.5, velocity: 0.8 },
-        { note: 'A4', startTime: 2.5, duration: 0.5, velocity: 0.8 },
-        { note: 'B4', startTime: 3.0, duration: 0.5, velocity: 0.8 },
-        { note: 'C5', startTime: 3.5, duration: 1.0, velocity: 0.8 },
-      ],
-      // Arpeggio
-      [
-        { note: 'C4', startTime: 0, duration: 0.25, velocity: 0.7 },
-        { note: 'E4', startTime: 0.25, duration: 0.25, velocity: 0.7 },
-        { note: 'G4', startTime: 0.5, duration: 0.25, velocity: 0.7 },
-        { note: 'C5', startTime: 0.75, duration: 0.25, velocity: 0.8 },
-        { note: 'G4', startTime: 1.0, duration: 0.25, velocity: 0.7 },
-        { note: 'E4', startTime: 1.25, duration: 0.25, velocity: 0.7 },
-        { note: 'C4', startTime: 1.5, duration: 0.5, velocity: 0.8 },
-      ],
-      // Simple melody
-      [
-        { note: 'G4', startTime: 0, duration: 0.5, velocity: 0.8 },
-        { note: 'A4', startTime: 0.5, duration: 0.5, velocity: 0.8 },
-        { note: 'B4', startTime: 1.0, duration: 1.0, velocity: 0.8 },
-        { note: 'C5', startTime: 2.0, duration: 1.0, velocity: 0.9 },
-      ]
-    ]
+    const melodyVariations = HISTORICAL_DEMO_NOTE_SEQUENCES
     
     // Select melody based on file characteristics
     const fileHash = bufferLength % melodyVariations.length
-    const selectedMelody = melodyVariations[fileHash]
+    const selectedMelody = melodyVariations[fileHash].map((note) => ({ ...note }))
     
     const totalDuration = Math.max(...selectedMelody.map(n => n.startTime + n.duration))
     
@@ -534,16 +506,7 @@ export class PDFParserService {
     fileSize: number
   }, extractedText: string): PianoAnimationData {
     // Create a simple demo melody (C major scale)
-    const demoNotes: PianoNote[] = [
-      { note: 'C4', startTime: 0, duration: 0.5, velocity: 0.8 },
-      { note: 'D4', startTime: 0.5, duration: 0.5, velocity: 0.8 },
-      { note: 'E4', startTime: 1.0, duration: 0.5, velocity: 0.8 },
-      { note: 'F4', startTime: 1.5, duration: 0.5, velocity: 0.8 },
-      { note: 'G4', startTime: 2.0, duration: 0.5, velocity: 0.8 },
-      { note: 'A4', startTime: 2.5, duration: 0.5, velocity: 0.8 },
-      { note: 'B4', startTime: 3.0, duration: 0.5, velocity: 0.8 },
-      { note: 'C5', startTime: 3.5, duration: 1.0, velocity: 0.8 },
-    ]
+    const demoNotes: PianoNote[] = HISTORICAL_DEMO_NOTE_SEQUENCES[0].map((note) => ({ ...note }))
 
     // Try to extract some basic information from the PDF text
     const detectedTempo = this.extractTempo(extractedText)

--- a/src/services/sheetProvenanceBackfill.ts
+++ b/src/services/sheetProvenanceBackfill.ts
@@ -15,6 +15,21 @@ export interface ProvenanceClassification {
 
 type AnimationLoader = (animationDataUrl: string) => Promise<unknown>
 
+interface ProvenanceBackfillDependencies {
+  listRows: () => Promise<ProvenanceCandidate[]>
+  loadAnimation: AnimationLoader
+  validateAnimationStorage: () => void
+  updateProvenance: (ids: { omrIds: number[]; demoIds: number[] }) => Promise<unknown>
+}
+
+export interface ProvenanceBackfillResult {
+  classifications: ProvenanceClassification[]
+  omrIds: number[]
+  demoIds: number[]
+  unknownIds: number[]
+  fetchFailures: number
+}
+
 /** Applies D-010's asymmetric rule: only exact evidence can produce demo. */
 export async function classifySheetProvenance(
   row: ProvenanceCandidate,
@@ -38,4 +53,42 @@ export async function classifySheetProvenance(
   } catch {
     return { id: row.id, provenance: 'unknown', fetchFailed: true }
   }
+}
+
+/** Validates shared storage configuration before any candidate fetch or write. */
+export async function runSheetProvenanceBackfill(
+  dependencies: ProvenanceBackfillDependencies,
+  apply: boolean
+): Promise<ProvenanceBackfillResult> {
+  const rows = await dependencies.listRows()
+  const hasAnimationCandidate = rows.some((row) => !row.omrJobId && row.animationDataUrl)
+
+  if (hasAnimationCandidate) {
+    dependencies.validateAnimationStorage()
+  }
+
+  const classifications: ProvenanceClassification[] = []
+  for (const row of rows) {
+    classifications.push(await classifySheetProvenance(row, dependencies.loadAnimation))
+  }
+
+  const idsByProvenance = (provenance: SheetMusicProvenance) =>
+    classifications.filter((item) => item.provenance === provenance).map((item) => item.id)
+
+  const result = {
+    classifications,
+    omrIds: idsByProvenance('omr'),
+    demoIds: idsByProvenance('demo'),
+    unknownIds: idsByProvenance('unknown'),
+    fetchFailures: classifications.filter((item) => item.fetchFailed).length,
+  }
+
+  if (apply) {
+    await dependencies.updateProvenance({
+      omrIds: result.omrIds,
+      demoIds: result.demoIds,
+    })
+  }
+
+  return result
 }

--- a/src/services/sheetProvenanceBackfill.ts
+++ b/src/services/sheetProvenanceBackfill.ts
@@ -1,0 +1,41 @@
+import type { SheetMusicProvenance } from '@prisma/client'
+import { isKnownDemoAnimation } from '@/utils/demoProvenance'
+
+export interface ProvenanceCandidate {
+  id: number
+  omrJobId: string | null
+  animationDataUrl: string
+}
+
+export interface ProvenanceClassification {
+  id: number
+  provenance: SheetMusicProvenance
+  fetchFailed: boolean
+}
+
+type AnimationLoader = (animationDataUrl: string) => Promise<unknown>
+
+/** Applies D-010's asymmetric rule: only exact evidence can produce demo. */
+export async function classifySheetProvenance(
+  row: ProvenanceCandidate,
+  loadAnimation: AnimationLoader
+): Promise<ProvenanceClassification> {
+  if (row.omrJobId) {
+    return { id: row.id, provenance: 'omr', fetchFailed: false }
+  }
+
+  if (!row.animationDataUrl) {
+    return { id: row.id, provenance: 'unknown', fetchFailed: false }
+  }
+
+  try {
+    const payload = await loadAnimation(row.animationDataUrl)
+    return {
+      id: row.id,
+      provenance: isKnownDemoAnimation(payload) ? 'demo' : 'unknown',
+      fetchFailed: false,
+    }
+  } catch {
+    return { id: row.id, provenance: 'unknown', fetchFailed: true }
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,7 @@
 // Clairkeys - Core types for the piano learning app
 
+import type { SheetMusicProvenance } from '@prisma/client'
+
 export interface User {
   id: string
   name?: string | null
@@ -23,6 +25,7 @@ export interface SheetMusic {
   categoryId?: number | null
   isPublic: boolean
   animationDataUrl: string
+  provenance: SheetMusicProvenance
   createdAt: Date
   updatedAt: Date
   category?: Category

--- a/src/types/sheet-music.ts
+++ b/src/types/sheet-music.ts
@@ -1,3 +1,5 @@
+import type { SheetMusicProvenance } from '@prisma/client'
+
 export interface SheetMusic {
   id: number
   title: string
@@ -6,6 +8,7 @@ export interface SheetMusic {
   categoryId: number | null
   isPublic: boolean
   animationDataUrl: string
+  provenance: SheetMusicProvenance
   createdAt: Date
   updatedAt: Date
 }

--- a/src/utils/__tests__/demoProvenance.test.ts
+++ b/src/utils/__tests__/demoProvenance.test.ts
@@ -1,0 +1,65 @@
+import { isKnownDemoAnimation } from '../demoProvenance'
+
+const scale = [
+  { note: 'C4', startTime: 0, duration: 0.5, velocity: 0.8 },
+  { note: 'D4', startTime: 0.5, duration: 0.5, velocity: 0.8 },
+  { note: 'E4', startTime: 1, duration: 0.5, velocity: 0.8 },
+  { note: 'F4', startTime: 1.5, duration: 0.5, velocity: 0.8 },
+  { note: 'G4', startTime: 2, duration: 0.5, velocity: 0.8 },
+  { note: 'A4', startTime: 2.5, duration: 0.5, velocity: 0.8 },
+  { note: 'B4', startTime: 3, duration: 0.5, velocity: 0.8 },
+  { note: 'C5', startTime: 3.5, duration: 1, velocity: 0.8 },
+]
+
+const arpeggio = [
+  { note: 'C4', startTime: 0, duration: 0.25, velocity: 0.7 },
+  { note: 'E4', startTime: 0.25, duration: 0.25, velocity: 0.7 },
+  { note: 'G4', startTime: 0.5, duration: 0.25, velocity: 0.7 },
+  { note: 'C5', startTime: 0.75, duration: 0.25, velocity: 0.8 },
+  { note: 'G4', startTime: 1, duration: 0.25, velocity: 0.7 },
+  { note: 'E4', startTime: 1.25, duration: 0.25, velocity: 0.7 },
+  { note: 'C4', startTime: 1.5, duration: 0.5, velocity: 0.8 },
+]
+
+const simpleMelody = [
+  { note: 'G4', startTime: 0, duration: 0.5, velocity: 0.8 },
+  { note: 'A4', startTime: 0.5, duration: 0.5, velocity: 0.8 },
+  { note: 'B4', startTime: 1, duration: 1, velocity: 0.8 },
+  { note: 'C5', startTime: 2, duration: 1, velocity: 0.9 },
+]
+
+function animation(notes: unknown, overrides: Record<string, unknown> = {}) {
+  return {
+    tempo: 120,
+    timeSignature: '4/4',
+    notes,
+    ...overrides,
+  }
+}
+
+describe('stored demo provenance matcher', () => {
+  it.each([[scale], [arpeggio], [simpleMelody]])(
+    'accepts each exact historical demo sequence',
+    (notes) => {
+      expect(isKnownDemoAnimation(animation(notes))).toBe(true)
+    }
+  )
+
+  it('rejects a score with the same pitches but a different tempo', () => {
+    expect(isKnownDemoAnimation(animation(scale, { tempo: 60 }))).toBe(false)
+  })
+
+  it('rejects extra note fields because a genuine score must not be hidden on a guess', () => {
+    const notes = scale.map((note, index) =>
+      index === 0 ? { ...note, hand: 'right' } : note
+    )
+
+    expect(isKnownDemoAnimation(animation(notes))).toBe(false)
+  })
+
+  it('rejects malformed or merely similar payloads', () => {
+    expect(isKnownDemoAnimation(null)).toBe(false)
+    expect(isKnownDemoAnimation(animation(scale.slice(0, -1)))).toBe(false)
+    expect(isKnownDemoAnimation(animation(scale, { timeSignature: '3/4' }))).toBe(false)
+  })
+})

--- a/src/utils/demoProvenance.ts
+++ b/src/utils/demoProvenance.ts
@@ -1,0 +1,74 @@
+type HistoricalDemoNote = {
+  note: string
+  startTime: number
+  duration: number
+  velocity: number
+}
+
+const NOTE_KEYS = ['duration', 'note', 'startTime', 'velocity']
+
+/**
+ * Exact note literals emitted by the pre-D-010 demo upload paths.
+ *
+ * These arrays are migration evidence. Changing them would make already stored
+ * demo rows impossible to identify, so product code and the backfill matcher
+ * deliberately share this single immutable source.
+ */
+export const HISTORICAL_DEMO_NOTE_SEQUENCES: readonly (readonly HistoricalDemoNote[])[] = [
+  [
+    { note: 'C4', startTime: 0, duration: 0.5, velocity: 0.8 },
+    { note: 'D4', startTime: 0.5, duration: 0.5, velocity: 0.8 },
+    { note: 'E4', startTime: 1, duration: 0.5, velocity: 0.8 },
+    { note: 'F4', startTime: 1.5, duration: 0.5, velocity: 0.8 },
+    { note: 'G4', startTime: 2, duration: 0.5, velocity: 0.8 },
+    { note: 'A4', startTime: 2.5, duration: 0.5, velocity: 0.8 },
+    { note: 'B4', startTime: 3, duration: 0.5, velocity: 0.8 },
+    { note: 'C5', startTime: 3.5, duration: 1, velocity: 0.8 },
+  ],
+  [
+    { note: 'C4', startTime: 0, duration: 0.25, velocity: 0.7 },
+    { note: 'E4', startTime: 0.25, duration: 0.25, velocity: 0.7 },
+    { note: 'G4', startTime: 0.5, duration: 0.25, velocity: 0.7 },
+    { note: 'C5', startTime: 0.75, duration: 0.25, velocity: 0.8 },
+    { note: 'G4', startTime: 1, duration: 0.25, velocity: 0.7 },
+    { note: 'E4', startTime: 1.25, duration: 0.25, velocity: 0.7 },
+    { note: 'C4', startTime: 1.5, duration: 0.5, velocity: 0.8 },
+  ],
+  [
+    { note: 'G4', startTime: 0, duration: 0.5, velocity: 0.8 },
+    { note: 'A4', startTime: 0.5, duration: 0.5, velocity: 0.8 },
+    { note: 'B4', startTime: 1, duration: 1, velocity: 0.8 },
+    { note: 'C5', startTime: 2, duration: 1, velocity: 0.9 },
+  ],
+]
+
+function isExactHistoricalNote(value: unknown, expected: HistoricalDemoNote): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+
+  const record = value as Record<string, unknown>
+  if (Object.keys(record).sort().join(',') !== NOTE_KEYS.join(',')) return false
+
+  return (
+    record.note === expected.note &&
+    record.startTime === expected.startTime &&
+    record.duration === expected.duration &&
+    record.velocity === expected.velocity
+  )
+}
+
+/** Returns true only for an exact pre-D-010 demo payload. */
+export function isKnownDemoAnimation(value: unknown): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+
+  const record = value as Record<string, unknown>
+  const notes = record.notes
+  if (record.tempo !== 120 || record.timeSignature !== '4/4' || !Array.isArray(notes)) {
+    return false
+  }
+
+  return HISTORICAL_DEMO_NOTE_SEQUENCES.some(
+    (sequence) =>
+      notes.length === sequence.length &&
+      sequence.every((expected, index) => isExactHistoricalNote(notes[index], expected))
+  )
+}


### PR DESCRIPTION
## Purpose

Complete the remaining P1-A migration contract by distinguishing real OMR rows, confirmed historical demo rows, and ambiguous legacy rows without deleting user-owned metadata.

## Recovery phase

- Phase: P1-A Upload Pipeline Consolidation
- Phase document: `docs/recovery/phases/P1-A-upload-pipeline.md`

## Scope

- Included: typed `SheetMusic.provenance` migration; exact matching against the three historical demo note sequences; dry-run-by-default backfill; OMR write-path provenance; confirmed-demo exclusion from public browsing; playback-page warning.
- Explicitly excluded: deleting rows; hiding `unknown` rows; persistent queue work; production migration/backfill execution without database credentials.

## Key decisions

- A missing `omrJobId` is only a candidate filter and never enough to mark a row as demo.
- Only exact historical note content with the fixed tempo and time signature can produce `demo`.
- Downloads during backfill are restricted to the configured Supabase origin.
- The migration must be applied before deploying application code that selects the new column.

## Validation

| Check | Result | Evidence record |
|---|---|---|
| Focused tests | PASS — 13/13 | Pending validation record |
| Type check | PASS | Pending validation record |
| Lint | PASS | Pending validation record |
| Unit tests | PASS — 62 suites / 589 tests | Pending validation record |
| Build | PASS | Pending validation record |
| Manual/E2E | BLOCKED — no production credentials | Pending validation record |

## Baseline difference

- Fixed failures: legacy score rows can now carry explicit source provenance; confirmed demos no longer appear in public browsing and show a warning before playback.
- Remaining known failures: production migration and data classification require `DATABASE_URL` plus Supabase configuration unavailable in this checkout.
- Evidence records: to be added in `docs/recovery/validation/` after PR creation.
- New failures: none in local gates.

## Risks and rollback

- Risks: deploying code before the migration would make Prisma queries select a missing column; an overly broad matcher could hide a genuine score.
- Rollback: revert application filtering and warning first; retain the additive provenance column and user rows. Never delete rows as rollback.

## Review checklist

- [x] The PR contains one phase or one bounded objective.
- [x] The PR was created review-ready and is not a draft.
- [x] Existing user-owned changes are excluded.
- [ ] Handoff and validation records are current.
- [ ] Canonical handoff, validation, and review evidence are stored inside the project.
- [x] No type, lint, or test failure is hidden by configuration.
- [ ] Every actionable review comment is tracked in `docs/recovery/reviews/`.
- [x] Merge is deferred until the user explicitly approves this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 악보 출처를 데모, OMR, 미확인으로 구분해 표시합니다.
  * 데모 악보에는 실제 악보 변환 결과가 아님을 알리는 안내가 표시됩니다.
  * 공개 악보 목록에서 데모 악보가 제외됩니다.
  * 악보 상세 API 응답에 출처 정보가 포함됩니다.

* **개선 사항**
  * 기존 악보의 출처를 자동 분류하고 업데이트할 수 있습니다.
  * OMR 변환 완료 시 해당 악보가 OMR 출처로 기록됩니다.

* **테스트**
  * 출처 분류, 공개 목록 필터링 및 데모 안내 동작을 검증했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->