### PR TITLE
Unify pill-shaped controls and metadata labels

### DIFF
--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState, Suspense } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import Link from 'next/link'
 import { toSafeReturnPath } from '@/lib/returnPath'
-import { CheckIcon, LogoMark, StatusState } from '@/components/ui'
+import { Button, CheckIcon, LogoMark, StatusState } from '@/components/ui'
 
 interface Provider {
   id: string
@@ -119,7 +119,7 @@ function SignInContent() {
             title="로그인하지 못했습니다"
             detail={getErrorMessage(error)}
             tone="error"
-            action={<Link href={callbackUrl} className="inline-flex rounded-md border border-rule-strong bg-surface px-4 py-2 text-sm text-ink hover:bg-surface-muted">다시 로그인하기</Link>}
+            action={<Link href={callbackUrl}><Button as="span" variant="outline">다시 로그인하기</Button></Link>}
           />
         )}
         {/*
@@ -144,12 +144,14 @@ function SignInContent() {
         <div className="mt-8 space-y-4">
           {providers && Object.values(providers).map((provider) => (
             <div key={provider.name}>
-              <button
+              <Button
                 onClick={() => handleSignIn(provider.id)}
-                className="w-full flex justify-center py-3 px-4 border border-rule-strong text-sm font-medium rounded-md text-ink bg-surface hover:bg-surface-muted transition-colors"
+                variant="outline"
+                size="lg"
+                className="w-full"
               >
                 {provider.name}로 계속하기
-              </button>
+              </Button>
             </div>
           ))}
         </div>

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -6,6 +6,7 @@ import { MainLayout, PageHeader, Container } from '@/components/layout'
 import { SheetMusicSearch } from '@/components/search'
 import { PublicSheetMusicBrowser } from '@/components/browse'
 import { SheetMusicWithOwner } from '@/types/sheet-music'
+import { Button } from '@/components/ui'
 
 export default function ExplorePage() {
   const [activeTab, setActiveTab] = useState<'browse' | 'search'>('browse')
@@ -30,21 +31,17 @@ export default function ExplorePage() {
       
       <Container className="py-8">
         {/* Tab Navigation */}
-        <div className="flex space-x-1 mb-8 p-1 bg-gray-100 rounded-lg max-w-md mx-auto">
+        <div className="flex space-x-1 mb-8 p-1 bg-surface-muted rounded-full max-w-md mx-auto">
           {tabs.map((tab) => (
-            <button
+            <Button
               key={tab.id}
               onClick={() => setActiveTab(tab.id)}
-              className={`
-                flex-1 flex items-center justify-center space-x-2 py-2 px-4 rounded-md text-sm font-medium transition-colors
-                ${activeTab === tab.id
-                  ? 'bg-white text-blue-600 shadow-sm'
-                  : 'text-gray-600 hover:text-gray-900'
-                }
-              `}
+              variant={activeTab === tab.id ? 'outline' : 'ghost'}
+              size="sm"
+              className="flex-1"
             >
               <span>{tab.label}</span>
-            </button>
+            </Button>
           ))}
         </div>
 
