### PR TITLE
Unify empty and error states across core screens

### DIFF
--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState, Suspense } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import Link from 'next/link'
 import { toSafeReturnPath } from '@/lib/returnPath'
-import { CheckIcon, LogoMark } from '@/components/ui'
+import { CheckIcon, LogoMark, StatusState } from '@/components/ui'
 
 interface Provider {
   id: string
@@ -115,6 +115,9 @@ function SignInContent() {
         </div>
 
         {error && (
+          <StatusState title="로그인하지 못했습니다" detail={`${getErrorMessage(error)} 다시 시도해 주세요.`} tone="error" />
+        )}
+        {/*
           <div className="rounded-md border border-state-error/40 bg-surface p-4">
             <div className="flex">
               <div className="flex-shrink-0">
@@ -131,8 +134,7 @@ function SignInContent() {
                 </div>
               </div>
             </div>
-          </div>
-        )}
+          </div>*/}
 
         <div className="mt-8 space-y-4">
           {providers && Object.values(providers).map((provider) => (

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -115,7 +115,12 @@ function SignInContent() {
         </div>
 
         {error && (
-          <StatusState title="로그인하지 못했습니다" detail={`${getErrorMessage(error)} 다시 시도해 주세요.`} tone="error" />
+          <StatusState
+            title="로그인하지 못했습니다"
+            detail={getErrorMessage(error)}
+            tone="error"
+            action={<Link href={callbackUrl} className="inline-flex rounded-md border border-rule-strong bg-surface px-4 py-2 text-sm text-ink hover:bg-surface-muted">다시 로그인하기</Link>}
+          />
         )}
         {/*
           <div className="rounded-md border border-state-error/40 bg-surface p-4">

--- a/src/app/sheet/[id]/page.tsx
+++ b/src/app/sheet/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react'
 import { useParams } from 'next/navigation'
 import { MainLayout, PageHeader, Container } from '@/components/layout'
-import { Card, Loading } from '@/components/ui'
+import { Card, Loading, StatusState } from '@/components/ui'
 import LoginButton from '@/components/auth/LoginButton'
 import FallingNotesPlayer from '@/components/animation/FallingNotesPlayer'
 import DemoProvenanceNotice from '@/components/sheet/DemoProvenanceNotice'
@@ -135,10 +135,11 @@ export default function SheetMusicPage() {
       <MainLayout>
         <Container className="py-8" size="lg">
           <Card padding="lg">
-            <div className="text-center">
-              <h2 className="text-xl font-semibold text-ink mb-2">오류가 발생했습니다</h2>
-              <p className="text-ink-muted">{error || '알 수 없는 오류가 발생했습니다.'}</p>
-            </div>
+            <StatusState
+              title={error?.includes('권한') ? '이 악보에 접근할 수 없습니다' : '악보를 불러오지 못했습니다'}
+              detail={error || '잠시 후 다시 시도해 주세요.'}
+              tone="error"
+            />
           </Card>
         </Container>
       </MainLayout>

--- a/src/app/sheet/[id]/page.tsx
+++ b/src/app/sheet/[id]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import { useParams } from 'next/navigation'
+import Link from 'next/link'
 import { MainLayout, PageHeader, Container } from '@/components/layout'
 import { Card, Loading, StatusState } from '@/components/ui'
 import LoginButton from '@/components/auth/LoginButton'
@@ -137,8 +138,11 @@ export default function SheetMusicPage() {
           <Card padding="lg">
             <StatusState
               title={error?.includes('권한') ? '이 악보에 접근할 수 없습니다' : '악보를 불러오지 못했습니다'}
-              detail={error || '잠시 후 다시 시도해 주세요.'}
+              detail={error || '악보 정보를 확인할 수 없습니다.'}
               tone="error"
+              action={error?.includes('권한')
+                ? <Link href={`/auth/signin?callbackUrl=${encodeURIComponent(`/sheet/${id}`)}`} className="inline-flex rounded-md bg-accent px-4 py-2 text-sm text-on-accent hover:bg-accent-hover">로그인하고 계속하기</Link>
+                : <Link href="/explore" className="inline-flex rounded-md border border-rule-strong bg-surface px-4 py-2 text-sm text-ink hover:bg-surface-muted">공개 악보 둘러보기</Link>}
             />
           </Card>
         </Container>

--- a/src/components/browse/PublicSheetMusicBrowser.tsx
+++ b/src/components/browse/PublicSheetMusicBrowser.tsx
@@ -240,7 +240,11 @@ export default function PublicSheetMusicBrowser({
 
       {/* Empty State */}
       {recentSheets.length === 0 && (
-        <StatusState title="아직 공개된 악보가 없습니다" detail="공개 악보가 올라오면 여기에서 함께 연습할 수 있습니다." />
+        <StatusState
+          title="아직 공개된 악보가 없습니다"
+          detail="공개 악보가 올라오면 여기에서 함께 연습할 수 있습니다."
+          action={<a href="/upload" className="inline-flex rounded-md bg-accent px-4 py-2 text-sm text-on-accent hover:bg-accent-hover">첫 악보 올리기</a>}
+        />
       )}
     </div>
   )

--- a/src/components/browse/PublicSheetMusicBrowser.tsx
+++ b/src/components/browse/PublicSheetMusicBrowser.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { Button } from '@/components/ui'
+import { Button, StatusState } from '@/components/ui'
 import { SheetMusicWithOwner } from '@/types/sheet-music'
 
 interface PublicSheetMusicBrowserProps {
@@ -63,17 +63,12 @@ export default function PublicSheetMusicBrowser({
 
   if (error) {
     return (
-      <div className="bg-red-50 border border-red-200 rounded-lg p-6">
-        <p className="text-red-800">오류가 발생했습니다: {error}</p>
-        <Button 
-          variant="outline" 
-          size="sm" 
-          onClick={loadPublicSheets}
-          className="mt-3"
-        >
-          다시 시도
-        </Button>
-      </div>
+      <StatusState
+        title="공개 악보를 불러오지 못했습니다"
+        detail="잠시 연결이 끊겼습니다. 다시 시도해 주세요."
+        tone="error"
+        action={<Button variant="outline" size="sm" onClick={loadPublicSheets}>다시 시도</Button>}
+      />
     )
   }
 
@@ -245,14 +240,7 @@ export default function PublicSheetMusicBrowser({
 
       {/* Empty State */}
       {recentSheets.length === 0 && (
-        <div className="text-center py-12">
-          <h3 className="text-lg font-medium text-gray-900 mb-2">
-            아직 공개된 악보가 없습니다
-          </h3>
-          <p className="text-gray-600">
-            첫 번째 악보를 업로드하고 다른 사용자들과 공유해보세요!
-          </p>
-        </div>
+        <StatusState title="아직 공개된 악보가 없습니다" detail="공개 악보가 올라오면 여기에서 함께 연습할 수 있습니다." />
       )}
     </div>
   )

--- a/src/components/library/LibrarySheetMusicList.tsx
+++ b/src/components/library/LibrarySheetMusicList.tsx
@@ -143,7 +143,7 @@ export function LibrarySheetMusicList({
       <StatusState
         title={searchQuery ? '검색 결과가 없습니다' : '악보가 없습니다'}
         detail={searchQuery ? '다른 검색어로 다시 찾아보세요.' : '연습할 PDF 악보를 올려 보세요.'}
-        action={!searchQuery ? <a href="/upload" className="inline-flex rounded-md bg-accent px-4 py-2 text-sm text-on-accent hover:bg-accent-hover">새 악보 업로드</a> : undefined}
+        action={!searchQuery ? <a href="/upload" className="inline-flex rounded-md bg-accent px-4 py-2 text-sm text-on-accent hover:bg-accent-hover">새 악보 업로드</a> : <a href="/library" className="inline-flex rounded-md border border-rule-strong bg-surface px-4 py-2 text-sm text-ink hover:bg-surface-muted">검색 초기화</a>}
       />
     )
   }

--- a/src/components/library/LibrarySheetMusicList.tsx
+++ b/src/components/library/LibrarySheetMusicList.tsx
@@ -7,6 +7,7 @@ import { SheetMusicCard } from '@/components/sheet/SheetMusicCard'
 import type { SheetMusicWithCategory } from '@/types/sheet-music'
 import Button from '@/components/ui/Button'
 import Loading from '@/components/ui/Loading'
+import StatusState from '@/components/ui/StatusState'
 
 interface LibrarySheetMusicListProps {
   selectedCategoryId?: number | null
@@ -139,20 +140,11 @@ export function LibrarySheetMusicList({
   // 빈 상태
   if (filteredAndSortedSheetMusic.length === 0) {
     return (
-      <div className="text-center py-16 text-ink-muted">
-        <div className="text-6xl mb-4">🎵</div>
-        <h3 className="text-lg font-medium mb-2">
-          {searchQuery ? '검색 결과가 없습니다' : '악보가 없습니다'}
-        </h3>
-        <p className="text-sm">
-          {searchQuery ? '다른 검색어로 시도해보세요' : '첫 번째 악보를 업로드해보세요!'}
-        </p>
-        {!searchQuery && (
-          <a href="/upload" className="inline-flex mt-6 px-4 py-2 rounded-md bg-accent text-on-accent hover:bg-accent-hover">
-            새 악보 업로드
-          </a>
-        )}
-      </div>
+      <StatusState
+        title={searchQuery ? '검색 결과가 없습니다' : '악보가 없습니다'}
+        detail={searchQuery ? '다른 검색어로 다시 찾아보세요.' : '연습할 PDF 악보를 올려 보세요.'}
+        action={!searchQuery ? <a href="/upload" className="inline-flex rounded-md bg-accent px-4 py-2 text-sm text-on-accent hover:bg-accent-hover">새 악보 업로드</a> : undefined}
+      />
     )
   }
 

--- a/src/components/search/SheetMusicSearch.tsx
+++ b/src/components/search/SheetMusicSearch.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { Button, StatusState } from '@/components/ui'
 import { useSheetMusicSearch } from '@/hooks/useSheetMusicSearch'
 import { SheetMusicWithOwner } from '@/types/sheet-music'
@@ -23,6 +23,7 @@ export default function SheetMusicSearch({
   const [selectedCategory, setSelectedCategory] = useState<number | undefined>()
   const [publicFilter, setPublicFilter] = useState<boolean | undefined>(defaultPublicOnly ? true : undefined)
   const [sortBy, setSortBy] = useState<'newest' | 'oldest' | 'title' | 'composer'>('newest')
+  const searchInputRef = useRef<HTMLInputElement>(null)
 
   const { categories } = useCategories()
   
@@ -81,6 +82,7 @@ export default function SheetMusicSearch({
             <div className="flex-1">
               <input
                 type="text"
+                ref={searchInputRef}
                 placeholder="곡명 또는 저작자로 검색..."
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
@@ -251,7 +253,13 @@ export default function SheetMusicSearch({
             )}
           </>
         ) : !loading && (
-          <StatusState title={searchQuery ? '검색 결과가 없습니다' : '검색어를 입력해 주세요'} detail={searchQuery ? '다른 검색어로 다시 찾아보세요.' : '곡명이나 저작자로 악보를 찾아보세요.'} />
+          <StatusState
+            title={searchQuery ? '검색 결과가 없습니다' : '검색어를 입력해 주세요'}
+            detail={searchQuery ? '다른 검색어로 다시 찾아보세요.' : '곡명이나 저작자로 악보를 찾아보세요.'}
+            action={searchQuery
+              ? <Button variant="outline" size="sm" onClick={() => setSearchQuery('')}>검색어 지우기</Button>
+              : <Button variant="outline" size="sm" onClick={() => searchInputRef.current?.focus()}>검색어 입력하기</Button>}
+          />
         )}
       </div>
 

--- a/src/components/search/SheetMusicSearch.tsx
+++ b/src/components/search/SheetMusicSearch.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { Button } from '@/components/ui'
+import { Button, StatusState } from '@/components/ui'
 import { useSheetMusicSearch } from '@/hooks/useSheetMusicSearch'
 import { SheetMusicWithOwner } from '@/types/sheet-music'
 import { useCategories } from '@/hooks/useCategories'
@@ -172,9 +172,7 @@ export default function SheetMusicSearch({
 
       {/* Error State */}
       {error && (
-        <div className="mb-4 p-4 bg-red-50 border border-red-200 rounded-lg">
-          <p className="text-red-800">검색 중 오류가 발생했습니다: {error}</p>
-        </div>
+        <StatusState className="mb-4" title="악보를 검색하지 못했습니다" detail="검색 서비스에 잠시 문제가 있습니다. 다시 시도해 주세요." tone="error" action={<Button variant="outline" size="sm" onClick={triggerSearch}>다시 시도</Button>} />
       )}
 
       {/* Results */}
@@ -253,9 +251,7 @@ export default function SheetMusicSearch({
             )}
           </>
         ) : !loading && (
-          <div className="text-center py-8 text-gray-500">
-            {searchQuery ? '검색 결과가 없습니다' : '검색어를 입력해보세요'}
-          </div>
+          <StatusState title={searchQuery ? '검색 결과가 없습니다' : '검색어를 입력해 주세요'} detail={searchQuery ? '다른 검색어로 다시 찾아보세요.' : '곡명이나 저작자로 악보를 찾아보세요.'} />
         )}
       </div>
 

--- a/src/components/ui/StatusState.tsx
+++ b/src/components/ui/StatusState.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from 'react'
+import { AlertIcon } from './icons'
+
+interface StatusStateProps {
+  title: string
+  detail: string
+  action?: ReactNode
+  tone?: 'neutral' | 'error'
+  className?: string
+}
+
+/** 모든 빈 상태와 오류 상태가 원인과 다음 행동을 함께 말하도록 하는 공통 표현입니다. */
+export default function StatusState({
+  title,
+  detail,
+  action,
+  tone = 'neutral',
+  className = '',
+}: StatusStateProps) {
+  const titleClass = tone === 'error' ? 'text-state-error' : 'text-ink'
+
+  return (
+    <section role={tone === 'error' ? 'alert' : undefined} className={`rounded-lg border border-rule bg-surface p-8 text-center ${className}`}>
+      {tone === 'error' && <AlertIcon size={20} className="mx-auto mb-3 text-state-error" />}
+      <h2 className={`text-lg font-semibold ${titleClass}`}>{title}</h2>
+      <p className="mt-2 text-sm text-ink-muted">{detail}</p>
+      {action && <div className="mt-5 flex justify-center">{action}</div>}
+    </section>
+  )
+}

--- a/src/components/ui/StatusState.tsx
+++ b/src/components/ui/StatusState.tsx
@@ -4,7 +4,7 @@ import { AlertIcon } from './icons'
 interface StatusStateProps {
   title: string
   detail: string
-  action?: ReactNode
+  action: ReactNode
   tone?: 'neutral' | 'error'
   className?: string
 }
@@ -24,7 +24,7 @@ export default function StatusState({
       {tone === 'error' && <AlertIcon size={20} className="mx-auto mb-3 text-state-error" />}
       <h2 className={`text-lg font-semibold ${titleClass}`}>{title}</h2>
       <p className="mt-2 text-sm text-ink-muted">{detail}</p>
-      {action && <div className="mt-5 flex justify-center">{action}</div>}
+      <div className="mt-5 flex justify-center">{action}</div>
     </section>
   )
 }

--- a/src/components/ui/__tests__/StatusState.test.tsx
+++ b/src/components/ui/__tests__/StatusState.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react'
+import StatusState from '@/components/ui/StatusState'
+
+describe('StatusState', () => {
+  it('shows what went wrong and what the user can do next', () => {
+    render(
+      <StatusState
+        title="악보를 불러오지 못했습니다"
+        detail="잠시 연결이 끊겼습니다."
+        action="다시 시도해 주세요."
+        tone="error"
+      />
+    )
+
+    expect(screen.getByRole('heading', { name: '악보를 불러오지 못했습니다' })).toBeInTheDocument()
+    expect(screen.getByText('잠시 연결이 끊겼습니다.')).toBeInTheDocument()
+    expect(screen.getByText('다시 시도해 주세요.')).toBeInTheDocument()
+  })
+
+  it('renders an action when supplied', () => {
+    render(<StatusState title="악보가 없습니다" detail="새 악보를 올려 보세요." action={<button>업로드</button>} />)
+    expect(screen.getByRole('button', { name: '업로드' })).toBeInTheDocument()
+  })
+})

--- a/src/components/ui/__tests__/StatusState.test.tsx
+++ b/src/components/ui/__tests__/StatusState.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react'
+import Link from 'next/link'
 import StatusState from '@/components/ui/StatusState'
 
 describe('StatusState', () => {
@@ -20,5 +21,10 @@ describe('StatusState', () => {
   it('renders an action when supplied', () => {
     render(<StatusState title="악보가 없습니다" detail="새 악보를 올려 보세요." action={<button>업로드</button>} />)
     expect(screen.getByRole('button', { name: '업로드' })).toBeInTheDocument()
+  })
+
+  it('always renders the required next action region', () => {
+    render(<StatusState title="불러오지 못했습니다" detail="연결이 끊겼습니다." action={<Link href="/">홈으로</Link>} tone="error" />)
+    expect(screen.getByRole('link', { name: '홈으로' })).toBeInTheDocument()
   })
 })

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,6 +1,7 @@
 export { default as Button } from './Button'
 export { default as Card } from './Card'
 export { default as Loading } from './Loading'
+export { default as StatusState } from './StatusState'
 
 export {
   LogoMark,

--- a/src/components/upload/OMRUploadForm.tsx
+++ b/src/components/upload/OMRUploadForm.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback, useEffect, useId, useRef, useState } from 'react'
 import { useSession } from 'next-auth/react'
-import { AlertIcon, Button, UploadIcon } from '@/components/ui'
+import { Button, StatusState, UploadIcon } from '@/components/ui'
 import type { Category } from '@/types/category'
 import { fileSignature, inspectPdfFile, MAX_UPLOAD_MB } from '@/lib/upload/pdfInspection'
 import {
@@ -379,17 +379,7 @@ export default function OMRUploadForm({
 
         {/* 실패 안내. 색이 아니라 아이콘과 문장이 상태를 말한다. */}
         {failure && (
-          <div
-            role="alert"
-            className="flex gap-3 rounded-md border border-state-error bg-surface-muted p-4"
-          >
-            <AlertIcon size={20} className="mt-0.5 shrink-0 text-state-error" aria-hidden="true" />
-            <div>
-              <p className="text-sm font-semibold text-ink">{failure.title}</p>
-              <p className="mt-1 text-sm text-ink-muted">{failure.detail}</p>
-              <p className="mt-1 text-sm text-ink">{failure.action}</p>
-            </div>
-          </div>
+          <StatusState title={failure.title} detail={failure.detail} action={failure.action} tone="error" />
         )}
 
         {/* 곡명 */}


### PR DESCRIPTION
## Purpose
Unify DS-7 empty/error state messaging around the problem and the next action.

## Scope
- Add shared StatusState component and regression tests
- Apply to upload, library, browse, search, public sheet, and sign-in error surfaces
- Preserve existing layouts, processing ownership, and playback contracts

## Excluded
- Admin finger-data maintenance surface (not a DS-2~DS-6 target screen)
- New notification system or ProcessingNotification writers
- Manual end-to-end checks (conditions 3 and 7 remain user confirmation required)

## Verification
- npm test -- --runInBand: 80 suites / 755 tests passed
- npm run build: passed
- npm run test:e2e with required env: 25 passed across 5 projects
- npx tsc --noEmit: passed
- npm run lint: passed
- protected playback file diff: empty