### PR TITLE
Unify library and upload field radii

### DIFF
--- a/src/app/library/__tests__/page.test.tsx
+++ b/src/app/library/__tests__/page.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react'
+import LibraryPage from '../page'
+
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({
+    data: { user: { id: 'user-1' } },
+    status: 'authenticated',
+  }),
+}))
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}))
+
+jest.mock('@/components/library/LibrarySheetMusicList', () => ({
+  LibrarySheetMusicList: () => <div data-testid="library-list" />,
+}))
+
+describe('Library page controls', () => {
+  it('uses rounded control surfaces for search and sorting', () => {
+    render(<LibraryPage />)
+
+    expect(screen.getByPlaceholderText('곡명, 저작자로 검색...')).toHaveClass('rounded-2xl')
+    expect(screen.getByRole('combobox')).toHaveClass('rounded-full')
+  })
+})

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -75,7 +75,7 @@ export default function LibraryPage() {
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
                   placeholder="곡명, 저작자로 검색..."
-                  className="w-full pl-10 pr-4 py-3 border border-rule-strong bg-surface text-ink rounded-lg"
+                  className="w-full rounded-2xl border border-rule-strong bg-surface py-3 pl-10 pr-4 text-ink shadow-sm transition-colors"
                 />
                 <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
                   <svg className="h-5 w-5 text-ink-muted" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -85,15 +85,21 @@ export default function LibraryPage() {
               </div>
               
               {/* Sort Dropdown */}
-              <select
-                value={sortBy}
-                onChange={(e) => setSortBy(e.target.value as 'recent' | 'name' | 'created')}
-                className="px-4 py-3 border border-rule-strong rounded-lg bg-surface text-ink min-w-[140px]"
-              >
-                <option value="recent">최근 수정</option>
-                <option value="name">이름순</option>
-                <option value="created">생성일순</option>
-              </select>
+              <div className="relative">
+                <select
+                  value={sortBy}
+                  onChange={(e) => setSortBy(e.target.value as 'recent' | 'name' | 'created')}
+                  className="h-12 min-w-[160px] appearance-none rounded-full border border-rule-strong bg-surface pl-4 pr-10 text-ink shadow-sm transition-colors hover:bg-surface-muted"
+                  aria-label="악보 정렬"
+                >
+                  <option value="recent">최근 수정</option>
+                  <option value="name">이름순</option>
+                  <option value="created">생성일순</option>
+                </select>
+                <svg aria-hidden="true" viewBox="0 0 20 20" className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-ink-muted">
+                  <path d="m5.5 7.5 4.5 4.5 4.5-4.5" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" />
+                </svg>
+              </div>
             </div>
           </div>
 

--- a/src/components/library/LibrarySheetMusicList.tsx
+++ b/src/components/library/LibrarySheetMusicList.tsx
@@ -167,7 +167,7 @@ export function LibrarySheetMusicList({
                 key={category.id}
                 onClick={() => onCategorySelect?.(category.id)}
                 className={`
-                  p-3 rounded-lg border-2 transition-colors text-left
+                  p-3 rounded-2xl border-2 transition-colors text-left
                   ${selectedCategoryId === category.id
                     ? 'border-accent bg-surface-muted text-ink'
                     : 'border-rule bg-surface hover:bg-surface-muted'

--- a/src/components/library/__tests__/LibrarySheetMusicList.test.tsx
+++ b/src/components/library/__tests__/LibrarySheetMusicList.test.tsx
@@ -80,4 +80,15 @@ describe('LibrarySheetMusicList', () => {
     expect(screen.getByText('악보가 없습니다')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: '새 악보 업로드' })).toHaveAttribute('href', '/upload')
   })
+
+  it('uses a rounded category control surface', () => {
+    mockUseCategories.mockReturnValue({
+      categories: [{ id: 1, name: 'classic', userId: 'user-1', createdAt: new Date() }],
+      loading: false, error: null, fetchCategories: jest.fn(), createCategory: jest.fn(), updateCategory: jest.fn(), deleteCategory: jest.fn(),
+    })
+
+    render(<LibrarySheetMusicList showCategorySelector />)
+
+    expect(screen.getByRole('button', { name: '📁 classic' })).toHaveClass('rounded-2xl')
+  })
 })

--- a/src/components/upload/OMRUploadForm.tsx
+++ b/src/components/upload/OMRUploadForm.tsx
@@ -343,7 +343,7 @@ export default function OMRUploadForm({
             onDrop={handleDrop}
             onDragOver={handleDragOver}
             onDragLeave={handleDragLeave}
-            className={`flex cursor-pointer flex-col items-center justify-center gap-2 rounded-md border-2 border-dashed px-6 py-10 text-center transition-colors focus-within:border-accent ${
+            className={`flex cursor-pointer flex-col items-center justify-center gap-2 rounded-2xl border-2 border-dashed px-6 py-10 text-center transition-colors focus-within:border-accent ${
               isDragging ? 'border-accent bg-surface-muted' : 'border-rule-strong hover:bg-surface-muted'
             }`}
           >
@@ -393,7 +393,7 @@ export default function OMRUploadForm({
             value={formData.title}
             onChange={(e) => handleInputChange('title', e.target.value)}
             aria-invalid={Boolean(errors.title)}
-            className={`w-full rounded-md border px-3 py-2 ${
+            className={`w-full rounded-2xl border px-3 py-2 transition-colors focus:border-accent ${
               errors.title ? 'border-state-error' : 'border-rule-strong'
             }`}
             placeholder="곡명을 입력하세요"
@@ -413,7 +413,7 @@ export default function OMRUploadForm({
             value={formData.composer}
             onChange={(e) => handleInputChange('composer', e.target.value)}
             aria-invalid={Boolean(errors.composer)}
-            className={`w-full rounded-md border px-3 py-2 ${
+            className={`w-full rounded-2xl border px-3 py-2 transition-colors focus:border-accent ${
               errors.composer ? 'border-state-error' : 'border-rule-strong'
             }`}
             placeholder="작곡가 또는 저작자를 입력하세요"
@@ -437,7 +437,7 @@ export default function OMRUploadForm({
             onChange={(e) => handleInputChange('tempo', e.target.value)}
             aria-describedby="tempo-help"
             aria-invalid={Boolean(errors.tempo)}
-            className={`w-full rounded-md border px-3 py-2 ${
+            className={`w-full rounded-2xl border px-3 py-2 transition-colors focus:border-accent ${
               errors.tempo ? 'border-state-error' : 'border-rule-strong'
             }`}
             placeholder="예: 60"
@@ -461,7 +461,7 @@ export default function OMRUploadForm({
               onChange={(e) =>
                 handleInputChange('categoryId', e.target.value ? parseInt(e.target.value) : null)
               }
-              className="w-full rounded-md border border-rule-strong px-3 py-2"
+              className="w-full rounded-2xl border border-rule-strong px-3 py-2 transition-colors focus:border-accent"
               disabled={isBusy || isLoadingCategories}
             >
               <option value="">카테고리 선택 (선택사항)</option>
@@ -492,7 +492,7 @@ export default function OMRUploadForm({
                   value={newCategoryName}
                   onChange={(e) => setNewCategoryName(e.target.value)}
                   placeholder="새 카테고리 이름"
-                  className="flex-1 rounded-md border border-rule-strong px-3 py-2"
+                  className="flex-1 rounded-2xl border border-rule-strong px-3 py-2 transition-colors focus:border-accent"
                   disabled={isCreatingCategory}
                 />
                 <Button

--- a/src/components/upload/__tests__/OMRUploadForm.test.tsx
+++ b/src/components/upload/__tests__/OMRUploadForm.test.tsx
@@ -72,6 +72,16 @@ describe('OMRUploadForm', () => {
   })
 
   describe('선택 전', () => {
+    it('uses the same rounded field surface for score metadata', async () => {
+      render(<OMRUploadForm />)
+      await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+
+      expect(screen.getByLabelText(/곡명/)).toHaveClass('rounded-2xl')
+      expect(screen.getByLabelText(/저작자/)).toHaveClass('rounded-2xl')
+      expect(screen.getByLabelText('빠르기 (BPM)')).toHaveClass('rounded-2xl')
+      expect(screen.getByLabelText('카테고리')).toHaveClass('rounded-2xl')
+    })
+
     it('파일이 없으면 변환을 시작할 수 없다', async () => {
       render(<OMRUploadForm />)
       await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))


### PR DESCRIPTION
내 악보와 새 악보 업로드 화면의 검색·정렬·카테고리·메타데이터 입력 필드 radius를 일관되게 정리했습니다. 라이브러리 검색은 rounded-2xl, 정렬 select는 rounded-full, 카테고리 버튼·업로드 드롭존·곡명·저작자·BPM·카테고리 입력은 rounded-2xl을 사용합니다. 검색·정렬·업로드 동작은 변경하지 않았습니다. 검증: npx tsc --noEmit, npm run lint, npm test -- --runInBand (82 suites, 766 tests), npm run build. 병합은 사용자 승인 전까지 하지 않습니다.