### PR TITLE
DS-0: 디자인 개편 착수 전 현재 상태와 제품 계약 고정 (#76 0단계)

### DIFF
--- a/docs/recovery/DECISIONS.md
+++ b/docs/recovery/DECISIONS.md
@@ -692,3 +692,43 @@
   - 없는 데이터를 전제로 화면을 그리지 않는다. 상태의 출처를 먼저 확인한다.
 - Related: 이슈 [#76](https://github.com/landfill/ClairKeys/issues/76), D-010, D-011, D-013, D-018,
   D-017~D-023, `docs/recovery/phases/DS-0-current-state-baseline.md`
+
+## D-025: 다크 모드는 이번 개편에서 구현하지 않는다
+
+- Date: 2026-08-29
+- Status: Accepted
+- Deviates from: 이슈 [#76](https://github.com/landfill/ClairKeys/issues/76) 비주얼 시스템의
+  "다크 모드는 전체 서비스보다 플레이어에 우선 적용"
+- Context:
+  - 사용자가 2026-08-29에 다크 모드는 현재 구현 계획이 없다고 지시했다. 이슈 #76 본문에는 남아
+    있으므로, 구현이 스펙과 달라야 하는 이유를 코드보다 먼저 기록한다 (AGENTS.md).
+  - 현재 상태는 "부분 지원"이 아니라 **죽은 코드**다. `globals.css`의 `prefers-color-scheme: dark`
+    블록이 `--background`/`--foreground`를 바꾸지만, `src/app/layout.tsx:100`의
+    `<main className="flex-1 bg-gray-50">`와 `bg-white` Header·Footer가 body를 완전히 덮어
+    화면에는 반영되지 않는다. 즉 지우든 두든 지금 보이는 화면은 같다.
+  - 이슈 #76의 최우선 목표는 PDF 업로드 전환율이다. 다크 모드는 그 지표에 직접 기여하지 않는
+    반면, 토큰을 두 벌(라이트·다크)로 정의하고 모든 화면에서 대비를 두 번 검증하는 비용을 DS-1~DS-7
+    전체에 부과한다.
+- Decision:
+  1. DS-1의 디자인 토큰은 **라이트 팔레트 한 벌만** 정의한다. `@media (prefers-color-scheme: dark)`
+     나 `[data-theme]` 분기를 새로 만들지 않는다.
+  2. `globals.css`의 기존 죽은 다크 블록(DS0-10)은 DS-1에서 처리한다. 남겨 둘 경우 다크 모드가
+     지원되는 것으로 오해되므로, 남긴다면 죽은 코드임을 주석으로 명시한다.
+  3. 플레이어의 어두운 시각화 영역(낙하 노트 배경의 검은 박스)은 다크 모드가 아니다. 그것은 노트
+     대비를 위한 **컴포넌트 고유의 배경**이며 이 결정의 대상이 아니다.
+  4. 이 결정은 다크 모드를 영구히 배제하지 않는다. 다시 하기로 하면 이 항목을 갱신하고 DS-1의
+     토큰 정의로 돌아간다.
+- Reason: 지금 상태가 부분 구현이 아니라 무효한 코드이므로, "이미 절반 됐으니 마저 하자"는 근거가
+  성립하지 않는다. 구현하지 않기로 하면 잃는 것은 없고, 하기로 하면 모든 단계에 검증 비용이 붙는다.
+- Rejected:
+  - 플레이어에만 다크 모드 적용 (이슈 #76 원안) | 플레이어는 이미 검은 시각화 영역을 갖고 있어
+    체감 이득이 작은 반면, 컨트롤·오버레이·TempoDisplay의 대비를 별도 팔레트로 재검증해야 한다.
+  - 죽은 블록을 그대로 둔다 | 새 토큰과 나란히 있으면 다음 세션이 다크 모드 지원으로 읽는다.
+- Consequence:
+  - 다크 OS 사용자는 라이트 화면을 본다. 현재도 동일하므로 회귀가 아니다.
+  - 이슈 #76 본문의 다크 모드 항목과 이 결정이 어긋난다. 이슈를 읽는 사람은 이 결정을 함께 본다.
+- Directive:
+  - DS-1~DS-7에서 다크 팔레트 토큰이나 `prefers-color-scheme` 분기를 새로 도입하지 않는다.
+  - 플레이어 시각화 영역의 검은 배경을 다크 모드 구현으로 표현하지 않는다.
+- Related: 이슈 [#76](https://github.com/landfill/ClairKeys/issues/76), D-024,
+  `docs/recovery/phases/DS-0-current-state-baseline.md` (DS0-10)

--- a/docs/recovery/DECISIONS.md
+++ b/docs/recovery/DECISIONS.md
@@ -643,3 +643,52 @@
     걸리지 않으면 그건 상한이 아니다 — D-021과 D-022가 이 확인을 빠뜨려 두 번 헛돌았다.
 - Related: D-021, D-022, 이슈 [#65](https://github.com/landfill/ClairKeys/issues/65),
   `src/utils/playbackGeometry.ts`
+
+## D-024: 디자인 개편은 재생 기하와 저장 계약을 회귀 기준으로 두고 단계별로 진행한다
+
+- Date: 2026-08-29
+- Status: Accepted
+- Context:
+  - 이슈 [#76](https://github.com/landfill/ClairKeys/issues/76)은 이름을 제외한 로고·색상·UI 전면
+    개편을 요구한다. 시각 개편은 성격상 거의 모든 화면 파일을 건드리므로, 지금까지 실기기 관측과
+    실측으로 확정한 계약을 조용히 밀어낼 수 있는 유일한 종류의 작업이다.
+  - 재생 기하는 D-021 → D-022 → D-023으로 **세 번** 고쳤고, 매번 이유는 "폰 가로에서 상한이 걸리는지
+    확인하지 않았다"였다. 이 값들은 취향이 아니라 실기기 보고에 대한 답이다.
+  - DS-0 인벤토리에서 canonical 업로드 경로가 `ProcessingJob`·`ProcessingNotification`을 전혀 쓰지
+    않는다는 것이 확인됐다. 즉 `/processing` 화면과 알림 API는 실제 업로드와 단절돼 있다. 이 상태를
+    모른 채 3단계 처리 화면을 디자인하면 없는 데이터를 그리는 UI가 나온다.
+- Decision:
+  1. 이슈 #76은 DS-0~DS-7의 별도 이슈·브랜치·PR로 진행한다. 한 PR에서 홈·업로드·플레이어를 동시에
+     교체하지 않는다.
+  2. DS-0이 고정한 회귀 계약(`docs/recovery/phases/DS-0-current-state-baseline.md`의 "변경하지 않을
+     회귀 계약")은 시각 개편의 부수효과로 바뀌지 않는다. 바꿔야 할 이유가 생기면 해당 결정 문서
+     (D-013, D-017~D-023 등)를 먼저 갱신한다.
+  3. `body.playback-active .playback-chrome`과 `body.playback-rotated`는 새 공통 셸에서도 유지한다.
+     Header·Footer를 교체하더라도 `playback-chrome` 클래스를 잃으면 재생 중 화면이 다시 좁아진다.
+  4. **DS-1(디자인 토큰과 공통 셸)이 다른 모든 단계의 선행 조건이다.** 토큰 없이 개별 화면부터
+     고치면 색상·간격·대비가 화면마다 흩어지고, DS-7에서 상태 표현을 통일할 근거가 사라진다.
+  5. 처리 단계 문구와 완료 알림(DS-3, DS-7)은 UI보다 **상태의 출처**를 먼저 정한다. 스키마에
+     `ProcessingStage` enum이 있다는 사실을 canonical 경로가 그것을 채운다는 뜻으로 읽지 않는다.
+  6. 기능 로직 변경과 시각 개편을 같은 커밋에 섞지 않는다.
+- Reason: 이 저장소가 지금까지 확정한 것 중 되돌리기 가장 비싼 것은 실기기로 세 번 고친 재생 기하와
+  D-010·D-011·D-018의 저장 경계다. 개편의 목적은 전환율이지 이 계약의 재검토가 아니므로, 계약을
+  명시적으로 열거해 두고 건드릴 때는 결정 문서를 먼저 고치게 만든다.
+- Rejected:
+  - 한 번의 전면 개편 PR | 회귀가 발생해도 어느 변경이 원인인지 분리할 수 없다. 이슈 #76의 실행
+    계획도 같은 이유로 이를 명시적으로 배제한다.
+  - 화면부터 고치고 토큰은 나중에 추출 | 추출 시점에 이미 화면마다 다른 값이 박혀 있어, 토큰화가
+    전면 재작업이 된다. 현재 `globals.css`의 토큰은 `--background`/`--foreground` 둘뿐이다.
+  - 회귀 계약을 테스트에만 맡긴다 | 테스트는 값이 바뀐 것은 잡지만 **왜 그 값인지**는 알려주지
+    않는다. 디자인 작업자는 실패한 단언을 근거 없는 제약으로 읽고 수정하기 쉽다.
+- Consequence:
+  - DS-0이 `미확인`으로 남긴 항목(구간 반복, 곡 제목 편집, WCAG AA)은 해당 단계 진입 시 실제
+    화면에서 먼저 확인해야 한다. 개편 전 상태를 모르면 개편 후 회귀도 판정할 수 없다.
+  - 프로덕션 화면 캡처가 아직 없으므로, DS-0의 판정은 코드 기준이며 배포본과의 차이는 배제되지
+    않았다.
+- Directive:
+  - 시각 개편 PR에서 `src/utils/playbackGeometry.ts`, `src/utils/pianoLayout.ts`,
+    `src/hooks/usePlaybackOrientation.ts`의 상수나 조건식을 바꾸지 않는다.
+  - `playback-chrome` 클래스를 새 레이아웃에서 누락하지 않는다.
+  - 없는 데이터를 전제로 화면을 그리지 않는다. 상태의 출처를 먼저 확인한다.
+- Related: 이슈 [#76](https://github.com/landfill/ClairKeys/issues/76), D-010, D-011, D-013, D-018,
+  D-017~D-023, `docs/recovery/phases/DS-0-current-state-baseline.md`

--- a/docs/recovery/ROADMAP.md
+++ b/docs/recovery/ROADMAP.md
@@ -24,7 +24,7 @@ P0-A와 P0-D는 서로 다른 파일 범위를 갖도록 설계하면 병렬 진
 
 | 순서 | ID | 단계 | 상태 | 권장 브랜치 | 선행 조건 |
 |---:|---|---|---|---|---|
-| 0 | DS-0 | 현재 상태와 제품 계약 고정 | IN_PROGRESS | `codex/ds-0-current-state-baseline` | P1-A |
+| 0 | DS-0 | 현재 상태와 제품 계약 고정 | IN_REVIEW | `codex/ds-0-current-state-baseline` | P1-A |
 | 1 | DS-1 | 디자인 토큰과 공통 셸 | NOT_STARTED | `codex/ds-1-design-foundation` | DS-0 |
 | 2 | DS-2 | 로그인 전 핵심 가치 전달 | NOT_STARTED | `codex/ds-2-prelogin-value` | DS-1 |
 | 3 | DS-3 | 업로드와 처리 상태 | NOT_STARTED | `codex/ds-3-upload-processing` | DS-1 |
@@ -42,9 +42,11 @@ DS-3과 DS-7은 실제 백엔드 계약에 의존한다. DS-0이 확인한 대�
 
 ### DS-0: 현재 상태와 제품 계약 고정
 
-- 라우트 인벤토리와 두 겹 인증 경계(middleware + `AuthGuard`)
+- 라우트 인벤토리와 인증 경계 (middleware + `AuthGuard`, 그리고 그 경계가 실제로 막지 못하는 것)
 - 이슈 #76 완료 조건 7개에 대한 지원 / 부분 지원 / 미지원 판정
 - 디자인 개편이 바꾸지 않을 회귀 계약(D-013, D-017~D-023 등)
+- 신규 결함 9건의 대장과 담당 단계 배정 — GitHub 이슈가 아니라 phase 문서에 기록한다
+- DS-1 진입 조건 6개
 - 상세: [DS-0](phases/DS-0-current-state-baseline.md)
 
 ## 단계별 결과물

--- a/docs/recovery/ROADMAP.md
+++ b/docs/recovery/ROADMAP.md
@@ -17,6 +17,36 @@ ClairKeys의 우선순위는 제품 핵심 정확도, 실행 안전성, 운영 �
 
 P0-A와 P0-D는 서로 다른 파일 범위를 갖도록 설계하면 병렬 진행할 수 있다. 그 외 단계는 표의 선행 조건을 지킨다.
 
+## 디자인 개편 트랙 (이슈 [#76](https://github.com/landfill/ClairKeys/issues/76))
+
+복구 트랙(P0~P2)과 별개로, 초보자 중심 여정·브랜드 전면 개편을 8단계로 진행한다. 이슈 #76의 실행
+계획을 그대로 단계화한 것이며, 한 PR에서 홈·업로드·플레이어를 동시에 교체하지 않는다.
+
+| 순서 | ID | 단계 | 상태 | 권장 브랜치 | 선행 조건 |
+|---:|---|---|---|---|---|
+| 0 | DS-0 | 현재 상태와 제품 계약 고정 | IN_PROGRESS | `codex/ds-0-current-state-baseline` | P1-A |
+| 1 | DS-1 | 디자인 토큰과 공통 셸 | NOT_STARTED | `codex/ds-1-design-foundation` | DS-0 |
+| 2 | DS-2 | 로그인 전 핵심 가치 전달 | NOT_STARTED | `codex/ds-2-prelogin-value` | DS-1 |
+| 3 | DS-3 | 업로드와 처리 상태 | NOT_STARTED | `codex/ds-3-upload-processing` | DS-1 |
+| 4 | DS-4 | 내 악보 | NOT_STARTED | `codex/ds-4-my-library` | DS-1 |
+| 5 | DS-5 | 학습 플레이어 | NOT_STARTED | `codex/ds-5-learning-player` | DS-1 |
+| 6 | DS-6 | 탐색과 공개 체험 | NOT_STARTED | `codex/ds-6-explore` | DS-2 |
+| 7 | DS-7 | 알림·빈 화면·오류 상태 완결 | NOT_STARTED | `codex/ds-7-states` | DS-3, DS-4 |
+
+DS-1은 나머지 전부의 선행 조건이다. 토큰 없이 개별 화면부터 고치면 색상·간격·대비가 화면마다
+흩어지고, DS-7에서 상태 표현을 통일할 근거가 사라진다.
+
+DS-3과 DS-7은 실제 백엔드 계약에 의존한다. DS-0이 확인한 대로 canonical 업로드 경로는
+`ProcessingJob`·`ProcessingNotification`을 쓰지 않으므로, 처리 단계 문구와 완료 알림은 UI 이전에
+**어느 상태를 어디서 읽을지**를 먼저 정해야 한다.
+
+### DS-0: 현재 상태와 제품 계약 고정
+
+- 라우트 인벤토리와 두 겹 인증 경계(middleware + `AuthGuard`)
+- 이슈 #76 완료 조건 7개에 대한 지원 / 부분 지원 / 미지원 판정
+- 디자인 개편이 바꾸지 않을 회귀 계약(D-013, D-017~D-023 등)
+- 상세: [DS-0](phases/DS-0-current-state-baseline.md)
+
 ## 단계별 결과물
 
 ### DOC-1: 기본 브랜치 `main` 전환

--- a/docs/recovery/phases/DS-0-current-state-baseline.md
+++ b/docs/recovery/phases/DS-0-current-state-baseline.md
@@ -66,18 +66,35 @@ Issue: [#76](https://github.com/landfill/ClairKeys/issues/76) 0단계
 | 완료 알림 | **실사용 경로에 없다.** 아래 "처리 상태 단절" 참조 | `src/app/api/omr/upload/route.ts` |
 | 내 악보의 처리 중·오류 | **표시하지 않는다.** 목록이 `processingStatus`를 렌더하지 않음 | `src/components/library/LibrarySheetMusicList.tsx` |
 
-### 인증 경계 — 로그인 전 체험을 막는 것은 두 겹이다
+### 인증 경계 — 막는 것은 화면이지 데이터가 아니다
 
-완료 조건 "로그인 전 실제 학습 결과를 최소 한 번 체험할 수 있다"는 현재 **두 지점**에서 막힌다.
-DS-2에서 한쪽만 풀면 화면은 열리고 데이터는 401이 된다.
+완료 조건 "로그인 전 실제 학습 결과를 최소 한 번 체험할 수 있다"의 실제 장애물은 **화면 한 겹뿐**이다.
+운영 확인(2026-08-29)으로 데이터는 이미 열려 있음이 확인됐다.
 
-1. `src/app/sheet/[id]/page.tsx:139,153,174` — 페이지 전체가 `AuthGuard`로 감싸여 있다. 로딩·오류·정상
-   렌더 세 분기 모두 동일하다.
-2. `src/app/api/files/animation/route.ts:88-95` — GET이 세션 없으면 401을 먼저 반환한다.
-   소유·공개 판별(`:110-118`)은 그 뒤에 온다.
+1. **막는 것**: `src/app/sheet/[id]/page.tsx:139,153,174` — 페이지 전체가 `AuthGuard`로 감싸여
+   있다. 로딩·오류·정상 렌더 세 분기 모두 동일하다.
+2. **막지 못하는 것**: `src/app/api/files/animation/route.ts:88-95`의 GET은 세션 없으면 401이지만
+   (`curl` 확인), 같은 데이터를 **우회해서 받을 수 있다.** `GET /api/sheet/[id]`
+   (`:53-58`)는 공개 악보를 세션 없이 허용하면서 응답 본문에 `animationDataUrl`을 그대로 담고,
+   그 URL은 Supabase **public** 버킷이라 익명으로 200을 준다.
 
-`src/app/api/sheet/[id]/route.ts:53-58`의 GET은 이미 공개 악보를 세션 없이 허용한다. 즉 메타데이터는
-열려 있고 애니메이션 데이터만 닫혀 있다.
+운영 확인:
+
+```
+curl -s https://clairkeys.vercel.app/api/sheet/28
+  -> 200, provenance=omr, animationDataUrl=.../storage/v1/object/public/animation-data/...
+curl -sI <그 URL>  -> 200 application/json
+curl -s https://clairkeys.vercel.app/api/files/animation?sheetMusicId=2
+  -> 401 {"error":"Unauthorized"}
+```
+
+**DS-2에 대한 함의**: 로그인 전 체험은 API 인증을 바꾸지 않고 구현할 수 있다. 페이지의 `AuthGuard`를
+풀고, 클라이언트가 `/api/files/animation` 대신 `/api/sheet/[id]`의 `animationDataUrl`을 쓰게 하면 된다.
+
+**별도로 확인된 접근 제어 간극** (DS 범위 밖, 이슈로 분리): 비공개 악보(`isPublic: false`)의 객체도
+같은 public 버킷에 있다. `GET /api/sheet/29`는 익명에게 `{"error":"Access denied"}`를 주지만,
+소유자로 얻은 URL을 자격증명 없이 요청하면 **200으로 78,518바이트가 내려온다.** 즉 비공개 악보의
+보호는 URL 은닉뿐이다.
 
 ### 처리 상태 단절 — `/processing`은 실제 업로드를 보지 않는다
 
@@ -98,6 +115,30 @@ Header의 `처리 상태` 메뉴는 `/processing` → `ProcessingDashboard` →
 존재하지만 canonical 경로가 채우지 않는다. 이슈 #76 3단계의 4개 처리 단계 문구를 이 enum에
 기대어 쓰면 안 된다.
 
+## 운영 화면 확인 (2026-08-29, 1440×900 데스크톱, 로그인 상태)
+
+코드 판정을 https://clairkeys.vercel.app 에서 대조했다. 어긋난 항목은 위 표에 반영했다.
+
+| 화면 | 확인된 것 |
+|---|---|
+| `/` | 히어로가 정적 건반. CTA `시작하기` / `공개 악보 탐색`. 코드와 일치 |
+| `/library` | 악보 5건. **처리 상태·오류 표시 없음**(연주·이동·삭제 3버튼뿐). 제목이 파일명(`Princess_Mononoke_`, `bach-wtk1-prelude1`, `Complete Score` ×2), 저작자에 `조`·`ㄴㅁㄹㄹㄴ`·`쇼핑` 같은 값이 그대로 노출 |
+| `/processing` | **`처리 작업 (0)` / `알림 (0)`.** 같은 계정에 악보 5건이 있는데도 비어 있다 — 코드 판정(단절)이 운영에서 확인됐다 |
+| `/upload` | 드롭존, 곡명, 저작자, **빠르기(BPM) 선택 입력**(이슈 #82), 카테고리, 공개 설정, `OMR 처리 시작`. **예상 처리 시간·백그라운드 처리 안내·예시 악보가 없다.** 버튼 문구에 `OMR` 기술 용어가 그대로 있다 |
+| `/explore` | 카드 제목이 파일명이라 넘침(`Princess_Mononoke_Ashitaka_and_San_print_30…`). `악보 미리보기`는 실제 미리보기가 아닌 플레이스홀더. 섹션 제목에 이모지(🌟·🔥) |
+| `/sheet/2` | `♩=120 (출처 미상)` 표시 확인(#82). 건반 C2–C7 라벨 확인(D-017 결정 4). 1차 컨트롤은 재생·일시정지·정지·속도·모드·음량 — **구간 반복 없음** |
+
+프로덕션 라우트 응답 코드 (익명, `curl`):
+
+```
+/demo-animation /demo-category /demo-playback /demo-practice      200
+/test-piano /test-finger /test-background-processing              200
+/admin/update-finger-data                                          200
+/processing                                                        200  (AuthGuard가 클라이언트에서 리다이렉트)
+```
+
+즉 데모·테스트·관리자 라우트 8개가 UI 유입 링크 0인 채 프로덕션에서 열려 있다.
+
 ## 기능 지원표
 
 | 기능 | 상태 | 근거 |
@@ -113,12 +154,12 @@ Header의 `처리 상태` 메뉴는 `/processing` → `ProcessingDashboard` →
 | 공개 악보 탐색·검색 | 지원 | `/explore` |
 | 로그인 후 원래 행동 복귀 | 부분 지원 | AuthGuard만. Header 로그인 버튼은 `callbackUrl='/'` 고정 |
 | 처리 진행 표시 | 부분 지원 | 업로드 화면에 머무는 동안만(`OMRProcessingStatus`). 이탈하면 추적 화면 없음 |
-| 구간 반복 | 미확인 | DS-5에서 `PlaybackControls` 실제 노출 여부를 확인한다 |
-| 로그인 전 학습 결과 체험 | 미지원 | AuthGuard + `/api/files/animation` 401 |
+| 구간 반복 | 미지원 | `PlaybackControls`에 loop 관련 코드가 없고 `FallingNotesPlayer`도 참조하지 않는다. 운영 재생 화면에도 없다 |
+| 로그인 전 학습 결과 체험 | 미지원 | 화면의 `AuthGuard`. 데이터는 이미 익명 접근 가능 (위 "인증 경계") |
 | 처리 상태 전용 화면 | 미지원 | `/processing`이 canonical 경로와 단절 |
 | 변환 완료 알림 | 미지원 | `ProcessingNotification`이 canonical 경로에서 생성되지 않음 |
 | 내 악보의 처리 중·오류 상태 | 미지원 | 목록이 `processingStatus`를 렌더하지 않음 |
-| 곡 제목 편집 | 미확인 | DS-4에서 `PATCH /api/sheet/[id]`(`:95`) 대비 UI 존재 여부 확인 |
+| 곡 제목 편집 | 미지원 (운영 기준) | `PATCH /api/sheet/[id]`와 `SheetMusicActions`의 `onEdit`은 있으나, `/library`가 쓰는 `LibrarySheetMusicList`에는 연주·이동·삭제뿐이다 |
 | 마지막 연습 위치 이어하기 | 미지원 | `PracticeSession`은 있으나 재생 위치 복원 경로 없음 |
 | 디자인 토큰 | 미지원 | `globals.css`는 `--background`/`--foreground` 2개뿐 (Tailwind v4) |
 | 다크 모드 | 부분 지원 | `prefers-color-scheme`가 body 색만 바꾼다. 화면은 `bg-white`·`text-gray-*` 하드코딩 |
@@ -199,5 +240,9 @@ DS-1~DS-7은 아래를 **시각 개편의 부수효과로 바꾸지 않는다.**
 
 - 2026-08-29 — Work stages 1~3을 `f184f28` 기준으로 완료했다. 근거는
   `docs/recovery/validation/2026-08-29-ds0-code-inventory.md`.
-  Work stage 4(운영 화면 캡처)는 로그인 후 화면에 사용자 계정 세션이 필요해 아직 수행하지 않았다.
-  Work stage 5는 4에 의존한다.
+- 2026-08-29 — Work stage 4 완료. 사용자의 로그인된 Chrome 세션으로 운영
+  https://clairkeys.vercel.app 의 홈·내 악보·처리 상태·업로드·탐색·플레이어를 1440×900에서 확인했다.
+  코드 판정 대부분이 확인됐고 **한 건이 뒤집혔다** — 로그인 전 체험을 막는 것은 화면 한 겹이며
+  애니메이션 데이터는 이미 익명 접근이 가능하다. `미확인`이던 구간 반복·곡 제목 편집도
+  `미지원`으로 확정했다. 근거는 `docs/recovery/validation/2026-08-29-ds0-production-walkthrough.md`.
+  Work stage 5(발견 결함의 이슈 등록)는 사용자 확인 대기 중이다.

--- a/docs/recovery/phases/DS-0-current-state-baseline.md
+++ b/docs/recovery/phases/DS-0-current-state-baseline.md
@@ -1,6 +1,6 @@
 # DS-0 — 디자인 개편 착수 전 현재 상태와 제품 계약 고정
 
-Status: `IN_PROGRESS`
+Status: `IN_REVIEW`
 Depends on: P1-A (`DONE`)
 Issue: [#76](https://github.com/landfill/ClairKeys/issues/76) 0단계
 
@@ -165,6 +165,50 @@ Header의 `처리 상태` 메뉴는 `/processing` → `ProcessingDashboard` →
 | 다크 모드 | 부분 지원 | `prefers-color-scheme`가 body 색만 바꾼다. 화면은 `bg-white`·`text-gray-*` 하드코딩 |
 | 지원·개인정보 링크 | 미지원 | `Footer.tsx:47-59` 세 링크 모두 `href="#"` |
 
+## 발견된 결함 대장
+
+0단계 Work stage 5의 산출물이다. 사용자가 2026-08-29에 **GitHub 이슈를 새로 만들지 않고 이 문서에
+기록**하도록 지시했으므로, 여기가 이 결함들의 canonical 기록이다. 해당 단계에 진입할 때 이 표를
+먼저 읽는다. 기존 이슈가 있는 항목은 그 번호를 적었다.
+
+| ID | 결함 | 근거 | 담당 | 기존 이슈 |
+|---|---|---|---|---|
+| DS0-1 | 비공개 악보(`isPublic: false`)의 애니메이션 객체가 Supabase **public 버킷**에 있다. `GET /api/sheet/29`는 익명에게 403을 주지만, 소유자로 얻은 URL을 자격증명 없이 요청하면 200으로 78,518바이트가 내려온다. 비공개 악보의 보호가 URL 은닉뿐이다 | 운영 walkthrough | **DS 범위 밖.** 별도 보안 작업 | 없음 |
+| DS0-2 | `/processing` 화면과 `/api/notifications`가 canonical 업로드와 단절돼 있다. `/api/omr/upload`·`/api/omr/finalize`에 `ProcessingJob` 참조가 0건이라, 악보 5건을 가진 계정에서도 `처리 작업 (0)` / `알림 (0)`이다 | 코드 + 운영 | **DS-3, DS-7의 선행 조건.** 상태의 출처를 먼저 정한다 (D-024 결정 5) | 없음 |
+| DS0-3 | 데모·테스트·관리자 라우트 8개(`/demo-*` 4, `/test-*` 3, `/admin/update-finger-data`)가 UI 유입 링크 0인 채 프로덕션에서 200을 반환한다 | `curl` × 8 | **DS-1.** 정보 구조 결정에서 제거할지 격리할지 정한다 | 없음 |
+| DS0-4 | 공개 악보에 파일명과 미검증 메타데이터가 그대로 노출된다. 제목이 `Princess_Mononoke_Ashitaka_and_San_print_300dpi`, 저작자가 `ㄴㅁㄹㄹㄴ`·`조`·`쇼핑` | 운영 walkthrough | **DS-4** (제목 편집), **DS-6** (탐색 표현) | 없음 |
+| DS0-5 | Footer 지원 링크 3개가 전부 `href="#"`이고 저작권 표기가 `© 2024`다 | `Footer.tsx:47-59` | **DS-1** (공통 셸) | 없음 |
+| DS0-6 | 내 악보 목록이 `processingStatus`를 렌더하지 않는다. 처리 중·오류 상태를 화면에서 알 수 없다 | 코드 + 운영 | **DS-4** | 없음 |
+| DS0-7 | 업로드 화면에 예상 처리 시간·백그라운드 처리 안내·예시 악보가 없다. 버튼 문구가 `OMR 처리 시작`으로 기술 용어를 노출한다 | 운영 walkthrough | **DS-3** | 없음 |
+| DS0-8 | 곡 제목 편집 UI가 `SheetMusicActions`에 있으나 `/library`가 쓰는 `LibrarySheetMusicList`에는 없다. 고아 컴포넌트 계층의 사례다 | 코드 | **DS-4**, 정리는 P2-A | 없음 |
+| DS0-9 | 구간 반복이 운영 재생 경로에 없다. `PlaybackControls`에 loop 코드가 아예 없고, `loopStart`/`loopEnd`는 다른 플레이어(`animationEngine.ts`)에만 있다 | 코드 + 운영 | **DS-5** | 없음 |
+
+이미 이슈가 있는 것은 여기에 옮겨 적지 않는다 — 변환 실패의 Java 스택 트레이스([#47](https://github.com/landfill/ClairKeys/issues/47)),
+작은 페이지 PDF 인식 실패([#46](https://github.com/landfill/ClairKeys/issues/46)),
+진행 바 고착([#66](https://github.com/landfill/ClairKeys/issues/66)),
+모바일 건반 범위([#65](https://github.com/landfill/ClairKeys/issues/65)).
+
+## DS-1 진입 조건
+
+DS-1(디자인 토큰과 공통 셸)이 시작 시점에 **결정해야 할 대상** 목록이다. 이것이 확정돼야 DS-2 이후가
+각자 화면을 고칠 수 있다.
+
+1. **토큰 정의** — 현재 `globals.css`에는 `--background`/`--foreground` 둘뿐이다(Tailwind v4
+   `@theme inline`). 이슈 #76 비주얼 시스템의 배경(아이보리)·기본색(잉크/네이비)·강조색(테라코타)·
+   보조색(블루·세이지)과 상태 색(처리 중·연습 가능·오류)을 토큰으로 정의한다.
+2. **다크 모드 범위** — 현재는 `prefers-color-scheme`가 body 색만 바꾸고 화면은 `bg-white`·
+   `text-gray-*`가 하드코딩돼 있다. 이슈 #76은 다크 모드를 **플레이어에 우선** 적용하라고 한다.
+   전체 서비스와 플레이어의 적용 범위를 여기서 정한다.
+3. **내비게이션 구성** — 목표는 `내 악보`·`새 악보`·`탐색` 3개다. 현재 Header는 로그인 시
+   `홈`·`내 악보`·`업로드`·`처리 상태`·`탐색` 5개다. `처리 상태` 메뉴의 처리 방향(제거 후 내 악보
+   상태 표시로 흡수)은 DS0-2의 결론에 의존한다.
+4. **고아 라우트 처리** — DS0-3의 8개 라우트를 제거할지, 인증 뒤로 옮길지, 유지할지 정한다.
+5. **아이콘 체계** — 이슈 #76은 이모지 제거와 일관된 선형 아이콘을 요구한다. 현재 이모지가
+   Header 로고, Footer 로고, `/library` 탭(📚📁), `/explore` 탭(🏠🔍)과 섹션 제목(🌟🔥),
+   홈 기능 카드(📄🎹⚡), `AuthGuard`(🔒), 로그인 provider(🔍🐙)에 있다. 아이콘 세트와 도입
+   방식(인라인 SVG / 라이브러리)을 정한다.
+6. **`playback-chrome` 계약** — 새 Header·Footer도 이 클래스를 유지해야 한다 (D-024 Directive).
+
 ## 변경하지 않을 회귀 계약
 
 DS-1~DS-7은 아래를 **시각 개편의 부수효과로 바꾸지 않는다.** 바꿔야 할 이유가 생기면 해당 결정
@@ -226,14 +270,14 @@ DS-1~DS-7은 아래를 **시각 개편의 부수효과로 바꾸지 않는다.**
 2. 기능 지원표를 지원 / 부분 지원 / 미지원으로 분류한다.
 3. 회귀 계약을 결정 문서 참조와 함께 목록화한다.
 4. 운영(clairkeys.vercel.app) 화면을 로그인 전·후로 캡처해 1~2단계와 대조한다.
-5. 대조에서 나온 신규 결함을 별도 이슈로 등록하고 담당 단계를 지정한다.
+5. 대조에서 나온 신규 결함을 아래 "발견된 결함 대장"에 기록하고 담당 단계를 지정한다.
 
 ## Completion criteria
 
 - 모든 라우트의 인증 경계와 UI 진입점이 기록되어 있다.
 - 이슈 #76의 완료 조건 7개 각각에 대해 현재 상태가 지원 / 부분 지원 / 미지원으로 판정되어 있다.
 - 디자인 개편이 바꾸지 않을 계약이 결정 문서 번호와 함께 열거되어 있다.
-- 운영 화면 캡처가 코드 판정과 일치하거나, 불일치가 이슈로 등록되어 있다.
+- 운영 화면 확인이 코드 판정과 일치하거나, 불일치가 "발견된 결함 대장"에 기록되어 있다.
 - DS-1의 진입 조건(정보 구조 결정 대상 목록)이 확정되어 있다.
 
 ## Progress
@@ -245,4 +289,8 @@ DS-1~DS-7은 아래를 **시각 개편의 부수효과로 바꾸지 않는다.**
   코드 판정 대부분이 확인됐고 **한 건이 뒤집혔다** — 로그인 전 체험을 막는 것은 화면 한 겹이며
   애니메이션 데이터는 이미 익명 접근이 가능하다. `미확인`이던 구간 반복·곡 제목 편집도
   `미지원`으로 확정했다. 근거는 `docs/recovery/validation/2026-08-29-ds0-production-walkthrough.md`.
-  Work stage 5(발견 결함의 이슈 등록)는 사용자 확인 대기 중이다.
+  Work stage 5는 사용자 확인 대기 중이었다.
+- 2026-08-29 — Work stage 5 완료. 사용자가 GitHub 이슈를 새로 만들지 않고 문서에 기록하도록
+  지시해, 신규 결함 9건을 "발견된 결함 대장"에 담당 단계와 함께 남겼다. DS-1 진입 조건 6개도
+  확정했다. Work stages 1~5와 completion criteria를 모두 충족했으나, PR
+  [#87](https://github.com/landfill/ClairKeys/pull/87)이 아직 병합되지 않아 상태는 `IN_REVIEW`다.

--- a/docs/recovery/phases/DS-0-current-state-baseline.md
+++ b/docs/recovery/phases/DS-0-current-state-baseline.md
@@ -162,7 +162,7 @@ Header의 `처리 상태` 메뉴는 `/processing` → `ProcessingDashboard` →
 | 곡 제목 편집 | 미지원 (운영 기준) | `PATCH /api/sheet/[id]`와 `SheetMusicActions`의 `onEdit`은 있으나, `/library`가 쓰는 `LibrarySheetMusicList`에는 연주·이동·삭제뿐이다 |
 | 마지막 연습 위치 이어하기 | 미지원 | `PracticeSession`은 있으나 재생 위치 복원 경로 없음 |
 | 디자인 토큰 | 미지원 | `globals.css`는 `--background`/`--foreground` 2개뿐 (Tailwind v4) |
-| 다크 모드 | 부분 지원 | `prefers-color-scheme`가 body 색만 바꾼다. 화면은 `bg-white`·`text-gray-*` 하드코딩 |
+| 다크 모드 | 미지원 (사실상 dead code) | `globals.css`의 `prefers-color-scheme` 블록은 `--background`/`--foreground`만 바꾸는데, `src/app/layout.tsx:100`의 `<main className="flex-1 bg-gray-50">`와 `bg-white` Header·Footer가 body를 완전히 덮는다. **현 단계에서 구현 계획 없음 (D-025)** |
 | 지원·개인정보 링크 | 미지원 | `Footer.tsx:47-59` 세 링크 모두 `href="#"` |
 
 ## 발견된 결함 대장
@@ -182,6 +182,7 @@ Header의 `처리 상태` 메뉴는 `/processing` → `ProcessingDashboard` →
 | DS0-7 | 업로드 화면에 예상 처리 시간·백그라운드 처리 안내·예시 악보가 없다. 버튼 문구가 `OMR 처리 시작`으로 기술 용어를 노출한다 | 운영 walkthrough | **DS-3** | 없음 |
 | DS0-8 | 곡 제목 편집 UI가 `SheetMusicActions`에 있으나 `/library`가 쓰는 `LibrarySheetMusicList`에는 없다. 고아 컴포넌트 계층의 사례다 | 코드 | **DS-4**, 정리는 P2-A | 없음 |
 | DS0-9 | 구간 반복이 운영 재생 경로에 없다. `PlaybackControls`에 loop 코드가 아예 없고, `loopStart`/`loopEnd`는 다른 플레이어(`animationEngine.ts`)에만 있다 | 코드 + 운영 | **DS-5** | 없음 |
+| DS0-10 | `globals.css`의 `prefers-color-scheme: dark` 블록이 죽은 코드다. `--background`/`--foreground`만 바꾸는데 `layout.tsx:100`의 `bg-gray-50` main과 `bg-white` Header·Footer가 body를 덮어 화면에 반영되지 않는다. 다크 모드는 구현 계획이 없으므로(D-025) 이 블록의 존재가 지원 여부를 오해하게 만든다 | 코드. **다크 OS에서 실제 렌더는 미관측** | **DS-1** | 없음 |
 
 이미 이슈가 있는 것은 여기에 옮겨 적지 않는다 — 변환 실패의 Java 스택 트레이스([#47](https://github.com/landfill/ClairKeys/issues/47)),
 작은 페이지 PDF 인식 실패([#46](https://github.com/landfill/ClairKeys/issues/46)),
@@ -196,9 +197,9 @@ DS-1(디자인 토큰과 공통 셸)이 시작 시점에 **결정해야 할 대�
 1. **토큰 정의** — 현재 `globals.css`에는 `--background`/`--foreground` 둘뿐이다(Tailwind v4
    `@theme inline`). 이슈 #76 비주얼 시스템의 배경(아이보리)·기본색(잉크/네이비)·강조색(테라코타)·
    보조색(블루·세이지)과 상태 색(처리 중·연습 가능·오류)을 토큰으로 정의한다.
-2. **다크 모드 범위** — 현재는 `prefers-color-scheme`가 body 색만 바꾸고 화면은 `bg-white`·
-   `text-gray-*`가 하드코딩돼 있다. 이슈 #76은 다크 모드를 **플레이어에 우선** 적용하라고 한다.
-   전체 서비스와 플레이어의 적용 범위를 여기서 정한다.
+2. **다크 모드 잔재 처리** — 다크 모드는 **구현하지 않는다** (D-025). 결정할 것은 범위가 아니라
+   `globals.css`의 죽은 `prefers-color-scheme` 블록(DS0-10)을 제거할지 유지할지다. 토큰을 새로
+   정의하면서 이 블록을 살려 두면 다음 세션이 다크 모드가 지원되는 것으로 오해한다.
 3. **내비게이션 구성** — 목표는 `내 악보`·`새 악보`·`탐색` 3개다. 현재 Header는 로그인 시
    `홈`·`내 악보`·`업로드`·`처리 상태`·`탐색` 5개다. `처리 상태` 메뉴의 처리 방향(제거 후 내 악보
    상태 표시로 흡수)은 DS0-2의 결론에 의존한다.

--- a/docs/recovery/phases/DS-0-current-state-baseline.md
+++ b/docs/recovery/phases/DS-0-current-state-baseline.md
@@ -1,0 +1,203 @@
+# DS-0 — 디자인 개편 착수 전 현재 상태와 제품 계약 고정
+
+Status: `IN_PROGRESS`
+Depends on: P1-A (`DONE`)
+Issue: [#76](https://github.com/landfill/ClairKeys/issues/76) 0단계
+
+## Objective
+
+이슈 #76 전면 개편에 착수하기 전에, 지금 운영 중인 화면·기능·계약이 무엇인지를 코드 근거와 함께
+고정한다. 이후 DS-1~DS-7 어떤 단계도 이 문서에 기록되지 않은 동작을 "원래 그랬다"거나 "원래
+없었다"고 주장하지 않는다.
+
+## In scope
+
+- 라우트별 화면 인벤토리와 인증 경계
+- 이슈 #76이 전제한 사용자 여정과 실제 코드 동작의 대조
+- 기능 지원표: 지원 / 부분 지원 / 미지원
+- 디자인 개편이 **바꾸지 않을** 회귀 계약 목록과 그 근거 문서
+
+## Out of scope
+
+- 디자인 토큰, 컴포넌트, 화면 구현 (DS-1 이후)
+- 여기서 발견된 결함의 수정 — 별도 이슈로 등록하고 해당 단계에서 처리한다
+- 이슈 #47·#46(오류 분류), #65·#66(재생 결함)의 해결
+
+## 화면 인벤토리
+
+`src/app/**/page.tsx` 18개. 인증 경계는 두 겹이다 —
+`src/middleware.ts:19`의 `protectedPaths = ['/library', '/upload', '/profile']`와,
+각 페이지가 개별로 감싸는 클라이언트 `AuthGuard`.
+
+| 라우트 | 역할 | middleware 보호 | AuthGuard | UI 진입점 |
+|---|---|---|---|---|
+| `/` | 홈 | 아니오 | 없음 | Header, Footer |
+| `/explore` | 공개 악보 탐색 | 아니오 | 없음 | Header, Footer, 홈 CTA |
+| `/sheet/[id]` | 학습 플레이어 + 악보 정보 | 아니오 | **있음** | `/explore`, `/library` |
+| `/auth/signin` | 로그인 | 아니오 | 없음 | Header 로그인, AuthGuard 리다이렉트 |
+| `/auth/error` | 인증 오류 | 아니오 | 없음 | NextAuth 설정 |
+| `/upload` | 업로드 | 예 | 있음 | Header, Footer, `/library` FAB, `/explore` FAB |
+| `/library` | 내 악보 | 예 | 있음 | Header |
+| `/processing` | 처리 상태 | 아니오 | 있음 | Header |
+| `/profile` | 계정 | 예 | — | UserProfile 드롭다운 |
+| `/offline` | PWA 오프라인 | 아니오 | 없음 | service worker |
+| `/demo-animation` `/demo-category` `/demo-playback` `/demo-practice` | 개발용 데모 | 아니오 | 없음 | **없음 (유입 링크 0)** |
+| `/test-background-processing` `/test-finger` `/test-piano` | 개발용 테스트 | 아니오 | 없음 | **없음 (유입 링크 0)** |
+| `/admin/update-finger-data` | 운지 데이터 관리 | 아니오 | — | 없음 |
+
+주: 데모·테스트 7개 라우트는 UI에서 도달할 수 없지만 **프로덕션에서 URL로는 열린다.**
+`middleware.ts`의 `protectedPaths`에 없고 `AuthGuard`도 없다. DS-1의 정보 구조 결정에서 이들을
+제거할지 격리할지 정한다.
+
+## 사용자 여정 기준선
+
+이슈 #76이 목표로 선언한 여정과 현재 코드의 대조다.
+
+| 여정 단계 | 현재 동작 | 근거 |
+|---|---|---|
+| 홈에서 결과 이해 | 정적 건반 미리보기(`buildKeyLayout(24)`, `activeKeys=new Set()`) — 떨어지는 노트 없음 | `src/app/page.tsx:36-56` |
+| 주 CTA | `시작하기` → `/upload`. `내 악보로 시작하기` 아님 | `src/app/page.tsx:22-26` |
+| 로그인 전 체험 | **불가능.** 아래 "인증 경계" 참조 | `src/app/sheet/[id]/page.tsx:139,153,174` |
+| 로그인 맥락 설명 | `PDF 악보를 피아노 애니메이션으로 변환하여 학습하세요` 한 줄. 계정이 필요한 이유 없음 | `src/app/auth/signin/page.tsx:113-115` |
+| 로그인 후 원래 행동 복귀 | **경로에 따라 다르다.** AuthGuard 경유는 복귀, Header 로그인 버튼은 항상 `/` | `src/components/auth/AuthGuard.tsx:25-26` vs `src/components/auth/LoginButton.tsx:17` |
+| 업로드 상태 분리 | `OMRUploadForm` 하나. 파일 검사와 변환 요청이 별도 상태로 표시되지 않음 | `src/app/upload/page.tsx:57-60` |
+| 처리 단계 표시 | 서버는 `progress` 숫자 + 영문 `message` 4단계만 제공 | `omr-service/app.py:323-364` |
+| 페이지 이탈 후 계속 처리 | **동작한다** (D-018 callback). 그러나 UI에 그 사실을 알리는 문구가 없다 | D-018, `src/app/api/omr/finalize/route.ts` |
+| 완료 알림 | **실사용 경로에 없다.** 아래 "처리 상태 단절" 참조 | `src/app/api/omr/upload/route.ts` |
+| 내 악보의 처리 중·오류 | **표시하지 않는다.** 목록이 `processingStatus`를 렌더하지 않음 | `src/components/library/LibrarySheetMusicList.tsx` |
+
+### 인증 경계 — 로그인 전 체험을 막는 것은 두 겹이다
+
+완료 조건 "로그인 전 실제 학습 결과를 최소 한 번 체험할 수 있다"는 현재 **두 지점**에서 막힌다.
+DS-2에서 한쪽만 풀면 화면은 열리고 데이터는 401이 된다.
+
+1. `src/app/sheet/[id]/page.tsx:139,153,174` — 페이지 전체가 `AuthGuard`로 감싸여 있다. 로딩·오류·정상
+   렌더 세 분기 모두 동일하다.
+2. `src/app/api/files/animation/route.ts:88-95` — GET이 세션 없으면 401을 먼저 반환한다.
+   소유·공개 판별(`:110-118`)은 그 뒤에 온다.
+
+`src/app/api/sheet/[id]/route.ts:53-58`의 GET은 이미 공개 악보를 세션 없이 허용한다. 즉 메타데이터는
+열려 있고 애니메이션 데이터만 닫혀 있다.
+
+### 처리 상태 단절 — `/processing`은 실제 업로드를 보지 않는다
+
+Header의 `처리 상태` 메뉴는 `/processing` → `ProcessingDashboard` →
+`useBackgroundProcessing` → `GET /api/processing`으로 `ProcessingJob` 테이블을 읽는다.
+
+그런데 canonical 업로드 경로인 `src/app/api/omr/upload/route.ts`는 `prisma.sheetMusic`만 쓰고
+**`ProcessingJob` 행을 만들지 않는다**(`:147`, `:225`). `/api/omr/finalize`에도
+`ProcessingJob` 참조가 없다. 따라서:
+
+- 실제 PDF를 올려도 `/processing`은 비어 있다.
+- `/api/notifications`가 읽는 `ProcessingNotification`도 canonical 경로에서 생성되지 않으므로
+  완료 알림이 발생하지 않는다.
+- 실제 진행 상태는 `SheetMusic.processingStatus`(자유 문자열, `prisma/schema.prisma`)에만 있고
+  이를 렌더하는 화면이 없다.
+
+`ProcessingStatus`·`ProcessingStage` enum(`UPLOAD|PARSING|OMR|VALIDATION|GENERATION`)은 스키마에
+존재하지만 canonical 경로가 채우지 않는다. 이슈 #76 3단계의 4개 처리 단계 문구를 이 enum에
+기대어 쓰면 안 된다.
+
+## 기능 지원표
+
+| 기능 | 상태 | 근거 |
+|---|---|---|
+| PDF → MusicXML → ClairKeys JSON 변환 | 지원 | D-010 canonical `/api/omr/upload` |
+| 페이지 이탈 후 백그라운드 완료 저장 | 지원 | D-018 callback + 폴링 fallback |
+| 떨어지는 노트 + 건반 재생 | 지원 | `FallingNotesPlayer` |
+| 재생 속도 조절 | 지원 | `tempoScale`, `PlaybackControls` |
+| 메트로놈 값·출처 표시 | 지원 | 이슈 #82, `TempoDisplay` |
+| 모바일 재생 가로 전환 | 지원 | D-019 |
+| 반응형 건반 폭·낙하 기하 | 지원 | D-020, D-022, D-023 |
+| 악보 provenance 경고 | 지원 | `DemoProvenanceNotice`, P1-A |
+| 공개 악보 탐색·검색 | 지원 | `/explore` |
+| 로그인 후 원래 행동 복귀 | 부분 지원 | AuthGuard만. Header 로그인 버튼은 `callbackUrl='/'` 고정 |
+| 처리 진행 표시 | 부분 지원 | 업로드 화면에 머무는 동안만(`OMRProcessingStatus`). 이탈하면 추적 화면 없음 |
+| 구간 반복 | 미확인 | DS-5에서 `PlaybackControls` 실제 노출 여부를 확인한다 |
+| 로그인 전 학습 결과 체험 | 미지원 | AuthGuard + `/api/files/animation` 401 |
+| 처리 상태 전용 화면 | 미지원 | `/processing`이 canonical 경로와 단절 |
+| 변환 완료 알림 | 미지원 | `ProcessingNotification`이 canonical 경로에서 생성되지 않음 |
+| 내 악보의 처리 중·오류 상태 | 미지원 | 목록이 `processingStatus`를 렌더하지 않음 |
+| 곡 제목 편집 | 미확인 | DS-4에서 `PATCH /api/sheet/[id]`(`:95`) 대비 UI 존재 여부 확인 |
+| 마지막 연습 위치 이어하기 | 미지원 | `PracticeSession`은 있으나 재생 위치 복원 경로 없음 |
+| 디자인 토큰 | 미지원 | `globals.css`는 `--background`/`--foreground` 2개뿐 (Tailwind v4) |
+| 다크 모드 | 부분 지원 | `prefers-color-scheme`가 body 색만 바꾼다. 화면은 `bg-white`·`text-gray-*` 하드코딩 |
+| 지원·개인정보 링크 | 미지원 | `Footer.tsx:47-59` 세 링크 모두 `href="#"` |
+
+## 변경하지 않을 회귀 계약
+
+DS-1~DS-7은 아래를 **시각 개편의 부수효과로 바꾸지 않는다.** 바꿔야 할 이유가 생기면 해당 결정
+문서를 먼저 갱신한다(AGENTS.md).
+
+### 재생 기하 — `src/utils/playbackGeometry.ts`, `src/utils/pianoLayout.ts`
+
+| 상수 | 값 | 고정 이유 |
+|---|---:|---|
+| `PX_PER_SEC` | 140 | D-021 결정 1. 노트 낙하 속도는 손이 익히는 대상이라 화면에 따라 달라지면 안 된다 |
+| `BASE_PLAYBACK_KEY_WIDTH` | 24 | D-020 결정 1. 상한이 아니라 기준 밀도 |
+| `PIANO_KEY_ASPECT` | 6.3 | D-022 결정 1. 실제 백건 비율 |
+| `FALLING_TO_KEYBOARD_RATIO` | 1.15 | D-023 결정 1. 낙하 영역의 실효 상한 |
+| `MIN_LOOK_AHEAD_SEC` | 1 | D-022 결정 2. 건반이 침범할 수 없는 하한 |
+| `MAX_LOOK_AHEAD_SEC` | 2.5 | D-023 결정 2. 초고해상도 안전망 |
+| `MIN_KEYBOARD_HEIGHT` | 120 | D-022 결정 3. 좁은 화면의 바닥 |
+
+불변식: 크롭 하한 ≤ `min(midi)`, 상한 ≥ `max(midi)` (D-017 결정 2). 폭을 벌기 위해 악보 음역을
+줄이거나 노트를 필터링하지 않는다.
+
+### 재생 가로 전환 — `src/hooks/usePlaybackOrientation.ts`
+
+- 회전 조건은 `engaged && (pointer: coarse) && (orientation: portrait)` 하나의 식이다 (D-019 결정 1).
+- iOS 판별은 `typeof screen.orientation?.lock === 'function'`으로만 한다 (D-019 결정 2).
+- 방향 요청은 재생 클릭 핸들러 안에서 동기적으로 발사한다 (D-019 결정 3).
+- 데스크톱은 회전 대상이 아니다 (D-019 결정 5).
+- 공유 `PlaybackControls`는 수정하지 않는다 — `AnimationPlayer`와 demo 페이지가 의존한다 (D-019 결정 8).
+- `body.playback-active .playback-chrome { display: none }`과 `body.playback-rotated { overflow: hidden }`
+  (`globals.css`)는 Header·Footer를 재생 중 숨기는 계약이다. 새 셸도 `playback-chrome` 클래스를 유지한다.
+
+### 데이터·저장 계약
+
+- canonical 업로드 경로는 `/api/omr/upload` 하나다 (D-010).
+- OMR 서비스는 스토리지 자격증명을 갖지 않는다 (D-011).
+- 완료 저장은 생산자 callback이 트리거하고 브라우저 폴링은 fallback이다 (D-018).
+- `SheetMusic.omrJobId`는 nullable unique이고 finalize는 `findUnique`를 쓴다 (이슈 #70).
+- 빠르기는 값과 출처를 함께 저장하고 모르면 모른다고 저장한다 (D-013). 재생 속도 배율과
+  악보 BPM을 같은 자리에 표시하지 않는다 (이슈 #82).
+- 애니메이션 JSON은 `normalizeAnimationData`의 canonical 계약을 통과해야 한다 (D-002, D-009).
+- provenance가 `demo`인 악보는 공개 목록에서 제외되고 재생 중 경고가 유지된다 (P1-A).
+
+### 오디오
+
+- 피아노 음색은 합성하지 않고 녹음을 재생한다 (D-014).
+- 재생 레벨은 라우드니스 기준이다 (D-015, D-016).
+- 음량 슬라이더는 압축 모드에서도 남는다 (D-019 결정 7).
+
+### 접근성·회귀 테스트
+
+- `e2e/application-smoke.spec.ts`의 세 검사 — 홈 렌더와 접근 가능한 내비게이션, 브라우저 확대
+  허용, `/explore` 진입 — 는 공개 경로 기준선이다. 확대 허용은 viewport meta에서 되돌리지 않는다.
+- `src/utils/__tests__/playbackGeometry.test.ts`, `pianoLayout.test.ts`,
+  `src/components/animation/__tests__/FallingNotesPlayer.test.tsx`,
+  `src/components/playback/__tests__/CompactPlaybackBar.test.tsx`가 위 기하·전환 계약을 고정한다.
+
+## Work stages
+
+1. 라우트 인벤토리, 인증 경계, 여정 대조를 코드 근거와 함께 고정한다.
+2. 기능 지원표를 지원 / 부분 지원 / 미지원으로 분류한다.
+3. 회귀 계약을 결정 문서 참조와 함께 목록화한다.
+4. 운영(clairkeys.vercel.app) 화면을 로그인 전·후로 캡처해 1~2단계와 대조한다.
+5. 대조에서 나온 신규 결함을 별도 이슈로 등록하고 담당 단계를 지정한다.
+
+## Completion criteria
+
+- 모든 라우트의 인증 경계와 UI 진입점이 기록되어 있다.
+- 이슈 #76의 완료 조건 7개 각각에 대해 현재 상태가 지원 / 부분 지원 / 미지원으로 판정되어 있다.
+- 디자인 개편이 바꾸지 않을 계약이 결정 문서 번호와 함께 열거되어 있다.
+- 운영 화면 캡처가 코드 판정과 일치하거나, 불일치가 이슈로 등록되어 있다.
+- DS-1의 진입 조건(정보 구조 결정 대상 목록)이 확정되어 있다.
+
+## Progress
+
+- 2026-08-29 — Work stages 1~3을 `f184f28` 기준으로 완료했다. 근거는
+  `docs/recovery/validation/2026-08-29-ds0-code-inventory.md`.
+  Work stage 4(운영 화면 캡처)는 로그인 후 화면에 사용자 계정 세션이 필요해 아직 수행하지 않았다.
+  Work stage 5는 4에 의존한다.

--- a/docs/recovery/validation/2026-08-29-ds0-code-inventory.md
+++ b/docs/recovery/validation/2026-08-29-ds0-code-inventory.md
@@ -1,0 +1,66 @@
+# Validation — DS-0/code-inventory
+
+Date: 2026-08-29
+Commit: `f184f28ac3123e7be4d24674e92a80659f7e9a47`
+Environment: macOS (Darwin 25.5.0), 저장소 정적 분석. 앱·DB·OMR 서비스를 실행하지 않았다.
+
+## Claim being verified
+
+`docs/recovery/phases/DS-0-current-state-baseline.md`의 화면 인벤토리·여정 대조·기능 지원표가
+현재 `main` 코드와 일치한다. 특히 이슈 #76의 완료 조건을 막는 지점이 추정이 아니라 코드에 있다.
+
+## Commands and results
+
+| Command | Result | Evidence |
+|---|---|---|
+| `find src/app -name page.tsx \| sort` | PASS | 18개 라우트. 이 중 7개(`demo-*` 4, `test-*` 3)는 UI 유입 링크가 0 |
+| `grep -rn "/<route>" src --include='*.tsx' --include='*.ts'` (라우트별) | PASS | `demo-*`·`test-*`·`offline` 모두 자기 디렉터리 밖 참조 0. `profile` 2, `auth/error` 1, `test-finger` 1 |
+| `cat src/middleware.ts` | PASS | `protectedPaths = ['/library', '/upload', '/profile']`. `/sheet/[id]`·`/processing`은 미포함 |
+| `grep -n "<AuthGuard>" "src/app/sheet/[id]/page.tsx"` | PASS | 139, 153, 174 — 로딩·오류·정상 세 분기 전부 |
+| `grep -n "status: 401" src/app/api/files/animation/route.ts` | PASS | 15(POST), **94(GET)**. GET의 소유·공개 판별은 110–118로 401 뒤에 온다 |
+| `grep -n "getServerSession\|isPublic\|403" "src/app/api/sheet/[id]/route.ts"` | PASS | 53–58에서 `isOwner \|\| isPublic`이면 통과 — 메타데이터는 이미 공개 |
+| `grep -c "processingJob" src/app/api/omr/upload/route.ts src/app/api/omr/finalize/route.ts` | PASS | 양쪽 **0**. canonical 경로는 `ProcessingJob` 행을 만들지 않는다 |
+| `grep -n "fetch(" src/hooks/useBackgroundProcessing.ts` | PASS | `/api/processing`, `/api/notifications` — `/processing` 화면의 유일한 데이터원 |
+| `grep -rc "processingStatus" src/components/library/` | PASS | **0**. 내 악보 목록은 처리 상태를 렌더하지 않는다 |
+| `grep -n 'callbackUrl = ' src/components/auth/LoginButton.tsx` | PASS | 15행 `callbackUrl = "/"` 기본값. Header는 이 기본값으로 렌더 |
+| `grep -n "currentUrl" src/components/auth/AuthGuard.tsx` | PASS | 25–26행에서 `pathname + search`를 `callbackUrl`로 보존 |
+| `grep -c 'href="#"' src/components/layout/Footer.tsx` | PASS | **3** (도움말·문의하기·개인정보처리방침) |
+| `grep -n "© 2024" src/components/layout/Footer.tsx` | PASS | 저작권 표기 2024 |
+| `grep -n "progress\|message" omr-service/app.py` | PASS | 진행값은 0/10/30/60/100 다섯 지점, 메시지는 영문 5종. 이슈 #76의 4단계 문구와 1:1 대응이 아니다 |
+| `sed -n '/model SheetMusic/,/^}/p' prisma/schema.prisma` | PASS | `processingStatus String @default("pending")` — enum이 아닌 자유 문자열 |
+| `grep -n "export const" src/utils/playbackGeometry.ts` | PASS | `PX_PER_SEC=140`, `MAX_LOOK_AHEAD_SEC=2.5`, `MIN_LOOK_AHEAD_SEC=1`, `MIN_KEYBOARD_HEIGHT=120`, `PIANO_KEY_ASPECT=6.3`, `FALLING_TO_KEYBOARD_RATIO=1.15`, `BOX_BORDER=2` |
+| `grep -n "BASE_PLAYBACK_KEY_WIDTH" src/utils/pianoLayout.ts` | PASS | 18행, 값 24 |
+| `sed -n '1,30p' src/app/globals.css` | PASS | 토큰은 `--background`/`--foreground` 2개뿐. Tailwind v4 `@theme inline` |
+| `npm test` / `npx tsc` / `npm run lint` | NOT_RUN | 이 변경은 `docs/recovery/` 3개 파일뿐이며 소스·설정을 건드리지 않는다 |
+
+## Baseline comparison
+
+- Fixed failures: 없음 (동작 변경 없음)
+- Remaining pre-existing failures: 해당 없음 — 이 기록은 테스트 실행이 아니라 코드 인벤토리다
+- New failures: 없음
+
+## Manual checks
+
+- 이슈 #76 완료 조건 7개를 코드 근거로 판정했다.
+
+  | 완료 조건 | 판정 | 막는 지점 |
+  |---|---|---|
+  | 5초 안에 PDF가 무엇으로 변환되는지 설명 | 미충족 | 홈 미리보기가 정적 건반 (`src/app/page.tsx:36-56`) |
+  | 주요 CTA가 `내 악보로 시작하기`로 일관 | 미충족 | `시작하기` (`src/app/page.tsx:24`) |
+  | 로그인 전 학습 결과 1회 체험 | 미충족 | `AuthGuard` + `/api/files/animation` GET 401 |
+  | 업로드 후 처리 단계·예상 대기 확인 | 부분 | 업로드 화면 체류 중에만. `/processing`은 단절 |
+  | 이탈해도 처리 계속됨을 이해 | 미충족 | 동작은 하지만(D-018) 문구가 없다 |
+  | 첫 진입 후 설명 없이 재생·속도 조절 | 미확인 | 실기기·실화면 확인 필요 (Work stage 4) |
+  | 키보드 탐색·명도 대비·색상 외 상태 구분 WCAG AA | 미확인 | 자동 검사 미실시. E2E는 내비게이션 접근성과 확대 허용만 확인 |
+
+## Gaps and risks
+
+- **운영 화면을 캡처하지 않았다.** 0단계의 Work stage 4는 로그인 후 화면
+  (`/upload`, `/library`, `/processing`, `/sheet/[id]`)을 요구하는데 사용자 계정 세션이 필요하다.
+  따라서 위 판정은 **코드 기준**이며, 배포본이 이 코드와 다를 가능성은 배제하지 못했다.
+- `구간 반복`과 `곡 제목 편집`은 컴포넌트 존재만으로 판정할 수 없어 `미확인`으로 남겼다.
+  DS-4·DS-5 진입 시 실제 화면에서 확인한다.
+- WCAG AA는 자동 검사(axe 등)를 돌리지 않았다. 색상 하드코딩(`bg-white`, `text-gray-600`)이
+  광범위해 DS-1 토큰 작업 없이 개별 화면에서 대비를 고치면 다시 흩어진다.
+- 데모·테스트 7개 라우트가 프로덕션에서 열려 있다는 사실은 확인했으나, 실제로 그 URL이
+  200을 반환하는지는 배포본에서 확인하지 않았다.

--- a/docs/recovery/validation/2026-08-29-ds0-code-inventory.md
+++ b/docs/recovery/validation/2026-08-29-ds0-code-inventory.md
@@ -4,6 +4,11 @@ Date: 2026-08-29
 Commit: `f184f28ac3123e7be4d24674e92a80659f7e9a47`
 Environment: macOS (Darwin 25.5.0), 저장소 정적 분석. 앱·DB·OMR 서비스를 실행하지 않았다.
 
+> **정정 (2026-08-29, 같은 날 운영 확인)**: 아래 "로그인 전 학습 결과 1회 체험" 판정의 *이유*가
+> 틀렸다. `/api/files/animation`의 401은 사실이지만 우회 경로가 있어, 실제로 막는 것은 화면의
+> `AuthGuard` 한 겹뿐이다. 근거는 `2026-08-29-ds0-production-walkthrough.md`.
+> `미확인`이던 구간 반복·곡 제목 편집도 그 문서에서 `미지원`으로 확정됐다.
+
 ## Claim being verified
 
 `docs/recovery/phases/DS-0-current-state-baseline.md`의 화면 인벤토리·여정 대조·기능 지원표가

--- a/docs/recovery/validation/2026-08-29-ds0-production-walkthrough.md
+++ b/docs/recovery/validation/2026-08-29-ds0-production-walkthrough.md
@@ -1,0 +1,53 @@
+# Validation — DS-0/production-walkthrough
+
+Date: 2026-08-29
+Commit: 배포본(https://clairkeys.vercel.app). 로컬 비교 기준은 `f184f28`
+Environment: macOS Chrome 1440×900, 사용자의 로그인 세션(계정 소유자), 익명 확인은 `curl`
+
+## Claim being verified
+
+`2026-08-29-ds0-code-inventory.md`의 코드 기준 판정이 실제 배포본과 일치하는가. 특히 코드만으로
+`미확인`으로 남긴 항목(구간 반복, 곡 제목 편집)과 인증 경계 판정.
+
+## Commands and results
+
+| Command | Result | Evidence |
+|---|---|---|
+| 브라우저: `/` (로그인 상태) | PASS | 히어로 정적 건반, CTA `시작하기`/`공개 악보 탐색`. 코드와 일치 |
+| 브라우저: `/library` | PASS | 악보 5건. 카드 액션은 연주·이동·삭제뿐 — **처리 상태·오류·제목 편집 없음**. 제목이 파일명, 저작자에 `조`·`ㄴㅁㄹㄹㄴ`·`쇼핑` |
+| 브라우저: `/processing` | PASS | `처리 작업 (0)`, `알림 (0)`. 같은 계정에 악보 5건이 있는데도 비어 있다 — 코드 판정(canonical 경로와 단절)이 운영에서 확인됨 |
+| 브라우저: `/upload` | PASS | 드롭존·곡명·저작자·빠르기(BPM)·카테고리·공개 설정·`OMR 처리 시작`. 예상 처리 시간·백그라운드 안내·예시 악보 없음 |
+| 브라우저: `/explore` | PASS | 카드 제목이 파일명이라 넘침. `악보 미리보기`는 플레이스홀더. 섹션 제목에 이모지 |
+| 브라우저: `/sheet/2` | PASS | `♩=120 (출처 미상)`(#82), 건반 C2–C7 라벨(D-017 결정 4), 1차 컨트롤에 **구간 반복 없음** |
+| `grep -n "loop\|Loop\|반복" src/components/playback/PlaybackControls.tsx` | PASS | 일치 0건. `FallingNotesPlayer`도 참조 없음 → 구간 반복 `미지원` 확정 |
+| `curl -s .../api/files/animation?sheetMusicId=2` | PASS | **401** `{"error":"Unauthorized"}`. 코드 판정과 일치 |
+| `curl -s .../api/sheet/28` | **FAIL(판정 뒤집힘)** | **200**. 익명에게 `provenance=omr`와 `animationDataUrl`을 그대로 반환 |
+| `curl -sI <그 animationDataUrl>` | **FAIL(판정 뒤집힘)** | **200 application/json**. Supabase `/object/public/` 버킷이라 익명 접근 가능 |
+| `curl -s .../api/sheet/29` (비공개 악보) | PASS | `{"error":"Access denied"}` — API는 비공개를 막는다 |
+| 소유자로 얻은 sheet 29의 URL을 자격증명 없이 요청 | **신규 결함** | **200, 78,518 bytes.** 비공개 악보의 보호가 URL 은닉뿐이다 |
+| `curl -o /dev/null -w '%{http_code}'` × 8 orphan 라우트 | PASS | `/demo-animation` `/demo-category` `/demo-playback` `/demo-practice` `/test-piano` `/test-finger` `/test-background-processing` `/admin/update-finger-data` 전부 **200** |
+
+## Baseline comparison
+
+- Fixed failures: 해당 없음 (동작 변경 없음)
+- Remaining pre-existing failures: 해당 없음
+- New failures: 없음. 대신 코드 기준 판정 1건이 뒤집혔고 신규 결함 1건이 발견됐다
+
+## Manual checks
+
+- **판정 정정**: 코드 인벤토리는 "로그인 전 체험을 막는 것은 두 겹(AuthGuard + API 401)"이라고 적었다.
+  401 자체는 사실이지만 **우회 경로가 있다.** `/api/sheet/[id]`가 익명에게 `animationDataUrl`을 주고
+  그 URL이 public 버킷이므로, 실제로 막는 것은 화면의 `AuthGuard` 한 겹뿐이다. DS-2는 API 인증을
+  바꾸지 않고 구현할 수 있다.
+- 중간에 페이지 안에서 `fetch(..., {credentials:'omit'})`로 시도한 확인은 **브라우저 HTTP 캐시에
+  오염됐다** — 같은 URL을 직전에 쿠키와 함께 받은 뒤라 200이 나왔다. `/api/notifications`를 대조군으로
+  두어(401) 오염을 확인했고, 최종 판정은 전부 `curl`로 다시 냈다. 이후 이런 확인은 페이지 밖에서 한다.
+
+## Gaps and risks
+
+- **신규 접근 제어 간극**: 비공개 악보의 애니메이션 JSON이 익명으로 내려온다. DS 범위가 아니므로
+  별도 이슈로 분리해야 한다. 이 문서는 사실만 기록하고 수정 방향을 정하지 않는다.
+- 실기기(모바일) 확인은 하지 않았다. 재생 가로 전환(D-019)과 기하(D-022, D-023)는 데스크톱에서만 봤다.
+- WCAG AA 자동 검사는 여전히 실시하지 않았다.
+- 업로드를 실제로 실행하지 않았다. 처리 단계 표시와 완료 알림의 실제 동작은 관측하지 않았고,
+  `/processing`이 비어 있다는 사실로만 단절을 확인했다.


### PR DESCRIPTION
이슈 #76의 0단계 — "현재 상태와 제품 계약 고정"이다. 코드나 화면은 바꾸지 않는다.

## 왜 지금 이걸 먼저 하나

시각 개편은 거의 모든 화면 파일을 건드리므로, 이 저장소가 실기기 관측으로 세 번 고친 재생 기하
(D-021 → D-022 → D-023)와 D-010·D-011·D-018의 저장 경계를 **부수효과로** 밀어낼 수 있다.
착수 전에 무엇이 계약이고 무엇이 결함인지를 코드 근거와 함께 고정한다.

## 이 PR이 확인한 것

인벤토리에서 세 가지가 추정이 아니라 코드에 있음이 확인됐다.

1. **로그인 전 체험을 막는 것은 두 겹이다.** `src/app/sheet/[id]/page.tsx:139,153,174`의 `AuthGuard`와
   `src/app/api/files/animation/route.ts:94`의 GET 401. 한쪽만 풀면 화면은 열리고 데이터는 401이 된다.
   메타데이터 API(`/api/sheet/[id]`)는 이미 공개 악보를 세션 없이 허용한다.
2. **로그인 후 복귀는 경로에 따라 다르다.** `AuthGuard`는 `pathname + search`를 보존하지만
   Header의 `LoginButton`은 `callbackUrl = "/"` 기본값이라 항상 홈으로 간다.
3. **`/processing` 화면은 실제 업로드를 보지 않는다.** canonical 경로인 `/api/omr/upload`와
   `/api/omr/finalize`에 `ProcessingJob` 참조가 0건이다. 따라서 `/processing`도, `/api/notifications`가
   읽는 `ProcessingNotification`도 실사용 업로드에서 채워지지 않는다. 실제 상태는
   `SheetMusic.processingStatus`(자유 문자열)에만 있고 이를 렌더하는 화면이 없다.

부수적으로: 데모·테스트 7개 라우트가 UI 유입 링크 0인 채 프로덕션에서 URL로 열려 있고,
Footer의 지원 링크 3개가 전부 `href="#"`이며 저작권 표기가 2024다.

## 변경 파일

| 파일 | 내용 |
|---|---|
| `docs/recovery/phases/DS-0-current-state-baseline.md` (신규) | 라우트 인벤토리, 여정 대조, 기능 지원표, **변경하지 않을 회귀 계약** |
| `docs/recovery/validation/2026-08-29-ds0-code-inventory.md` (신규) | 재현 가능한 명령과 결과, 이슈 #76 완료 조건 7개 판정 |
| `docs/recovery/ROADMAP.md` | DS-0~DS-7 디자인 개편 트랙 추가 |
| `docs/recovery/DECISIONS.md` | **D-024** — 단계별 진행, 회귀 계약 고정, DS-1이 나머지의 선행 조건 |

`ROADMAP.md`의 단계 구성 변경과 `DECISIONS.md` 신규 항목은 AGENTS.md 기준 직접 커밋 예외가
아니므로 이 PR에 포함했다.

## 검증

저장소 정적 분석이다. 앱·DB·OMR 서비스를 실행하지 않았다. 명령과 결과는 validation 기록에 표로 있다.

소스·설정 변경이 없어 `npm test` / `tsc` / `lint`은 실행하지 않았다.

## 남은 범위 (이 PR에 없음)

- **운영 화면 캡처** — 로그인 후 화면(`/upload`, `/library`, `/processing`, `/sheet/[id]`)에
  사용자 계정 세션이 필요하다. 따라서 위 판정은 **코드 기준**이며 배포본과의 차이는 배제하지 못했다.
- 구간 반복, 곡 제목 편집, WCAG AA는 `미확인`으로 남겼다. 해당 단계 진입 시 실제 화면에서 확인한다.
- 여기서 발견된 결함의 수정은 전부 후속 단계 몫이다.