@@ -87,13 +84,13 @@ export default function ExplorePage() {
         {/* Quick Actions */}
         <div className="fixed bottom-6 right-6">
           <div className="flex flex-col space-y-2">
-            <button
+            <Button
               onClick={() => router.push('/upload')}
-              className="w-14 h-14 bg-blue-600 hover:bg-blue-700 text-white rounded-full shadow-lg flex items-center justify-center transition-colors"
+              className="h-14 w-14 p-0 text-xl shadow-lg"
               title="악보 업로드"
             >
-              <span className="text-xl">+</span>
-            </button>
+              +
+            </Button>
           </div>
         </div>
       </Container>

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import { MainLayout, PageHeader, Container } from '@/components/layout'
 import AuthGuard from '@/components/auth/AuthGuard'
 import { LibrarySheetMusicList } from '@/components/library/LibrarySheetMusicList'
+import { Button } from '@/components/ui'
 
 export default function LibraryPage() {
   const router = useRouter()
@@ -44,9 +45,9 @@ export default function LibraryPage() {
         
         <Container className="py-8" size="full">
           {/* Tab Navigation */}
-          <div className="flex space-x-1 mb-8 p-1 tab-navigation rounded-lg max-w-md">
+          <div className="flex space-x-1 mb-8 p-1 tab-navigation rounded-full max-w-md">
             {tabs.map((tab) => (
-              <button
+              <Button
                 key={tab.id}
                 onClick={() => {
                   setActiveTab(tab.id)
@@ -54,17 +55,13 @@ export default function LibraryPage() {
                     setSelectedCategoryId(null)
                   }
                 }}
-                className={`
-                  flex-1 flex items-center justify-center space-x-2 py-2 px-4 rounded-md text-sm font-medium transition-colors
-                  ${activeTab === tab.id
-                    ? 'bg-surface text-accent shadow-sm'
-                    : 'text-ink-muted hover:text-ink'
-                  }
-                `}
+                variant={activeTab === tab.id ? 'outline' : 'ghost'}
+                size="sm"
+                className="flex-1"
               >
                 <span>{tab.icon}</span>
                 <span>{tab.label}</span>
-              </button>
+              </Button>
             ))}
           </div>
 
@@ -116,14 +113,14 @@ export default function LibraryPage() {
 
           {/* Floating Action Button */}
           <div className="fixed bottom-6 right-6 z-10">
-            <button
+            <Button
               onClick={() => router.push('/upload')}
-              className="w-14 h-14 fab-button text-on-accent rounded-full flex items-center justify-center"
+              className="h-14 w-14 p-0 text-xl fab-button"
               title="새 악보 업로드"
               aria-label="새 악보 업로드"
             >
-              <span className="text-xl">+</span>
-            </button>
+              +
+            </Button>
           </div>
         </Container>
       </MainLayout>

--- a/src/app/sheet/[id]/page.tsx
+++ b/src/app/sheet/[id]/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react'
 import { useParams } from 'next/navigation'
 import Link from 'next/link'
 import { MainLayout, PageHeader, Container } from '@/components/layout'
-import { Card, Loading, StatusState } from '@/components/ui'
+import { Button, Card, Loading, StatusState } from '@/components/ui'
 import LoginButton from '@/components/auth/LoginButton'
 import FallingNotesPlayer from '@/components/animation/FallingNotesPlayer'
 import DemoProvenanceNotice from '@/components/sheet/DemoProvenanceNotice'
@@ -141,8 +141,8 @@ export default function SheetMusicPage() {
               detail={error || '악보 정보를 확인할 수 없습니다.'}
               tone="error"
               action={error?.includes('권한')
-                ? <Link href={`/auth/signin?callbackUrl=${encodeURIComponent(`/sheet/${id}`)}`} className="inline-flex rounded-md bg-accent px-4 py-2 text-sm text-on-accent hover:bg-accent-hover">로그인하고 계속하기</Link>
-                : <Link href="/explore" className="inline-flex rounded-md border border-rule-strong bg-surface px-4 py-2 text-sm text-ink hover:bg-surface-muted">공개 악보 둘러보기</Link>}
+                ? <Link href={`/auth/signin?callbackUrl=${encodeURIComponent(`/sheet/${id}`)}`}><Button as="span">로그인하고 계속하기</Button></Link>
+                : <Link href="/explore"><Button as="span" variant="outline">공개 악보 둘러보기</Button></Link>}
             />
           </Card>
         </Container>

--- a/src/components/auth/LoginButton.tsx
+++ b/src/components/auth/LoginButton.tsx
@@ -20,7 +20,7 @@ export interface LoginButtonProps {
  * 세션으로 이미 정하고 있으므로 여기서 이동시킬 이유가 없다.
  */
 export default function LoginButton({
-  className = 'bg-accent text-on-accent px-4 py-2 rounded-md text-sm hover:bg-accent-hover transition-colors',
+  className = 'bg-accent text-on-accent px-4 py-2 rounded-full text-sm hover:bg-accent-hover transition-colors',
   children = '로그인',
   callbackUrl,
 }: LoginButtonProps) {

--- a/src/components/browse/PublicSheetMusicBrowser.tsx
+++ b/src/components/browse/PublicSheetMusicBrowser.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { Button, StatusState } from '@/components/ui'
+import { Badge, Button, StatusState } from '@/components/ui'
 import { SheetMusicWithOwner } from '@/types/sheet-music'
 
 interface PublicSheetMusicBrowserProps {
@@ -118,9 +118,9 @@ export default function PublicSheetMusicBrowser({
                   
                   {sheetMusic.category && (
                     <div className="mt-2">
-                      <span className="inline-block px-2 py-1 bg-blue-100 text-blue-800 text-xs rounded">
+                      <Badge tone="info">
                         {sheetMusic.category.name}
-                      </span>
+                      </Badge>
                     </div>
                   )}
                 </div>
@@ -227,9 +227,9 @@ export default function PublicSheetMusicBrowser({
                 
                 <div className="mt-3 text-center">
                   {sheetMusic.category && (
-                    <span className="inline-block px-2 py-1 bg-gray-100 text-gray-700 text-xs rounded">
+                    <Badge>
                       {sheetMusic.category.name}
-                    </span>
+                    </Badge>
                   )}
                 </div>
               </div>
@@ -243,7 +243,7 @@ export default function PublicSheetMusicBrowser({
         <StatusState
           title="아직 공개된 악보가 없습니다"
           detail="공개 악보가 올라오면 여기에서 함께 연습할 수 있습니다."
-          action={<a href="/upload" className="inline-flex rounded-md bg-accent px-4 py-2 text-sm text-on-accent hover:bg-accent-hover">첫 악보 올리기</a>}
+          action={<a href="/upload"><Button>첫 악보 올리기</Button></a>}
         />
       )}
     </div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -105,7 +105,7 @@ export default function Header() {
               ) : session ? (
                 <UserProfile showDropdown={false} />
               ) : (
-                <LoginButton className="w-full bg-accent text-on-accent px-4 py-2 rounded-md text-sm hover:bg-accent-hover transition-colors" />
+                <LoginButton className="w-full bg-accent text-on-accent px-4 py-2 rounded-full text-sm hover:bg-accent-hover transition-colors" />
               )}
             </div>
           </div>

--- a/src/components/library/LibrarySheetMusicList.tsx
+++ b/src/components/library/LibrarySheetMusicList.tsx
@@ -143,7 +143,9 @@ export function LibrarySheetMusicList({
       <StatusState
         title={searchQuery ? '검색 결과가 없습니다' : '악보가 없습니다'}
         detail={searchQuery ? '다른 검색어로 다시 찾아보세요.' : '연습할 PDF 악보를 올려 보세요.'}
-        action={!searchQuery ? <a href="/upload" className="inline-flex rounded-md bg-accent px-4 py-2 text-sm text-on-accent hover:bg-accent-hover">새 악보 업로드</a> : <a href="/library" className="inline-flex rounded-md border border-rule-strong bg-surface px-4 py-2 text-sm text-ink hover:bg-surface-muted">검색 초기화</a>}
+        action={!searchQuery
+          ? <a href="/upload"><Button as="span">새 악보 업로드</Button></a>
+          : <a href="/library"><Button as="span" variant="outline">검색 초기화</Button></a>}
       />
     )
   }
@@ -151,7 +153,7 @@ export function LibrarySheetMusicList({
   return (
     <div className="space-y-8">
       {errorMessage && (
-        <p role="alert" className="rounded-md border border-state-error bg-surface px-4 py-3 text-sm text-ink">
+        <p role="alert" className="rounded-lg border border-state-error bg-surface px-4 py-3 text-sm text-ink">
           {errorMessage}
         </p>
       )}

--- a/src/components/playback/CompactPlaybackBar.tsx
+++ b/src/components/playback/CompactPlaybackBar.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { Button } from '@/components/ui'
+
 /**
  * One-row transport for a screen that is being watched rather than set up.
  *
@@ -101,31 +103,35 @@ export default function CompactPlaybackBar({
       data-testid="compact-playback-bar"
       className={`flex items-center gap-3 h-14 px-1 ${className}`}
     >
-      <button
+      <Button
         type="button"
         onClick={onPause}
         disabled={!isReady}
         aria-label="일시정지"
-        className="h-10 w-10 shrink-0 rounded-md border border-gray-300 bg-white text-lg leading-none hover:border-gray-400 disabled:opacity-50"
+        variant="outline"
+        size="md"
+        className="h-10 w-10 shrink-0 p-0 text-lg leading-none"
       >
         ⏸️
-      </button>
+      </Button>
       {onLoopStart && onLoopEnd && onLoopClear && (
         <div className="flex shrink-0 gap-1" data-testid="compact-loop-controls">
-          <button type="button" onClick={onLoopStart} disabled={!isReady} className="h-10 w-8 rounded-md border border-gray-300 bg-white text-xs">A</button>
-          <button type="button" onClick={onLoopEnd} disabled={!isReady || loopStart === null} className="h-10 w-8 rounded-md border border-gray-300 bg-white text-xs">B</button>
-          <button type="button" onClick={onLoopClear} disabled={!isReady || loopStart === null} aria-label="루프 초기화" className={`h-10 w-8 rounded-md border text-xs ${loopEnd !== null ? 'border-accent bg-accent text-white' : 'border-gray-300 bg-white'}`}>↻</button>
+          <Button type="button" onClick={onLoopStart} disabled={!isReady} variant="outline" size="sm" className="h-10 w-10 p-0 border-hand-left text-xs text-hand-left" title="현재 위치를 A로 설정">A</Button>
+          <Button type="button" onClick={onLoopEnd} disabled={!isReady || loopStart === null} variant="outline" size="sm" className="h-10 w-10 p-0 border-hand-right text-xs text-hand-right" title="현재 위치를 B로 설정">B</Button>
+          <Button type="button" onClick={onLoopClear} disabled={!isReady || loopStart === null} variant={loopEnd !== null ? 'primary' : 'ghost'} size="sm" className="h-10 w-10 p-0 text-xs" aria-label="루프 초기화">↻</Button>
         </div>
       )}
-      <button
+      <Button
         type="button"
         onClick={onStop}
         disabled={!isReady}
         aria-label="정지"
-        className="h-10 w-10 shrink-0 rounded-md border border-gray-300 bg-white text-lg leading-none hover:border-gray-400 disabled:opacity-50"
+        variant="outline"
+        size="md"
+        className="h-10 w-10 shrink-0 p-0 text-lg leading-none"
       >
         ⏹️
-      </button>
+      </Button>
 
       {/* The two readouts are the first things to go on a narrow box: the
           transport, the seek bar and the two inputs all have to keep working
@@ -153,7 +159,7 @@ export default function CompactPlaybackBar({
         value={playbackSpeed}
         onChange={event => onSpeedChange(parseFloat(event.target.value))}
         aria-label="재생 속도"
-        className="h-10 shrink-0 rounded-md border border-gray-300 bg-white px-2 text-xs"
+        className="h-10 shrink-0 rounded-full border border-rule-strong bg-surface px-3 text-xs text-ink shadow-sm"
       >
         {SPEEDS.map(speed => (
           <option key={speed} value={speed}>

--- a/src/components/playback/CompactPlaybackBar.tsx
+++ b/src/components/playback/CompactPlaybackBar.tsx
@@ -110,15 +110,15 @@ export default function CompactPlaybackBar({
         aria-label="일시정지"
         variant="outline"
         size="md"
-        className="h-10 w-10 shrink-0 p-0 text-lg leading-none"
+        className="h-10 w-10 shrink-0 p-0 !px-0 !py-0 text-lg leading-none"
       >
         ⏸️
       </Button>
       {onLoopStart && onLoopEnd && onLoopClear && (
         <div className="flex shrink-0 gap-1" data-testid="compact-loop-controls">
-          <Button type="button" onClick={onLoopStart} disabled={!isReady} variant="outline" size="sm" className="h-10 w-10 p-0 border-hand-left text-xs text-hand-left" title="현재 위치를 A로 설정">A</Button>
-          <Button type="button" onClick={onLoopEnd} disabled={!isReady || loopStart === null} variant="outline" size="sm" className="h-10 w-10 p-0 border-hand-right text-xs text-hand-right" title="현재 위치를 B로 설정">B</Button>
-          <Button type="button" onClick={onLoopClear} disabled={!isReady || loopStart === null} variant={loopEnd !== null ? 'primary' : 'ghost'} size="sm" className="h-10 w-10 p-0 text-xs" aria-label="루프 초기화">↻</Button>
+          <Button type="button" onClick={onLoopStart} disabled={!isReady} variant="outline" size="sm" className="h-10 w-10 p-0 !px-0 !py-0 border-hand-left text-xs text-hand-left" title="구간 시작 A 설정" aria-label="구간 시작 A 설정">A</Button>
+          <Button type="button" onClick={onLoopEnd} disabled={!isReady || loopStart === null} variant="outline" size="sm" className="h-10 w-10 p-0 !px-0 !py-0 border-hand-right text-xs text-hand-right" title="구간 끝 B 설정" aria-label="구간 끝 B 설정">B</Button>
+          <Button type="button" onClick={onLoopClear} disabled={!isReady || loopStart === null} variant={loopEnd !== null ? 'primary' : 'ghost'} size="sm" className="h-10 w-10 p-0 !px-0 !py-0 text-xs" aria-label="A-B 구간 반복 초기화" title="A-B 구간 반복 초기화">↻</Button>
         </div>
       )}
       <Button

--- a/src/components/playback/PlaybackControls.tsx
+++ b/src/components/playback/PlaybackControls.tsx
@@ -130,10 +130,12 @@ export default function PlaybackControls({
             variant="primary"
             size="lg"
             disabled={!isReady || isPlaying}
-            className="h-12 w-12 p-0"
+            className="h-12 w-20 gap-1 p-0 !px-0 !py-0 text-xs"
+            aria-label="재생"
             data-testid="playback-play"
           >
             <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5 fill-current"><path d="m8 5 11 7-11 7V5Z" /></svg>
+            <span>재생</span>
           </Button>
           
           {/* Pause Button */}
@@ -142,10 +144,12 @@ export default function PlaybackControls({
             variant="outline"
             size="lg"
             disabled={!isReady || !isPlaying}
-            className="h-12 w-12 p-0"
+            className="h-12 w-20 gap-1 p-0 !px-0 !py-0 text-xs"
+            aria-label="일시정지"
             data-testid="playback-pause"
           >
             <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5 fill-current"><path d="M7 5h3v14H7zm7 0h3v14h-3z" /></svg>
+            <span>일시정지</span>
           </Button>
           
           {/* Stop Button */}
@@ -154,18 +158,21 @@ export default function PlaybackControls({
             variant="outline"
             size="lg"
             disabled={!isReady}
-            className="h-12 w-12 p-0"
+            className="h-12 w-20 gap-1 p-0 !px-0 !py-0 text-xs"
+            aria-label="중지"
             data-testid="playback-stop"
           >
             <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5 fill-current"><rect x="6" y="6" width="12" height="12" rx="1" /></svg>
+            <span>중지</span>
           </Button>
 
           {onLoopStart && onLoopEnd && onLoopClear && (
             <div className="flex items-center gap-1 rounded-full border border-rule bg-surface-muted p-1" data-testid="playback-loop">
-              <Button onClick={onLoopStart} variant="outline" size="lg" disabled={!isReady || duration <= 0} className="h-12 w-12 p-0 border-hand-left text-hand-left" title="현재 위치를 A로 설정">A</Button>
-              <Button onClick={onLoopEnd} variant="outline" size="lg" disabled={!isReady || duration <= 0 || loopStart === null} className="h-12 w-12 p-0 border-hand-right text-hand-right" title="현재 위치를 B로 설정">B</Button>
-              <Button onClick={onLoopClear} variant={loopEnd !== null ? 'primary' : 'ghost'} size="lg" disabled={!isReady || loopStart === null} className="h-12 w-12 p-0" title="A-B 구간 반복 해제">
+              <Button onClick={onLoopStart} variant="outline" size="lg" disabled={!isReady || duration <= 0} className="h-12 w-20 p-0 !px-0 !py-0 border-hand-left text-hand-left text-xs" title="구간 시작 A 설정" aria-label="A 시작">A 시작</Button>
+              <Button onClick={onLoopEnd} variant="outline" size="lg" disabled={!isReady || duration <= 0 || loopStart === null} className="h-12 w-20 p-0 !px-0 !py-0 border-hand-right text-hand-right text-xs" title="구간 끝 B 설정" aria-label="B 종료">B 종료</Button>
+              <Button onClick={onLoopClear} variant={loopEnd !== null ? 'primary' : 'ghost'} size="lg" disabled={!isReady || loopStart === null} className="h-12 w-20 gap-1 p-0 !px-0 !py-0 text-xs" title="A-B 구간 반복 초기화" aria-label="A-B 구간 반복 초기화">
                 <svg aria-hidden="true" viewBox="0 0 24 24" className="h-4 w-4 fill-none stroke-current" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M17 2l4 4-4 4" /><path d="M3 11V9a3 3 0 0 1 3-3h15" /><path d="m7 22-4-4 4-4" /><path d="M21 13v2a3 3 0 0 1-3 3H3" /></svg>
+                <span>초기화</span>
               </Button>
             </div>
           )}
@@ -200,7 +207,7 @@ export default function PlaybackControls({
       </div>
       {onLoopStart && onLoopEnd && (
         <p className="text-xs text-ink-muted">
-          구간 반복: A {loopStart === null ? '미설정' : formatTime(loopStart)} · B {loopEnd === null ? '미설정' : formatTime(loopEnd)}
+          구간 반복: A(시작) {loopStart === null ? '미설정' : formatTime(loopStart)} · B(종료) {loopEnd === null ? '미설정' : formatTime(loopEnd)}
         </p>
       )}
 

--- a/src/components/playback/PlaybackControls.tsx
+++ b/src/components/playback/PlaybackControls.tsx
@@ -123,14 +123,14 @@ export default function PlaybackControls({
 
       {/* Main Controls */}
       <div className="flex flex-wrap items-center justify-between gap-4">
-        <div className="flex items-center space-x-3">
+        <div className="flex items-center gap-3">
           {/* Play Button */}
           <Button
             onClick={onPlay}
             variant="primary"
             size="lg"
             disabled={!isReady || isPlaying}
-            className="min-w-[60px] h-12"
+            className="h-12 w-12 p-0"
             data-testid="playback-play"
           >
             <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5 fill-current"><path d="m8 5 11 7-11 7V5Z" /></svg>
@@ -142,7 +142,7 @@ export default function PlaybackControls({
             variant="outline"
             size="lg"
             disabled={!isReady || !isPlaying}
-            className="min-w-[60px] h-12"
+            className="h-12 w-12 p-0"
             data-testid="playback-pause"
           >
             <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5 fill-current"><path d="M7 5h3v14H7zm7 0h3v14h-3z" /></svg>
@@ -154,17 +154,17 @@ export default function PlaybackControls({
             variant="outline"
             size="lg"
             disabled={!isReady}
-            className="min-w-[60px] h-12"
+            className="h-12 w-12 p-0"
             data-testid="playback-stop"
           >
             <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5 fill-current"><rect x="6" y="6" width="12" height="12" rx="1" /></svg>
           </Button>
 
           {onLoopStart && onLoopEnd && onLoopClear && (
-            <div className="flex items-center gap-1 rounded-md border border-rule p-1" data-testid="playback-loop">
-              <Button onClick={onLoopStart} variant="outline" size="sm" disabled={!isReady || duration <= 0} title="현재 위치를 A로 설정">A</Button>
-              <Button onClick={onLoopEnd} variant="outline" size="sm" disabled={!isReady || duration <= 0 || loopStart === null} title="현재 위치를 B로 설정">B</Button>
-              <Button onClick={onLoopClear} variant={loopEnd !== null ? 'primary' : 'outline'} size="sm" disabled={!isReady || loopStart === null} title="A-B 구간 반복 해제">
+            <div className="flex items-center gap-1 rounded-full border border-rule bg-surface-muted p-1" data-testid="playback-loop">
+              <Button onClick={onLoopStart} variant="outline" size="lg" disabled={!isReady || duration <= 0} className="h-12 w-12 p-0 border-hand-left text-hand-left" title="현재 위치를 A로 설정">A</Button>
+              <Button onClick={onLoopEnd} variant="outline" size="lg" disabled={!isReady || duration <= 0 || loopStart === null} className="h-12 w-12 p-0 border-hand-right text-hand-right" title="현재 위치를 B로 설정">B</Button>
+              <Button onClick={onLoopClear} variant={loopEnd !== null ? 'primary' : 'ghost'} size="lg" disabled={!isReady || loopStart === null} className="h-12 w-12 p-0" title="A-B 구간 반복 해제">
                 <svg aria-hidden="true" viewBox="0 0 24 24" className="h-4 w-4 fill-none stroke-current" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M17 2l4 4-4 4" /><path d="M3 11V9a3 3 0 0 1 3-3h15" /><path d="m7 22-4-4 4-4" /><path d="M21 13v2a3 3 0 0 1-3 3H3" /></svg>
               </Button>
             </div>
@@ -176,21 +176,26 @@ export default function PlaybackControls({
           <label htmlFor={speedSelectId} className="text-sm text-ink-muted font-medium">
             속도:
           </label>
-          <select
-            id={speedSelectId}
-            value={playbackSpeed}
-            onChange={(e) => onSpeedChange(parseFloat(e.target.value))}
-            className="px-3 py-2 border border-rule-strong rounded-md text-sm bg-surface text-ink transition-colors"
-            disabled={!isReady}
-          >
-            <option value={0.25}>0.25x</option>
-            <option value={0.5}>0.5x</option>
-            <option value={0.75}>0.75x</option>
-            <option value={1.0}>1.0x</option>
-            <option value={1.25}>1.25x</option>
-            <option value={1.5}>1.5x</option>
-            <option value={2.0}>2.0x</option>
-          </select>
+          <div className="relative">
+            <select
+              id={speedSelectId}
+              value={playbackSpeed}
+              onChange={(e) => onSpeedChange(parseFloat(e.target.value))}
+              className="h-12 min-w-[104px] appearance-none rounded-full border border-rule-strong bg-surface pl-4 pr-9 text-sm text-ink shadow-sm transition-colors hover:bg-surface-muted"
+              disabled={!isReady}
+            >
+              <option value={0.25}>0.25x</option>
+              <option value={0.5}>0.5x</option>
+              <option value={0.75}>0.75x</option>
+              <option value={1.0}>1.0x</option>
+              <option value={1.25}>1.25x</option>
+              <option value={1.5}>1.5x</option>
+              <option value={2.0}>2.0x</option>
+            </select>
+            <svg aria-hidden="true" viewBox="0 0 20 20" className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 fill-current text-ink-muted">
+              <path d="m5.5 7.5 4.5 4.5 4.5-4.5" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" />
+            </svg>
+          </div>
         </div>
       </div>
       {onLoopStart && onLoopEnd && (
@@ -200,24 +205,32 @@ export default function PlaybackControls({
       )}
 
       {/* Secondary settings stay out of the first-action path. */}
-      <details className="rounded-lg border border-rule bg-surface px-3 py-2">
-        <summary className="cursor-pointer text-sm font-medium text-ink-muted">전체 설정</summary>
-        <div className="mt-3 flex items-center justify-between gap-3">
-        <div className="flex items-center space-x-3">
+      <details className="overflow-hidden rounded-2xl border border-rule bg-surface">
+        <summary className="flex cursor-pointer list-none items-center justify-between px-4 py-3 text-sm font-medium text-ink hover:bg-surface-muted [&::-webkit-details-marker]:hidden">
+          <span>전체 설정</span>
+          <span aria-hidden="true" className="text-lg leading-none text-ink-muted">⌄</span>
+        </summary>
+        <div className="flex flex-wrap items-center justify-between gap-3 border-t border-rule px-4 py-4">
+        <div className="flex items-center gap-3">
           <label htmlFor={modeSelectId} className="text-sm text-ink-muted font-medium">
             모드:
           </label>
-          <select
-            id={modeSelectId}
-            value={playbackMode}
-            onChange={(e) => onModeChange(e.target.value as 'listen' | 'follow' | 'practice')}
-            className="px-3 py-2 border border-rule-strong rounded-md text-sm bg-surface text-ink transition-colors"
-            disabled={!isReady}
-          >
-            <option value="listen">🎵 듣기</option>
-            <option value="follow">🎹 따라하기</option>
-            <option value="practice">📚 연습 가이드</option>
-          </select>
+          <div className="relative">
+            <select
+              id={modeSelectId}
+              value={playbackMode}
+              onChange={(e) => onModeChange(e.target.value as 'listen' | 'follow' | 'practice')}
+              className="h-10 min-w-[148px] appearance-none rounded-full border border-rule-strong bg-surface pl-4 pr-9 text-sm text-ink shadow-sm transition-colors hover:bg-surface-muted"
+              disabled={!isReady}
+            >
+              <option value="listen">🎵 듣기</option>
+              <option value="follow">🎹 따라하기</option>
+              <option value="practice">📚 연습 가이드</option>
+            </select>
+            <svg aria-hidden="true" viewBox="0 0 20 20" className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 fill-current text-ink-muted">
+              <path d="m5.5 7.5 4.5 4.5 4.5-4.5" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" />
+            </svg>
+          </div>
         </div>
 
         <div className="text-sm text-ink-muted">

--- a/src/components/playback/__tests__/CompactPlaybackBar.test.tsx
+++ b/src/components/playback/__tests__/CompactPlaybackBar.test.tsx
@@ -79,4 +79,25 @@ describe('CompactPlaybackBar', () => {
     fireEvent.change(screen.getByLabelText('음량 (master gain)'), { target: { value: '0.4' } })
     expect(props.onVolumeChange).toHaveBeenCalledWith(0.4)
   })
+
+  it('keeps compact transport and loop controls the same size', () => {
+    renderBar({
+      loopStart: null,
+      loopEnd: null,
+      onLoopStart: jest.fn(),
+      onLoopEnd: jest.fn(),
+      onLoopClear: jest.fn(),
+    })
+
+    const controls = [
+      screen.getByLabelText('일시정지'),
+      screen.getByText('A'),
+      screen.getByText('B'),
+      screen.getByLabelText('루프 초기화'),
+      screen.getByLabelText('정지'),
+    ]
+
+    controls.forEach(control => expect(control).toHaveClass('h-10', 'w-10', 'rounded-full'))
+    expect(screen.getByLabelText('재생 속도')).toHaveClass('rounded-full')
+  })
 })

--- a/src/components/playback/__tests__/CompactPlaybackBar.test.tsx
+++ b/src/components/playback/__tests__/CompactPlaybackBar.test.tsx
@@ -91,9 +91,9 @@ describe('CompactPlaybackBar', () => {
 
     const controls = [
       screen.getByLabelText('일시정지'),
-      screen.getByText('A'),
-      screen.getByText('B'),
-      screen.getByLabelText('루프 초기화'),
+      screen.getByLabelText('구간 시작 A 설정'),
+      screen.getByLabelText('구간 끝 B 설정'),
+      screen.getByLabelText('A-B 구간 반복 초기화'),
       screen.getByLabelText('정지'),
     ]
 

--- a/src/components/playback/__tests__/PlaybackControls.test.tsx
+++ b/src/components/playback/__tests__/PlaybackControls.test.tsx
@@ -78,4 +78,28 @@ describe('PlaybackControls', () => {
     expect(props.onStop).toHaveBeenCalled()
     expect(props.onSpeedChange).toHaveBeenCalledWith(1.5)
   })
+
+  it('keeps transport and loop controls the same size while differentiating their roles', () => {
+    renderControls()
+
+    const controls = [
+      screen.getByTestId('playback-play'),
+      screen.getByTestId('playback-pause'),
+      screen.getByTestId('playback-stop'),
+      screen.getByTitle('현재 위치를 A로 설정'),
+      screen.getByTitle('현재 위치를 B로 설정'),
+      screen.getByTitle('A-B 구간 반복 해제'),
+    ]
+
+    controls.forEach(control => expect(control).toHaveClass('h-12', 'w-12', 'p-0'))
+    expect(screen.getByTestId('playback-play')).toHaveClass('bg-accent')
+    expect(screen.getByTestId('playback-stop')).toHaveClass('border-rule-strong')
+  })
+
+  it('presents speed and secondary settings as matching rounded controls', () => {
+    renderControls()
+
+    expect(screen.getByLabelText('속도:')).toHaveClass('rounded-full')
+    expect(screen.getByText('전체 설정').closest('details')).toHaveClass('rounded-2xl')
+  })
 })

--- a/src/components/playback/__tests__/PlaybackControls.test.tsx
+++ b/src/components/playback/__tests__/PlaybackControls.test.tsx
@@ -56,9 +56,9 @@ describe('PlaybackControls', () => {
     }
 
     render(<LoopHarness />)
-    const start = screen.getByTitle('현재 위치를 A로 설정')
-    const end = screen.getByTitle('현재 위치를 B로 설정')
-    const clear = screen.getByTitle('A-B 구간 반복 해제')
+    const start = screen.getByTitle('구간 시작 A 설정')
+    const end = screen.getByTitle('구간 끝 B 설정')
+    const clear = screen.getByTitle('A-B 구간 반복 초기화')
 
     expect(end).toBeDisabled()
     fireEvent.click(start)
@@ -86,12 +86,12 @@ describe('PlaybackControls', () => {
       screen.getByTestId('playback-play'),
       screen.getByTestId('playback-pause'),
       screen.getByTestId('playback-stop'),
-      screen.getByTitle('현재 위치를 A로 설정'),
-      screen.getByTitle('현재 위치를 B로 설정'),
-      screen.getByTitle('A-B 구간 반복 해제'),
+      screen.getByTitle('구간 시작 A 설정'),
+      screen.getByTitle('구간 끝 B 설정'),
+      screen.getByTitle('A-B 구간 반복 초기화'),
     ]
 
-    controls.forEach(control => expect(control).toHaveClass('h-12', 'w-12', 'p-0'))
+    controls.forEach(control => expect(control).toHaveClass('h-12', 'w-20', 'p-0'))
     expect(screen.getByTestId('playback-play')).toHaveClass('bg-accent')
     expect(screen.getByTestId('playback-stop')).toHaveClass('border-rule-strong')
   })
@@ -101,5 +101,16 @@ describe('PlaybackControls', () => {
 
     expect(screen.getByLabelText('속도:')).toHaveClass('rounded-full')
     expect(screen.getByText('전체 설정').closest('details')).toHaveClass('rounded-2xl')
+  })
+
+  it('shows the meaning of every playback action next to its icon', () => {
+    renderControls()
+
+    expect(screen.getByRole('button', { name: '재생' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '일시정지' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '중지' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'A 시작' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'B 종료' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'A-B 구간 반복 초기화' })).toBeInTheDocument()
   })
 })

--- a/src/components/search/SheetMusicSearch.tsx
+++ b/src/components/search/SheetMusicSearch.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect, useRef } from 'react'
-import { Button, StatusState } from '@/components/ui'
+import { Badge, Button, StatusState } from '@/components/ui'
 import { useSheetMusicSearch } from '@/hooks/useSheetMusicSearch'
 import { SheetMusicWithOwner } from '@/types/sheet-music'
 import { useCategories } from '@/hooks/useCategories'
@@ -198,18 +198,14 @@ export default function SheetMusicSearch({
                     
                     <div className="flex items-center space-x-4 text-sm text-gray-500">
                       {sheetMusic.category && (
-                        <span className="px-2 py-1 bg-blue-100 text-blue-800 rounded">
+                        <Badge tone="info">
                           {sheetMusic.category.name}
-                        </span>
+                        </Badge>
                       )}
                       
-                      <span className={`px-2 py-1 rounded ${
-                        sheetMusic.isPublic 
-                          ? 'bg-green-100 text-green-800' 
-                          : 'bg-gray-100 text-gray-800'
-                      }`}>
+                      <Badge>
                         {sheetMusic.isPublic ? '공개' : '비공개'}
-                      </span>
+                      </Badge>
                       
                       {sheetMusic.owner && (
                         <span>

--- a/src/components/sheet/SheetMusicCard.tsx
+++ b/src/components/sheet/SheetMusicCard.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { SheetMusicWithCategory } from '@/types/sheet-music'
 import { Category } from '@/types/category'
 import Button from '@/components/ui/Button'
+import Badge from '@/components/ui/Badge'
 import Card from '@/components/ui/Card'
 import { DeleteConfirmDialog } from '@/components/ui/ConfirmDialog'
 import type { SheetMusicAvailability } from '@/lib/sheetMusicAvailability'
@@ -45,10 +46,10 @@ export function SheetMusicCard({
   }
 
   const availabilityDetails = availability && {
-    ready: { label: '연습 가능', icon: '✓', className: 'bg-state-ready text-on-accent' },
-    processing: { label: '처리 중', icon: '◌', className: 'bg-state-progress text-on-accent' },
-    failed: { label: '변환 오류', icon: '!', className: 'bg-state-error text-on-accent' },
-    unknown: { label: '확인 필요', icon: '?', className: 'bg-surface-muted text-ink' },
+    ready: { label: '연습 가능', icon: '✓', tone: 'success' as const },
+    processing: { label: '처리 중', icon: '◌', tone: 'warning' as const },
+    failed: { label: '변환 오류', icon: '!', tone: 'danger' as const },
+    unknown: { label: '확인 필요', icon: '?', tone: 'neutral' as const },
   }[availability]
 
   return (
@@ -64,21 +65,17 @@ export function SheetMusicCard({
 
         {/* Category and visibility info */}
         <div className="flex flex-wrap items-center gap-1.5 text-xs flex-shrink-0">
-          <span className="max-w-full px-2 py-1 bg-surface-muted rounded-full truncate">
+          <Badge className="truncate">
             📁 {sheetMusic.category?.name || '미분류'}
-          </span>
-          <span className={`px-2 py-1 rounded-full ${
-            sheetMusic.isPublic 
-              ? 'bg-surface-muted text-ink'
-              : 'bg-surface-muted text-ink'
-          }`}>
+          </Badge>
+          <Badge>
             {sheetMusic.isPublic ? '🌍 공개' : '🔒 비공개'}
-          </span>
+          </Badge>
           {availabilityDetails && (
-            <span className={`inline-flex items-center gap-1 px-2 py-1 rounded-full ${availabilityDetails.className}`}>
+            <Badge tone={availabilityDetails.tone}>
               <span aria-hidden="true">{availabilityDetails.icon}</span>
               {availabilityDetails.label}
-            </span>
+            </Badge>
           )}
         </div>
 

--- a/src/components/sheet/SheetMusicCardBase.tsx
+++ b/src/components/sheet/SheetMusicCardBase.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import Card from '@/components/ui/Card'
+import Badge from '@/components/ui/Badge'
 import { 
   SheetMusicDisplayProps, 
   SheetMusicInteractiveProps 
@@ -42,16 +43,12 @@ export function SheetMusicInfo({
       {/* Category and visibility info */}
       {showMetadata && (
         <div className="flex items-center gap-2 text-xs">
-          <span className="px-2 py-1 bg-gray-100 rounded-full">
+          <Badge>
             📁 {sheetMusic.category?.name || '미분류'}
-          </span>
-          <span className={`px-2 py-1 rounded-full ${
-            sheetMusic.isPublic 
-              ? 'bg-green-100 text-green-700' 
-              : 'bg-gray-100 text-gray-700'
-          }`}>
+          </Badge>
+          <Badge>
             {sheetMusic.isPublic ? '🌍 공개' : '🔒 비공개'}
-          </span>
+          </Badge>
         </div>
       )}
 

--- a/src/components/sheet/SheetMusicCardRefactored.tsx
+++ b/src/components/sheet/SheetMusicCardRefactored.tsx
@@ -4,6 +4,7 @@ import { Category } from '@/types/category'
 import { SheetMusicCardBase } from './SheetMusicCardBase'
 import { SheetMusicActions } from './SheetMusicActions'
 import { SheetMusicMoveMenu } from './SheetMusicMoveMenu'
+import Badge from '@/components/ui/Badge'
 import { 
   SheetMusicCardCoreProps,
   SheetMusicActionableProps,
@@ -82,18 +83,14 @@ export function SheetMusicCardRefactored({
           <p className="text-xs text-gray-600 truncate">{sheetMusic.composer}</p>
         </div>
         <div className="col-span-2 flex items-center text-xs">
-          <span className="px-2 py-1 bg-gray-100 rounded-full truncate">
+          <Badge className="truncate">
             📁 {sheetMusic.category?.name || '미분류'}
-          </span>
+          </Badge>
         </div>
         <div className="col-span-2 flex items-center text-xs">
-          <span className={`px-2 py-1 rounded-full ${
-            sheetMusic.isPublic 
-              ? 'bg-green-100 text-green-700' 
-              : 'bg-gray-100 text-gray-700'
-          }`}>
+          <Badge>
             {sheetMusic.isPublic ? '🌍 공개' : '🔒 비공개'}
-          </span>
+          </Badge>
         </div>
         <div className="col-span-2 flex items-center text-xs text-gray-500">
           {new Date(sheetMusic.createdAt).toLocaleDateString('ko-KR')}

--- a/src/components/sheet/SheetMusicList.tsx
+++ b/src/components/sheet/SheetMusicList.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { SheetMusicWithCategory } from '@/types/sheet-music'
 import Button from '@/components/ui/Button'
+import Badge from '@/components/ui/Badge'
 import Card from '@/components/ui/Card'
 
 interface SheetMusicListProps {
@@ -83,9 +84,9 @@ export function SheetMusicList({
                 {sheet.title}
               </h3>
               {sheet.isPublic && (
-                <span className="bg-green-100 text-green-800 text-xs px-2 py-1 rounded-full ml-2">
+                <Badge tone="success" className="ml-2">
                   Public
-                </span>
+                </Badge>
               )}
             </div>
             

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -1,0 +1,38 @@
+import { HTMLAttributes, forwardRef } from 'react'
+
+interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
+  tone?: 'neutral' | 'accent' | 'info' | 'success' | 'warning' | 'danger'
+  size?: 'sm' | 'md'
+}
+
+const Badge = forwardRef<HTMLSpanElement, BadgeProps>(
+  ({ className = '', tone = 'neutral', size = 'sm', children, ...props }, ref) => {
+    const toneClasses = {
+      neutral: 'bg-surface-muted text-ink',
+      accent: 'bg-accent text-on-accent',
+      info: 'bg-hand-left text-on-accent',
+      success: 'bg-state-ready text-on-accent',
+      warning: 'bg-state-progress text-on-accent',
+      danger: 'bg-state-error text-on-accent',
+    }
+
+    const sizeClasses = {
+      sm: 'px-2.5 py-1 text-xs',
+      md: 'px-3 py-1.5 text-sm',
+    }
+
+    return (
+      <span
+        ref={ref}
+        className={`inline-flex max-w-full items-center justify-center gap-1 rounded-full font-medium leading-none ${sizeClasses[size]} ${toneClasses[tone]} ${className}`}
+        {...props}
+      >
+        {children}
+      </span>
+    )
+  },
+)
+
+Badge.displayName = 'Badge'
+
+export default Badge

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -20,7 +20,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   }, ref) => {
     // 포커스 링은 `globals.css`의 전역 `:focus-visible`이 담당한다. variant마다 다른 링 색을
     // 두면 화면마다 포커스가 달라 보인다.
-    const baseClasses = 'inline-flex items-center justify-center font-medium rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
+    const baseClasses = 'inline-flex items-center justify-center font-medium rounded-full transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
 
     const variantClasses = {
       primary: 'bg-accent text-on-accent hover:bg-accent-hover',

--- a/src/components/ui/__tests__/Badge.test.tsx
+++ b/src/components/ui/__tests__/Badge.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react'
+import Badge from '@/components/ui/Badge'
+
+describe('Badge Component', () => {
+  test('renders a rounded status badge with its label', () => {
+    render(<Badge tone="success">연습 가능</Badge>)
+
+    const badge = screen.getByText('연습 가능')
+    expect(badge).toHaveClass('inline-flex', 'rounded-full', 'bg-state-ready', 'text-on-accent')
+  })
+
+  test('supports neutral metadata badges', () => {
+    render(<Badge>미분류</Badge>)
+
+    expect(screen.getByText('미분류')).toHaveClass('rounded-full', 'bg-surface-muted', 'text-ink')
+  })
+})

--- a/src/components/ui/__tests__/Button.test.tsx
+++ b/src/components/ui/__tests__/Button.test.tsx
@@ -35,6 +35,16 @@ describe('Button Component', () => {
     expect(button).toHaveClass('bg-state-error', 'text-on-accent')
   })
 
+  test('uses a pill shape consistently across variants', () => {
+    const { rerender } = render(<Button variant="primary">Primary Button</Button>)
+    let button = screen.getByText('Primary Button')
+    expect(button).toHaveClass('rounded-full')
+
+    rerender(<Button variant="outline">Outline Button</Button>)
+    button = screen.getByText('Outline Button')
+    expect(button).toHaveClass('rounded-full')
+  })
+
   // 포커스 링은 globals.css의 전역 :focus-visible이 담당한다. 컴포넌트가 다시 정의하면 화면마다
   // 포커스가 달라 보인다.
   test('does not define its own focus ring', () => {

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,4 +1,5 @@
 export { default as Button } from './Button'
+export { default as Badge } from './Badge'
 export { default as Card } from './Card'
 export { default as Loading } from './Loading'
 export { default as StatusState } from './StatusState'


### PR DESCRIPTION
## 목적\n버튼과 정보 라벨이 페이지마다 서로 다른 radius와 로컬 색상 클래스를 사용해 화면의 인상이 분산되는 문제를 정리합니다.\n\n## 범위\n- 공통 Button을 rounded-full pill 형태로 통일\n- category/visibility/processing 상태용 Badge 컴포넌트 추가\n- 탐색·내 악보·검색·로그인·상세의 버튼과 정보 라벨을 공통 컴포넌트로 교체\n- 탭과 빈 상태/오류 상태 CTA도 동일 규칙 적용\n\n## 제외\n카드·입력 필드·메뉴·재생 기하의 radius는 이번 변경에서 건드리지 않았습니다.\n\n## 검증\n- npx tsc --noEmit\n- npm run lint\n- npm test -- --runInBand (81 suites, 759 tests)\n- npm run build\n\n## 위험 및 롤백\n기존 Button variant 계약을 유지하고 시각적 radius와 라벨 렌더링만 공통화했습니다. 문제 발생 시 커밋 7ba646c를 되돌리면 됩니다.