### PR TITLE
Clarify score availability in my library

### DIFF
--- a/src/app/api/sheet/[id]/__tests__/route.test.ts
+++ b/src/app/api/sheet/[id]/__tests__/route.test.ts
@@ -44,6 +44,8 @@ describe('/api/sheet/[id]', () => {
         isPublic: false,
         provenance: 'demo',
         animationDataUrl: 'http://example.com/data.json',
+        processingStatus: 'pending',
+        omrJobId: 'internal-job-id',
         createdAt: new Date(),
         updatedAt: new Date(),
         user: { id: 'user1', name: 'Test User', email: 'test@example.com' },
@@ -60,6 +62,9 @@ describe('/api/sheet/[id]', () => {
       expect(data.sheetMusic.title).toBe('Test Song')
       expect(data.sheetMusic.provenance).toBe('demo')
       expect(data.sheetMusic.owner).toBeTruthy()
+      expect(data.sheetMusic.availability).toBe('ready')
+      expect(data.sheetMusic).not.toHaveProperty('processingStatus')
+      expect(data.sheetMusic).not.toHaveProperty('omrJobId')
     })
 
     it('should return public sheet music for non-owner', async () => {

--- a/src/app/api/sheet/[id]/route.ts
+++ b/src/app/api/sheet/[id]/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from '@/lib/auth/config'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
 import { sheetMusicCache } from '@/services/cacheService'
+import { deriveSheetMusicAvailability } from '@/lib/sheetMusicAvailability'
 
 export async function GET(
   request: NextRequest,
@@ -70,6 +71,7 @@ export async function GET(
         category: sheetMusic.category?.name || null,
         isPublic: sheetMusic.isPublic,
         provenance: sheetMusic.provenance,
+        availability: deriveSheetMusicAvailability(sheetMusic),
         createdAt: sheetMusic.createdAt,
         updatedAt: sheetMusic.updatedAt,
         animationDataUrl: sheetMusic.animationDataUrl,

--- a/src/app/api/sheet/__tests__/route.test.ts
+++ b/src/app/api/sheet/__tests__/route.test.ts
@@ -51,9 +51,11 @@ describe('/api/sheet', () => {
         {
           id: 1,
           title: 'Test Song',
-          composer: 'Test Composer',
-          isPublic: false,
-          createdAt: new Date(),
+        composer: 'Test Composer',
+        isPublic: false,
+        animationDataUrl: '',
+        processingStatus: 'processing',
+        createdAt: new Date(),
           updatedAt: new Date(),
           category: { id: 1, name: 'Classical' }
         }
@@ -68,6 +70,9 @@ describe('/api/sheet', () => {
       expect(data.success).toBe(true)
       expect(data.sheetMusic).toHaveLength(1)
       expect(data.sheetMusic[0].title).toBe('Test Song')
+      expect(data.sheetMusic[0].availability).toBe('processing')
+      expect(data.sheetMusic[0]).not.toHaveProperty('processingStatus')
+      expect(data.sheetMusic[0]).not.toHaveProperty('omrJobId')
     })
 
     it('should filter by category', async () => {

--- a/src/app/api/sheet/route.ts
+++ b/src/app/api/sheet/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth/config'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
+import { deriveSheetMusicAvailability } from '@/lib/sheetMusicAvailability'
 
 // GET /api/sheet - Get user's sheet music list
 export async function GET(request: NextRequest) {
@@ -68,6 +69,7 @@ export async function GET(request: NextRequest) {
         categoryId: sheet.categoryId,
         category: sheet.category,
         isPublic: sheet.isPublic,
+        availability: deriveSheetMusicAvailability(sheet),
         createdAt: sheet.createdAt,
         updatedAt: sheet.updatedAt
       }))

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -57,8 +57,8 @@ export default function LibraryPage() {
                 className={`
                   flex-1 flex items-center justify-center space-x-2 py-2 px-4 rounded-md text-sm font-medium transition-colors
                   ${activeTab === tab.id
-                    ? 'bg-white text-blue-600 shadow-sm'
-                    : 'text-gray-600 hover:text-gray-900'
+                    ? 'bg-surface text-accent shadow-sm'
+                    : 'text-ink-muted hover:text-ink'
                   }
                 `}
               >
@@ -78,10 +78,10 @@ export default function LibraryPage() {
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
                   placeholder="곡명, 저작자로 검색..."
-                  className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full pl-10 pr-4 py-3 border border-rule-strong bg-surface text-ink rounded-lg"
                 />
                 <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                  <svg className="h-5 w-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg className="h-5 w-5 text-ink-muted" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
                   </svg>
                 </div>
@@ -91,7 +91,7 @@ export default function LibraryPage() {
               <select
                 value={sortBy}
                 onChange={(e) => setSortBy(e.target.value as 'recent' | 'name' | 'created')}
-                className="px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white min-w-[140px]"
+                className="px-4 py-3 border border-rule-strong rounded-lg bg-surface text-ink min-w-[140px]"
               >
                 <option value="recent">최근 수정</option>
                 <option value="name">이름순</option>
@@ -118,7 +118,7 @@ export default function LibraryPage() {
           <div className="fixed bottom-6 right-6 z-10">
             <button
               onClick={() => router.push('/upload')}
-              className="w-14 h-14 fab-button text-white rounded-full flex items-center justify-center focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+              className="w-14 h-14 fab-button text-on-accent rounded-full flex items-center justify-center"
               title="새 악보 업로드"
               aria-label="새 악보 업로드"
             >

--- a/src/components/library/LibrarySheetMusicList.tsx
+++ b/src/components/library/LibrarySheetMusicList.tsx
@@ -31,6 +31,7 @@ export function LibrarySheetMusicList({
   const { categories, loading: categoriesLoading } = useCategories()
   const [editingSheet, setEditingSheet] = useState<SheetMusicWithCategory | null>(null)
   const [title, setTitle] = useState('')
+  const [titleError, setTitleError] = useState<string | null>(null)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
   // 데이터 로드
@@ -107,14 +108,20 @@ export function LibrarySheetMusicList({
 
   const openTitleEditor = (sheet: SheetMusicWithCategory) => {
     setTitle(sheet.title)
+    setTitleError(null)
     setEditingSheet(sheet)
   }
 
   const saveTitle = async (event: FormEvent) => {
     event.preventDefault()
-    if (!editingSheet || !title.trim()) return
+    if (!editingSheet) return
+    if (!title.trim()) {
+      setTitleError('제목을 입력해 주세요.')
+      return
+    }
 
     try {
+      setTitleError(null)
       setErrorMessage(null)
       await updateSheetMusic(editingSheet.id, { title: title.trim() })
       setEditingSheet(null)
@@ -221,13 +228,21 @@ export function LibrarySheetMusicList({
             <input
               id="sheet-title"
               value={title}
-              onChange={(event) => setTitle(event.target.value)}
+              onChange={(event) => {
+                setTitle(event.target.value)
+                setTitleError(null)
+              }}
               className="mt-1 w-full rounded-md border border-rule-strong bg-surface px-3 py-2 text-ink"
               autoFocus
               required
+              aria-describedby={titleError ? 'sheet-title-error' : undefined}
             />
+            {titleError && <p id="sheet-title-error" role="alert" className="mt-2 text-sm text-state-error">{titleError}</p>}
             <div className="mt-6 flex justify-end gap-3">
-              <Button type="button" variant="outline" onClick={() => setEditingSheet(null)}>취소</Button>
+              <Button type="button" variant="outline" onClick={() => {
+                setTitleError(null)
+                setEditingSheet(null)
+              }}>취소</Button>
               <Button type="submit">저장</Button>
             </div>
           </form>

--- a/src/components/library/LibrarySheetMusicList.tsx
+++ b/src/components/library/LibrarySheetMusicList.tsx
@@ -1,9 +1,11 @@
 'use client'
 
-import { useEffect } from 'react'
+import { FormEvent, useEffect, useState } from 'react'
 import { useSheetMusic } from '@/hooks/useSheetMusic'
 import { useCategories } from '@/hooks/useCategories'
 import { SheetMusicCard } from '@/components/sheet/SheetMusicCard'
+import type { SheetMusicWithCategory } from '@/types/sheet-music'
+import Button from '@/components/ui/Button'
 import Loading from '@/components/ui/Loading'
 
 interface LibrarySheetMusicListProps {
@@ -27,6 +29,9 @@ export function LibrarySheetMusicList({
 }: LibrarySheetMusicListProps) {
   const { sheetMusic, loading: sheetMusicLoading, fetchUserSheetMusic, updateSheetMusic, deleteSheetMusic } = useSheetMusic()
   const { categories, loading: categoriesLoading } = useCategories()
+  const [editingSheet, setEditingSheet] = useState<SheetMusicWithCategory | null>(null)
+  const [title, setTitle] = useState('')
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
   // 데이터 로드
   useEffect(() => {
@@ -86,9 +91,8 @@ export function LibrarySheetMusicList({
   }
 
   const handleDeleteSheetMusic = async (sheetMusicId: number) => {
-    if (!confirm('정말 이 악보를 삭제하시겠습니까?')) return
-    
     try {
+      setErrorMessage(null)
       await deleteSheetMusic(sheetMusicId)
       // 새로고침
       await fetchUserSheetMusic({
@@ -97,7 +101,26 @@ export function LibrarySheetMusicList({
       })
     } catch (error) {
       console.error('Failed to delete sheet music:', error)
-      alert('악보 삭제 중 오류가 발생했습니다.')
+      setErrorMessage('악보를 삭제하지 못했습니다. 잠시 후 다시 시도해 주세요.')
+    }
+  }
+
+  const openTitleEditor = (sheet: SheetMusicWithCategory) => {
+    setTitle(sheet.title)
+    setEditingSheet(sheet)
+  }
+
+  const saveTitle = async (event: FormEvent) => {
+    event.preventDefault()
+    if (!editingSheet || !title.trim()) return
+
+    try {
+      setErrorMessage(null)
+      await updateSheetMusic(editingSheet.id, { title: title.trim() })
+      setEditingSheet(null)
+    } catch (error) {
+      console.error('Failed to update sheet music title:', error)
+      setErrorMessage('제목을 저장하지 못했습니다. 잠시 후 다시 시도해 주세요.')
     }
   }
 
@@ -109,7 +132,7 @@ export function LibrarySheetMusicList({
   // 빈 상태
   if (filteredAndSortedSheetMusic.length === 0) {
     return (
-      <div className="text-center py-16 text-gray-500">
+      <div className="text-center py-16 text-ink-muted">
         <div className="text-6xl mb-4">🎵</div>
         <h3 className="text-lg font-medium mb-2">
           {searchQuery ? '검색 결과가 없습니다' : '악보가 없습니다'}
@@ -117,12 +140,22 @@ export function LibrarySheetMusicList({
         <p className="text-sm">
           {searchQuery ? '다른 검색어로 시도해보세요' : '첫 번째 악보를 업로드해보세요!'}
         </p>
+        {!searchQuery && (
+          <a href="/upload" className="inline-flex mt-6 px-4 py-2 rounded-md bg-accent text-on-accent hover:bg-accent-hover">
+            새 악보 업로드
+          </a>
+        )}
       </div>
     )
   }
 
   return (
     <div className="space-y-8">
+      {errorMessage && (
+        <p role="alert" className="rounded-md border border-state-error bg-surface px-4 py-3 text-sm text-ink">
+          {errorMessage}
+        </p>
+      )}
       {/* 카테고리 선택 UI */}
       {showCategorySelector && (
         <div className="mb-8">
@@ -135,8 +168,8 @@ export function LibrarySheetMusicList({
                 className={`
                   p-3 rounded-lg border-2 transition-colors text-left
                   ${selectedCategoryId === category.id
-                    ? 'border-blue-500 bg-blue-50 text-blue-700'
-                    : 'border-gray-200 bg-white hover:bg-gray-50'
+                    ? 'border-accent bg-surface-muted text-ink'
+                    : 'border-rule bg-surface hover:bg-surface-muted'
                   }
                 `}
               >
@@ -153,12 +186,12 @@ export function LibrarySheetMusicList({
       {/* 악보 그리드 */}
       <div>
         <div className="mb-4">
-          <h3 className="text-lg font-semibold text-gray-900">
+          <h3 className="text-lg font-semibold text-ink">
             {selectedCategoryId === null 
               ? '전체 악보' 
               : categories.find(c => c.id === selectedCategoryId)?.name || '카테고리'
             }
-            <span className="ml-2 text-sm text-gray-500">
+            <span className="ml-2 text-sm text-ink-muted">
               ({filteredAndSortedSheetMusic.length}개)
             </span>
           </h3>
@@ -172,11 +205,34 @@ export function LibrarySheetMusicList({
               categories={categories}
               onMove={handleMoveSheetMusic}
               onDelete={handleDeleteSheetMusic}
+              onEdit={openTitleEditor}
+              availability={sheet.availability}
               showMoveOptions={true}
             />
           ))}
         </div>
       </div>
+
+      {editingSheet && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" role="dialog" aria-modal="true" aria-labelledby="edit-sheet-title">
+          <form onSubmit={saveTitle} className="w-full max-w-md rounded-lg bg-surface p-6 shadow-xl">
+            <h2 id="edit-sheet-title" className="text-lg font-semibold text-ink">악보 제목 수정</h2>
+            <label className="mt-4 block text-sm font-medium text-ink" htmlFor="sheet-title">제목</label>
+            <input
+              id="sheet-title"
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              className="mt-1 w-full rounded-md border border-rule-strong bg-surface px-3 py-2 text-ink"
+              autoFocus
+              required
+            />
+            <div className="mt-6 flex justify-end gap-3">
+              <Button type="button" variant="outline" onClick={() => setEditingSheet(null)}>취소</Button>
+              <Button type="submit">저장</Button>
+            </div>
+          </form>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/library/__tests__/LibrarySheetMusicList.test.tsx
+++ b/src/components/library/__tests__/LibrarySheetMusicList.test.tsx
@@ -58,6 +58,17 @@ describe('LibrarySheetMusicList', () => {
     await waitFor(() => expect(updateSheetMusic).toHaveBeenCalledWith(1, { title: '새 제목' }))
   })
 
+  it('explains why a whitespace-only title cannot be saved', async () => {
+    render(<LibrarySheetMusicList />)
+
+    fireEvent.click(screen.getByRole('button', { name: '연습 가능 제목 수정' }))
+    fireEvent.change(screen.getByLabelText('제목'), { target: { value: '   ' } })
+    fireEvent.click(screen.getByRole('button', { name: '저장' }))
+
+    expect(await screen.findByText('제목을 입력해 주세요.')).toBeInTheDocument()
+    expect(updateSheetMusic).not.toHaveBeenCalled()
+  })
+
   it('offers an upload action for an empty library', () => {
     mockUseSheetMusic.mockReturnValue({
       ...mockUseSheetMusic(),

--- a/src/components/library/__tests__/LibrarySheetMusicList.test.tsx
+++ b/src/components/library/__tests__/LibrarySheetMusicList.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { LibrarySheetMusicList } from '../LibrarySheetMusicList'
+import { useSheetMusic } from '@/hooks/useSheetMusic'
+import { useCategories } from '@/hooks/useCategories'
+
+jest.mock('@/hooks/useSheetMusic')
+jest.mock('@/hooks/useCategories')
+
+const mockUseSheetMusic = useSheetMusic as jest.MockedFunction<typeof useSheetMusic>
+const mockUseCategories = useCategories as jest.MockedFunction<typeof useCategories>
+
+const sheets = [
+  { id: 1, title: '연습 가능', composer: '작곡가', userId: 'user-1', categoryId: null, category: null, isPublic: false, animationDataUrl: 'url', provenance: 'omr' as const, availability: 'ready' as const, createdAt: new Date(), updatedAt: new Date() },
+  { id: 2, title: '처리 중 악보', composer: '작곡가', userId: 'user-1', categoryId: null, category: null, isPublic: false, animationDataUrl: '', provenance: 'omr' as const, availability: 'processing' as const, createdAt: new Date(), updatedAt: new Date() },
+  { id: 3, title: '오류 악보', composer: '작곡가', userId: 'user-1', categoryId: null, category: null, isPublic: false, animationDataUrl: '', provenance: 'omr' as const, availability: 'failed' as const, createdAt: new Date(), updatedAt: new Date() },
+  { id: 4, title: '확인 악보', composer: '작곡가', userId: 'user-1', categoryId: null, category: null, isPublic: false, animationDataUrl: '', provenance: 'omr' as const, availability: 'unknown' as const, createdAt: new Date(), updatedAt: new Date() },
+]
+
+describe('LibrarySheetMusicList', () => {
+  const fetchUserSheetMusic = jest.fn()
+  const updateSheetMusic = jest.fn().mockResolvedValue({})
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseSheetMusic.mockReturnValue({
+      sheetMusic: sheets,
+      loading: false,
+      error: null,
+      fetchUserSheetMusic,
+      updateSheetMusic,
+      deleteSheetMusic: jest.fn(),
+      createSheetMusic: jest.fn(),
+    })
+    mockUseCategories.mockReturnValue({
+      categories: [], loading: false, error: null, fetchCategories: jest.fn(), createCategory: jest.fn(), updateCategory: jest.fn(), deleteCategory: jest.fn(),
+    })
+  })
+
+  it('distinguishes all derived availability states without exposing raw processing values', () => {
+    render(<LibrarySheetMusicList />)
+
+    expect(screen.getAllByText('연습 가능')).toHaveLength(2)
+    expect(screen.getAllByText('처리 중')).toHaveLength(2)
+    expect(screen.getByText('변환 오류')).toBeInTheDocument()
+    expect(screen.getByText('확인 필요')).toBeInTheDocument()
+    expect(screen.queryByText('pending')).not.toBeInTheDocument()
+    expect(screen.getByRole('link', { name: '연습 시작' })).toHaveAttribute('href', '/sheet/1')
+    expect(screen.getAllByRole('link', { name: '다시 업로드' })).toHaveLength(2)
+  })
+
+  it('edits a user title from the keyboard-accessible dialog', async () => {
+    render(<LibrarySheetMusicList />)
+
+    fireEvent.click(screen.getByRole('button', { name: '연습 가능 제목 수정' }))
+    fireEvent.change(screen.getByLabelText('제목'), { target: { value: '새 제목' } })
+    fireEvent.click(screen.getByRole('button', { name: '저장' }))
+
+    await waitFor(() => expect(updateSheetMusic).toHaveBeenCalledWith(1, { title: '새 제목' }))
+  })
+
+  it('offers an upload action for an empty library', () => {
+    mockUseSheetMusic.mockReturnValue({
+      ...mockUseSheetMusic(),
+      sheetMusic: [],
+    })
+
+    render(<LibrarySheetMusicList />)
+
+    expect(screen.getByText('악보가 없습니다')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: '새 악보 업로드' })).toHaveAttribute('href', '/upload')
+  })
+})

--- a/src/components/sheet/SheetMusicCard.tsx
+++ b/src/components/sheet/SheetMusicCard.tsx
@@ -7,6 +7,7 @@ import { Category } from '@/types/category'
 import Button from '@/components/ui/Button'
 import Card from '@/components/ui/Card'
 import { DeleteConfirmDialog } from '@/components/ui/ConfirmDialog'
+import type { SheetMusicAvailability } from '@/lib/sheetMusicAvailability'
 
 interface SheetMusicCardProps {
   sheetMusic: SheetMusicWithCategory
@@ -15,6 +16,7 @@ interface SheetMusicCardProps {
   onMove?: (sheetMusicId: number, newCategoryId: number | null) => void
   onEdit?: (sheetMusic: SheetMusicWithCategory) => void
   onDelete?: (sheetMusicId: number) => void
+  availability?: SheetMusicAvailability
 }
 
 export function SheetMusicCard({
@@ -23,7 +25,8 @@ export function SheetMusicCard({
   categories = [],
   onMove,
   onEdit,
-  onDelete
+  onDelete,
+  availability
 }: SheetMusicCardProps) {
   const [showMoveMenu, setShowMoveMenu] = useState(false)
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
@@ -41,33 +44,46 @@ export function SheetMusicCard({
     })
   }
 
+  const availabilityDetails = availability && {
+    ready: { label: '연습 가능', icon: '✓', className: 'bg-state-ready text-on-accent' },
+    processing: { label: '처리 중', icon: '◌', className: 'bg-state-progress text-on-accent' },
+    failed: { label: '변환 오류', icon: '!', className: 'bg-state-error text-on-accent' },
+    unknown: { label: '확인 필요', icon: '?', className: 'bg-surface-muted text-ink' },
+  }[availability]
+
   return (
     <Card className="group hover:shadow-lg transition-shadow duration-200 h-full flex flex-col">
       <div className="p-4 space-y-3 flex-1 flex flex-col">
         {/* Header with title and composer */}
         <div className="space-y-1 flex-shrink-0">
-          <h3 className="font-semibold text-lg line-clamp-2 group-hover:text-blue-600 transition-colors min-h-[3.5rem]">
+          <h3 title={sheetMusic.title} className="font-semibold text-lg text-ink line-clamp-2 group-hover:text-accent transition-colors min-h-[3.5rem]">
             {sheetMusic.title}
           </h3>
-          <p className="text-gray-600 text-sm truncate">{sheetMusic.composer}</p>
+          <p className="text-ink-muted text-sm truncate">{sheetMusic.composer}</p>
         </div>
 
         {/* Category and visibility info */}
         <div className="flex items-center gap-2 text-xs flex-shrink-0">
-          <span className="px-2 py-1 bg-gray-100 rounded-full truncate">
+            <span className="px-2 py-1 bg-surface-muted rounded-full truncate">
             📁 {sheetMusic.category?.name || '미분류'}
           </span>
           <span className={`px-2 py-1 rounded-full ${
             sheetMusic.isPublic 
-              ? 'bg-green-100 text-green-700' 
-              : 'bg-gray-100 text-gray-700'
+              ? 'bg-state-ready text-on-accent'
+              : 'bg-surface-muted text-ink'
           }`}>
             {sheetMusic.isPublic ? '🌍 공개' : '🔒 비공개'}
           </span>
+          {availabilityDetails && (
+            <span className={`inline-flex items-center gap-1 px-2 py-1 rounded-full ${availabilityDetails.className}`}>
+              <span aria-hidden="true">{availabilityDetails.icon}</span>
+              {availabilityDetails.label}
+            </span>
+          )}
         </div>
 
         {/* Date */}
-        <p className="text-xs text-gray-500 flex-shrink-0">
+        <p className="text-xs text-ink-muted flex-shrink-0">
           {formatDate(sheetMusic.createdAt)}
         </p>
 
@@ -76,11 +92,23 @@ export function SheetMusicCard({
 
         {/* Action buttons */}
         <div className="flex gap-2 pt-2 flex-shrink-0">
-          <Link href={`/sheet/${sheetMusic.id}`} className="flex-1">
-            <Button className="w-full" size="sm">
-              연주
+          {availability === 'ready' || availability === undefined ? (
+            <Link href={`/sheet/${sheetMusic.id}`} className="flex-1">
+              <Button as="span" className="w-full" size="sm">
+                연습 시작
+              </Button>
+            </Link>
+          ) : availability === 'processing' ? (
+            <Button className="flex-1" size="sm" disabled>
+              처리 중
             </Button>
-          </Link>
+          ) : (
+            <Link href="/upload" className="flex-1">
+              <Button as="span" className="w-full" size="sm">
+                다시 업로드
+              </Button>
+            </Link>
+          )}
           
           {onEdit && (
             <Button
@@ -88,6 +116,7 @@ export function SheetMusicCard({
               variant="outline"
               size="sm"
               className="min-w-[3.5rem] flex-shrink-0"
+              aria-label={`${sheetMusic.title} 제목 수정`}
             >
               수정
             </Button>
@@ -105,11 +134,11 @@ export function SheetMusicCard({
               </Button>
               
               {showMoveMenu && (
-                <div className="absolute right-0 top-full mt-1 bg-white border border-gray-200 rounded-md shadow-lg z-10 min-w-[150px]">
+                <div className="absolute right-0 top-full mt-1 bg-surface border border-rule rounded-md shadow-lg z-10 min-w-[150px]">
                   <div className="py-1">
                     <button
                       onClick={() => handleMove(null)}
-                      className="w-full text-left px-3 py-2 text-sm hover:bg-gray-100 flex items-center gap-2"
+                      className="w-full text-left px-3 py-2 text-sm text-ink hover:bg-surface-muted flex items-center gap-2"
                     >
                       📁 미분류
                     </button>
@@ -117,12 +146,12 @@ export function SheetMusicCard({
                       <button
                         key={category.id}
                         onClick={() => handleMove(category.id)}
-                        className="w-full text-left px-3 py-2 text-sm hover:bg-gray-100 flex items-center gap-2"
+                        className="w-full text-left px-3 py-2 text-sm text-ink hover:bg-surface-muted flex items-center gap-2"
                         disabled={sheetMusic.categoryId === category.id}
                       >
                         📁 {category.name}
                         {sheetMusic.categoryId === category.id && (
-                          <span className="text-xs text-gray-500">(현재)</span>
+                          <span className="text-xs text-ink-muted">(현재)</span>
                         )}
                       </button>
                     ))}
@@ -137,7 +166,7 @@ export function SheetMusicCard({
               onClick={() => setShowDeleteDialog(true)}
               variant="outline"
               size="sm"
-              className="text-red-600 hover:text-red-700 hover:border-red-300 min-w-[3.5rem] flex-shrink-0"
+              className="text-state-error hover:border-state-error min-w-[3.5rem] flex-shrink-0"
             >
               삭제
             </Button>

--- a/src/components/sheet/SheetMusicCard.tsx
+++ b/src/components/sheet/SheetMusicCard.tsx
@@ -9,7 +9,7 @@ import Card from '@/components/ui/Card'
 import { DeleteConfirmDialog } from '@/components/ui/ConfirmDialog'
 import type { SheetMusicAvailability } from '@/lib/sheetMusicAvailability'
 
-interface SheetMusicCardProps {
+export interface SheetMusicCardProps {
   sheetMusic: SheetMusicWithCategory
   showMoveOptions?: boolean
   categories?: Category[]

--- a/src/lib/__tests__/sheetMusicAvailability.test.ts
+++ b/src/lib/__tests__/sheetMusicAvailability.test.ts
@@ -1,0 +1,13 @@
+import { deriveSheetMusicAvailability } from '../sheetMusicAvailability'
+
+describe('deriveSheetMusicAvailability', () => {
+  it.each([
+    ['stored animation data', 'https://storage.example/song.json', 'pending', 'ready'],
+    ['active conversion', '', 'processing', 'processing'],
+    ['failed conversion', '', 'failed', 'failed'],
+    ['legacy pending row', '', 'pending', 'unknown'],
+    ['unrecognized source status', '', 'something-new', 'unknown'],
+  ])('returns %s as %s', (_description, animationDataUrl, processingStatus, expected) => {
+    expect(deriveSheetMusicAvailability({ animationDataUrl, processingStatus })).toBe(expected)
+  })
+})

--- a/src/lib/sheetMusicAvailability.ts
+++ b/src/lib/sheetMusicAvailability.ts
@@ -1,0 +1,18 @@
+export type SheetMusicAvailability = 'ready' | 'processing' | 'failed' | 'unknown'
+
+/**
+ * Converts persisted processing details into the only status a library client may read.
+ * Stored animation data is authoritative because legacy rows may retain `pending`.
+ */
+export function deriveSheetMusicAvailability({
+  animationDataUrl,
+  processingStatus,
+}: {
+  animationDataUrl: string
+  processingStatus: string
+}): SheetMusicAvailability {
+  if (animationDataUrl !== '') return 'ready'
+  if (processingStatus === 'processing') return 'processing'
+  if (processingStatus === 'failed') return 'failed'
+  return 'unknown'
+}

--- a/src/types/sheet-music.ts
+++ b/src/types/sheet-music.ts
@@ -1,4 +1,5 @@
 import type { SheetMusicProvenance } from '@prisma/client'
+import type { SheetMusicAvailability } from '@/lib/sheetMusicAvailability'
 
 export interface SheetMusic {
   id: number
@@ -8,6 +9,8 @@ export interface SheetMusic {
   categoryId: number | null
   isPublic: boolean
   animationDataUrl: string
+  /** API-derived status for client display; persistence code must not supply it. */
+  availability?: SheetMusicAvailability
   provenance: SheetMusicProvenance
   createdAt: Date
   updatedAt: Date


### PR DESCRIPTION
## 목적
내 악보가 원시 처리 상태를 해석하지 않고, 연습 가능·처리 중·변환 오류·확인 필요의 파생 상태로 현재 행동을 안내합니다.

## 범위
- 목록과 상세 API의 availability 파생 상태 계약
- 상태 배지·연습/재업로드 행동·제목 편집·빈 상태 업로드 CTA
- 라이브러리 삭제 오류의 앱 내 알림

## 제외 범위
- 실제 재생 위치 저장/이어하기: PracticeSession에 위치 필드·복원 경로가 없어 UI를 만들지 않았습니다.
- 업로드 화면의 상세 처리 단계와 OMR 서비스 변경

## 위험 및 롤백
클라이언트 API 응답에 새 파생 필드가 더해집니다. 롤백은 해당 응답 필드와 라이브러리 소비를 함께 되돌리면 됩니다.

## 검증
- npm run lint
- npx tsc --noEmit
- npm test -- --runInBand — 75 suites / 759 tests
- Chromium·Mobile Chrome E2E 10/10
- npm run build

Firefox·WebKit E2E는 이 로컬 환경에 실행 파일이 없어 시작하지 못했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 악보의 준비 완료, 처리 중, 변환 실패, 확인 필요 상태를 라이브러리에서 확인할 수 있습니다.
  - 상태에 따라 연습 시작, 처리 중, 재업로드 안내가 표시됩니다.
  - 라이브러리에서 악보 제목을 직접 수정할 수 있습니다.
  - 삭제 실패 시 확인 가능한 오류 메시지가 표시됩니다.
  - 악보가 없을 때 새 악보 업로드 링크가 제공됩니다.

- **개선**
  - 라이브러리와 악보 카드의 색상 및 상태 표시가 테마에 맞게 개선되었습니다.
  - 내부 처리 정보가 API 응답에 노출되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->