### PR TITLE
Enforce unique OMR job identifiers

### DIFF
--- a/prisma/migrations/20260829020000_make_omr_job_id_unique/migration.sql
+++ b/prisma/migrations/20260829020000_make_omr_job_id_unique/migration.sql
@@ -1,0 +1,4 @@
+-- Each OMR service job is generated as a UUID and belongs to at most one score.
+-- PostgreSQL permits multiple NULL values in this unique index, so rows before
+-- the OMR service has returned a job identifier remain valid.
+CREATE UNIQUE INDEX "SheetMusic_omrJobId_key" ON "SheetMusic"("omrJobId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -75,7 +75,7 @@ model SheetMusic {
   isPublic         Boolean           @default(false)
   animationDataUrl String
   processingStatus String            @default("pending") // pending, processing, completed, failed
-  omrJobId         String?           // OMR service job ID for tracking
+  omrJobId         String?           @unique // OMR service job ID for tracking
   provenance       SheetMusicProvenance @default(unknown)
   createdAt        DateTime          @default(now())
   updatedAt        DateTime          @updatedAt

--- a/src/app/api/omr/finalize/__tests__/route.test.ts
+++ b/src/app/api/omr/finalize/__tests__/route.test.ts
@@ -9,6 +9,7 @@ jest.mock('@/lib/prisma', () => ({
   prisma: {
     sheetMusic: {
       findFirst: jest.fn(),
+      findUnique: jest.fn(),
       update: jest.fn(),
     },
   },
@@ -20,6 +21,7 @@ jest.mock('@/services/fileStorageService', () => ({
 }))
 
 const mockFindFirst = prisma.sheetMusic.findFirst as jest.Mock
+const mockFindUnique = prisma.sheetMusic.findUnique as jest.Mock
 const mockUpdate = prisma.sheetMusic.update as jest.Mock
 const mockGetInstance = FileStorageService.getInstance as jest.Mock
 
@@ -73,6 +75,7 @@ describe('POST /api/omr/finalize — server-owned completion trigger', () => {
     })
     mockGetInstance.mockReturnValue({ uploadOmrAnimationData })
     mockFindFirst.mockResolvedValue(row())
+    mockFindUnique.mockResolvedValue(row())
     mockUpdate.mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({
       ...row(),
       ...data,
@@ -92,7 +95,8 @@ describe('POST /api/omr/finalize — server-owned completion trigger', () => {
     const response = await POST(callbackRequest())
 
     expect(response.status).toBe(200)
-    expect(mockFindFirst).toHaveBeenCalledWith({ where: { omrJobId: JOB_ID } })
+    expect(mockFindUnique).toHaveBeenCalledWith({ where: { omrJobId: JOB_ID } })
+    expect(mockFindFirst).not.toHaveBeenCalled()
     expect(uploadOmrAnimationData).toHaveBeenCalledWith(JOB_ID, 'user-1', ANIMATION)
     expect(mockUpdate).toHaveBeenCalledWith({
       where: { id: 17 },
@@ -142,7 +146,7 @@ describe('POST /api/omr/finalize — server-owned completion trigger', () => {
   })
 
   it('is idempotent after another trigger has stored the result', async () => {
-    mockFindFirst.mockResolvedValue(
+    mockFindUnique.mockResolvedValue(
       row({
         animationDataUrl:
           `https://project.supabase.co/storage/v1/object/public/animation-data/user-1/omr_${JOB_ID}.json`,
@@ -160,7 +164,7 @@ describe('POST /api/omr/finalize — server-owned completion trigger', () => {
   })
 
   it('retries a row previously marked failed when storage becomes available', async () => {
-    mockFindFirst.mockResolvedValue(row({ processingStatus: 'failed' }))
+    mockFindUnique.mockResolvedValue(row({ processingStatus: 'failed' }))
 
     const { POST } = await import('../route')
     const response = await POST(callbackRequest())

--- a/src/app/api/omr/finalize/route.ts
+++ b/src/app/api/omr/finalize/route.ts
@@ -58,7 +58,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'A valid job_id UUID is required.' }, { status: 400 })
   }
 
-  const sheetMusic = await prisma.sheetMusic.findFirst({
+  const sheetMusic = await prisma.sheetMusic.findUnique({
     where: { omrJobId: jobId },
   })
 


### PR DESCRIPTION
## Purpose

Make every OMR completion callback resolve one indexed SheetMusic row, rather than scanning a non-unique identifier.

## Recovery phase

- Phase: bounded P1-B-adjacent issue #70; P1-B itself remains NOT_STARTED
- Phase document: docs/recovery/phases/P1-B-durable-omr.md

## Scope

- Included: nullable unique omrJobId, additive unique-index migration, deterministic finalize lookup, regression coverage.
- Explicitly excluded: durable queue, retry/cancel redesign, CORS/file-content work, callback URL hardening, and status-route refactoring.

## Key decisions

PostgreSQL permits multiple NULL values in a unique index. Rows before OMR assigns a job ID remain valid; assigned UUIDs become unique and indexed. Finalize uses findUnique.

## Validation

| Check | Result | Evidence record |
|---|---|---|
| Focused tests | PASS; regression failed first | Pending PR review log |
| Type check | PASS | Local command |
| Lint | PASS | Local command |
| Unit tests | PASS; 62 suites, 591 tests | Local command |
| Build | PASS | Local command |
| Manual/E2E | Production duplicate preflight: 0 duplicate groups across 5 rows | Pending validation record |

## Baseline difference

- Fixed failures: callback lookup no longer relies on an unconstrained, unindexed identifier.
- Remaining known failures: P1-B durable execution and security scope remain intentionally deferred.
- Evidence records: will be recorded on main after PR creation.
- New failures: none observed.

## Risks and rollback

- Risks: migration fails if a pre-existing non-null duplicate exists; production preflight found none.
- Rollback: revert code and drop the unique index only after confirming no code relies on findUnique.

## Review checklist

- [x] The PR contains one bounded objective.
- [x] The PR was created review-ready and is not a draft.
- [x] Existing user-owned changes are excluded.
- [ ] Handoff and validation records are current.
- [ ] Canonical handoff, validation, and review evidence are stored inside the project.
- [x] No type, lint, or test failure is hidden by configuration.
- [ ] Every actionable review comment is tracked in docs/recovery/reviews/.
- [x] Merge is deferred until the user explicitly approves this PR.