### PR TITLE
Show metronome value and provenance in playback

### DIFF
--- a/src/components/animation/AnimationPlayer.tsx
+++ b/src/components/animation/AnimationPlayer.tsx
@@ -6,12 +6,13 @@ import { PracticeGuideControls, PracticeKeyHighlight } from '@/components/practi
 import { AnimationEvent, PianoAnimationData, PracticeState } from '@/types/animation'
 import {
   DEFAULT_TIMING_REFERENCE_BPM,
-  type TempoDisplay,
-  type TempoDisplayInput,
   type TempoSource,
 } from '@/types/animationContract'
 import { getAnimationEngine } from '@/services/animationEngine'
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts'
+import { getTempoDisplay } from '@/utils/tempoDisplay'
+
+export { getTempoDisplay } from '@/utils/tempoDisplay'
 
 type AnimationPlayerData = Omit<PianoAnimationData, 'tempo'> & {
   tempo: number | null
@@ -26,36 +27,6 @@ interface AnimationPlayerProps {
   onNoteStop?: (note: string) => void
   onActiveNotesChange?: (activeNotes: Set<string>) => void
   className?: string
-}
-
-/** Pure presentation rule for the v1.1 tempo provenance contract. */
-export function getTempoDisplay({
-  tempo,
-  tempoSource,
-  timingReferenceBpm,
-  scoreTempo,
-}: TempoDisplayInput): TempoDisplay {
-  if (tempo === null) {
-    return {
-      primary: '빠르기 미상',
-      secondary: `♩=${timingReferenceBpm} 기준으로 계산됨`,
-    }
-  }
-
-  if (tempoSource === 'score') {
-    return { primary: `♩=${tempo} (악보에서 읽음)` }
-  }
-
-  if (tempoSource === 'user') {
-    return {
-      primary: `♩=${tempo} (직접 입력)`,
-      ...(scoreTempo !== null && scoreTempo !== undefined && scoreTempo !== tempo
-        ? { secondary: `악보 표기: ♩=${scoreTempo}` }
-        : {}),
-    }
-  }
-
-  return { primary: `♩=${tempo} (출처 미상)` }
 }
 
 export default function AnimationPlayer({

--- a/src/components/animation/AnimationPlayer.tsx
+++ b/src/components/animation/AnimationPlayer.tsx
@@ -10,8 +10,6 @@ import {
 } from '@/types/animationContract'
 import { getAnimationEngine } from '@/services/animationEngine'
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts'
-import { getTempoDisplay } from '@/utils/tempoDisplay'
-
 export { getTempoDisplay } from '@/utils/tempoDisplay'
 
 type AnimationPlayerData = Omit<PianoAnimationData, 'tempo'> & {

--- a/src/components/animation/AnimationPlayer.tsx
+++ b/src/components/animation/AnimationPlayer.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react'
-import { PlaybackControls } from '@/components/playback'
+import { PlaybackControls, TempoDisplay } from '@/components/playback'
 import { PracticeGuideControls, PracticeKeyHighlight } from '@/components/practice'
 import { AnimationEvent, PianoAnimationData, PracticeState } from '@/types/animation'
 import {
@@ -58,20 +58,6 @@ export default function AnimationPlayer({
     }),
     [animationData]
   )
-  const tempoDisplay = useMemo(
-    () =>
-      getTempoDisplay({
-        tempo: animationData.tempo,
-        tempoSource: animationData.tempoSource ?? 'unknown',
-        timingReferenceBpm:
-          animationData.timingReferenceBpm ??
-          animationData.tempo ??
-          DEFAULT_TIMING_REFERENCE_BPM,
-        scoreTempo: animationData.scoreTempo,
-      }),
-    [animationData]
-  )
-  
   // Performance optimization: Throttle state updates
   const updateThrottleRef = useRef<number | null>(null)
   const THROTTLE_MS = 16 // ~60fps
@@ -303,10 +289,18 @@ export default function AnimationPlayer({
         <p className="text-gray-600">
           {animationData.composer} • {animationData.timeSignature}
         </p>
-        <p className="mt-1 text-sm font-medium text-gray-700">{tempoDisplay.primary}</p>
-        {tempoDisplay.secondary && (
-          <p className="text-xs text-gray-500">{tempoDisplay.secondary}</p>
-        )}
+        <TempoDisplay
+          tempo={animationData.tempo}
+          tempoSource={animationData.tempoSource ?? 'unknown'}
+          timingReferenceBpm={
+            animationData.timingReferenceBpm ??
+            animationData.tempo ??
+            DEFAULT_TIMING_REFERENCE_BPM
+          }
+          scoreTempo={animationData.scoreTempo}
+          isPlaybackActive={isPlaying}
+          className="mt-1"
+        />
       </div>
 
       {/* Controls - Switch based on mode */}

--- a/src/components/animation/FallingNotesPlayer.tsx
+++ b/src/components/animation/FallingNotesPlayer.tsx
@@ -10,7 +10,7 @@ import { usePlaybackOrientation } from '@/hooks/usePlaybackOrientation'
 import { MAX_MASTER_GAIN } from '@/hooks/useFallingNotesAudio'
 import FallingNotes from './FallingNotes'
 import SimplePianoKeyboard from '../piano/SimplePianoKeyboard'
-import { CompactPlaybackBar, PlaybackControls } from '@/components/playback'
+import { CompactPlaybackBar, PlaybackControls, TempoDisplay } from '@/components/playback'
 import { getActiveNotes } from '@/utils/visualUtils'
 
 /**
@@ -186,6 +186,15 @@ export default function FallingNotesPlayer({
       ].filter(Boolean).join(' ')}
       style={orientation.rotate ? rotatedRootStyle : undefined}
     >
+      <TempoDisplay
+        tempo={animationData.tempo}
+        tempoSource={animationData.tempoSource}
+        timingReferenceBpm={animationData.timingReferenceBpm}
+        scoreTempo={animationData.scoreTempo}
+        isPlaybackActive={isPlaying}
+        className={isPlaying ? '' : 'mb-4'}
+      />
+
       {isPlaying ? (
         /* One row instead of four. The landscape viewport this mode targets is
            390px tall in total; the stacked setup chrome cost 264px of it. */

--- a/src/components/animation/__tests__/AnimationPlayer.test.tsx
+++ b/src/components/animation/__tests__/AnimationPlayer.test.tsx
@@ -8,6 +8,7 @@ jest.mock('@/services/animationEngine', () => ({
 }))
 
 jest.mock('@/components/playback', () => ({
+  ...jest.requireActual('@/components/playback'),
   PlaybackControls: ({ currentTime }: { currentTime: number }) => (
     <div data-testid="current-time">{currentTime}</div>
   )
@@ -73,6 +74,12 @@ describe('AnimationPlayer', () => {
 
   afterEach(() => {
     jest.useRealTimers()
+  })
+
+  it('renders the shared tempo display in the alternate player', () => {
+    render(<AnimationPlayer animationData={animationData} />)
+
+    expect(screen.getByTestId('tempo-display')).toHaveTextContent('♩=120 (출처 미상)')
   })
 
   it('captures the time value before the throttled callback runs', () => {

--- a/src/components/animation/__tests__/FallingNotesPlayer.test.tsx
+++ b/src/components/animation/__tests__/FallingNotesPlayer.test.tsx
@@ -93,6 +93,19 @@ describe('FallingNotesPlayer', () => {
     expect(document.body).toHaveClass('playback-active')
   })
 
+  it('shows the metronome value and provenance before and during playback', () => {
+    const { rerender } = render(<FallingNotesPlayer animationData={animationData} />)
+
+    expect(screen.getByTestId('tempo-display')).toHaveTextContent('♩=120 (출처 미상)')
+    expect(screen.getByTestId('tempo-display')).toHaveClass('fixed')
+
+    mockPlayerState.isPlaying = false
+    rerender(<FallingNotesPlayer animationData={animationData} />)
+
+    expect(screen.getByTestId('tempo-display')).toHaveTextContent('♩=120 (출처 미상)')
+    expect(screen.getByTestId('tempo-display')).not.toHaveClass('fixed')
+  })
+
   it('shows the current master gain and forwards slider changes to setVolume', () => {
     mockPlayerState.setVolume.mockClear()
     mockPlayerState.isPlaying = false

--- a/src/components/playback/TempoDisplay.tsx
+++ b/src/components/playback/TempoDisplay.tsx
@@ -1,0 +1,35 @@
+import type { TempoDisplayInput } from '@/types/animationContract'
+import { getTempoDisplay } from '@/utils/tempoDisplay'
+
+export interface TempoDisplayProps extends TempoDisplayInput {
+  isPlaybackActive?: boolean
+  className?: string
+}
+
+/** Shows the recorded tempo and whether it came from the score or the user. */
+export default function TempoDisplay({
+  isPlaybackActive = false,
+  className = '',
+  ...input
+}: TempoDisplayProps) {
+  const display = getTempoDisplay(input)
+
+  return (
+    <div
+      data-testid="tempo-display"
+      aria-label={`메트로놈: ${display.primary}`}
+      className={[
+        'text-sm font-medium text-gray-700',
+        isPlaybackActive
+          ? 'fixed left-2 right-2 top-16 z-50 mx-auto max-w-2xl rounded-lg border border-gray-200 bg-white/95 px-3 py-2 text-center shadow-sm backdrop-blur-sm'
+          : '',
+        className,
+      ].filter(Boolean).join(' ')}
+    >
+      <span>{display.primary}</span>
+      {display.secondary && (
+        <span className="ml-2 text-xs font-normal text-gray-500">{display.secondary}</span>
+      )}
+    </div>
+  )
+}

--- a/src/components/playback/index.ts
+++ b/src/components/playback/index.ts
@@ -1,3 +1,4 @@
 export { default as PlaybackControls } from './PlaybackControls'
 export { default as AdvancedPlaybackControls } from './AdvancedPlaybackControls'
 export { default as CompactPlaybackBar } from './CompactPlaybackBar'
+export { default as TempoDisplay } from './TempoDisplay'

--- a/src/utils/tempoDisplay.ts
+++ b/src/utils/tempoDisplay.ts
@@ -1,0 +1,35 @@
+import {
+  DEFAULT_TIMING_REFERENCE_BPM,
+  type TempoDisplay,
+  type TempoDisplayInput,
+} from '@/types/animationContract'
+
+/** Formats the tempo and its provenance for both player implementations. */
+export function getTempoDisplay({
+  tempo,
+  tempoSource,
+  timingReferenceBpm,
+  scoreTempo,
+}: TempoDisplayInput): TempoDisplay {
+  if (tempo === null) {
+    return {
+      primary: '빠르기 미상',
+      secondary: `♩=${timingReferenceBpm ?? DEFAULT_TIMING_REFERENCE_BPM} 기준으로 계산됨`,
+    }
+  }
+
+  if (tempoSource === 'score') {
+    return { primary: `♩=${tempo} (악보에서 읽음)` }
+  }
+
+  if (tempoSource === 'user') {
+    return {
+      primary: `♩=${tempo} (직접 입력)`,
+      ...(scoreTempo !== null && scoreTempo !== undefined && scoreTempo !== tempo
+        ? { secondary: `악보 표기: ♩=${scoreTempo}` }
+        : {}),
+    }
+  }
+
+  return { primary: `♩=${tempo} (출처 미상)` }
+}


### PR DESCRIPTION
## Purpose

The converter already records tempo and its provenance, but the production sheet route uses FallingNotesPlayer while the existing readout lived only in the alternate AnimationPlayer. This makes the applied metronome value visible where users actually play.

## Recovery phase

- Phase: Issue #82, bounded P1-A follow-up
- Phase document: docs/recovery/phases/P1-A-upload-pipeline.md

## Scope

- Included: shared tempo display formatting, score/user/unknown provenance labels, display before playback, fixed overlay during active playback, regression coverage.
- Explicitly excluded: database schema/migration, tempo recognition/conversion logic, playback speed behavior, P1-B durable queue/security.

## Key decisions

Use existing animation JSON fields (`tempo`, `tempoSource`, `scoreTempo`, `timingReferenceBpm`). The active label is fixed-position so the established compact playback geometry remains unchanged.

## Validation

| Check | Result | Evidence record |
|---|---|---|
| Focused tests | PASS; 27 tests | Pending validation record |
| Type check | PASS | Pending validation record |
| Lint | PASS | Pending validation record |
| Unit tests | PASS; 62 suites, 592 tests | Pending validation record |
| Build | PASS | Pending validation record |
| Manual/E2E | Not run for authenticated score; Vercel Preview pending | Pending validation record |

## Baseline difference

- Fixed failures: metronome value/source was invisible in the real FallingNotesPlayer route.
- Remaining known failures: physical-device typography/position and production score with confirmed tempo metadata remain unobserved.
- Evidence records: will be committed to main after PR creation.
- New failures: none.

## Risks and rollback

- Risks: fixed label could overlap very small mobile controls; it does not consume flow height.
- Rollback: revert the display component and two player integrations; no schema rollback is required.

## Review checklist

- [x] The PR contains one bounded objective.
- [x] The PR was created review-ready and is not a draft.
- [x] Existing user-owned changes are excluded.
- [ ] Handoff and validation records are current.
- [ ] Canonical handoff, validation, and review evidence are stored inside the project.
- [x] No type, lint, or test failure is hidden by configuration.
- [ ] Every actionable review comment is tracked in docs/recovery/reviews/.
- [x] Merge is deferred until the user explicitly approves this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 재생 화면에 템포와 템포 출처를 표시합니다.
  * 재생 중에는 템포 정보가 화면 상단에 고정되어 표시됩니다.
  * 악보 템포, 사용자 입력값, 기준 BPM 등 다양한 템포 정보를 구분해 안내합니다.

* **버그 수정**
  * 템포 정보가 없거나 출처를 알 수 없는 경우에도 적절한 안내 문구를 표시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->