### PR TITLE
finalize 콜백이 자기 방어와 행 상태에 대해 사실만 말하게 한다

### DIFF
--- a/src/app/api/omr/finalize/__tests__/route.test.ts
+++ b/src/app/api/omr/finalize/__tests__/route.test.ts
@@ -163,6 +163,32 @@ describe('POST /api/omr/finalize — server-owned completion trigger', () => {
     expect(mockUpdate).not.toHaveBeenCalled()
   })
 
+  it('repairs a stored row whose status drifted away from completed', async () => {
+    // Storage succeeded but the follow-up status write did not, leaving a row
+    // with an animationDataUrl and processingStatus 'failed'. The status poll
+    // already answers this by re-marking the row completed; the callback must
+    // not report completed while leaving the row as it was (issue #72, R11).
+    mockFindUnique.mockResolvedValue(
+      row({
+        animationDataUrl:
+          `https://project.supabase.co/storage/v1/object/public/animation-data/user-1/omr_${JOB_ID}.json`,
+        processingStatus: 'failed',
+      })
+    )
+
+    const { POST } = await import('../route')
+    const response = await POST(callbackRequest())
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({ status: 'completed', alreadyStored: true })
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(uploadOmrAnimationData).not.toHaveBeenCalled()
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { id: 17 },
+      data: expect.objectContaining({ processingStatus: 'completed' }),
+    })
+  })
+
   it('retries a row previously marked failed when storage becomes available', async () => {
     mockFindUnique.mockResolvedValue(row({ processingStatus: 'failed' }))
 

--- a/src/app/api/omr/finalize/__tests__/route.test.ts
+++ b/src/app/api/omr/finalize/__tests__/route.test.ts
@@ -189,6 +189,32 @@ describe('POST /api/omr/finalize — server-owned completion trigger', () => {
     })
   })
 
+  it('answers the route JSON 500 when the status repair itself fails', async () => {
+    // The repair write sits outside the try that shapes every other failure,
+    // so a rejected update must still come back as this route's error JSON
+    // (a 5xx the OMR service will retry), not as a rejected handler.
+    mockFindUnique.mockResolvedValue(
+      row({
+        animationDataUrl:
+          `https://project.supabase.co/storage/v1/object/public/animation-data/user-1/omr_${JOB_ID}.json`,
+        processingStatus: 'failed',
+      })
+    )
+    mockUpdate.mockRejectedValue(new Error('connection reset'))
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    try {
+      const { POST } = await import('../route')
+      const response = await POST(callbackRequest())
+
+      expect(response.status).toBe(500)
+      expect(await response.json()).toEqual({ error: 'Internal server error' })
+      expect(fetchSpy).not.toHaveBeenCalled()
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
+
   it('retries a row previously marked failed when storage becomes available', async () => {
     mockFindUnique.mockResolvedValue(row({ processingStatus: 'failed' }))
 

--- a/src/app/api/omr/finalize/route.ts
+++ b/src/app/api/omr/finalize/route.ts
@@ -81,10 +81,17 @@ export async function POST(request: NextRequest) {
     // leaves the row drifted; the status poll repairs it on its own
     // short-circuit, and answering `completed` here must do the same.
     if (sheetMusic.processingStatus !== 'completed') {
-      await prisma.sheetMusic.update({
-        where: { id: sheetMusic.id },
-        data: { processingStatus: 'completed', updatedAt: new Date() },
-      })
+      try {
+        await prisma.sheetMusic.update({
+          where: { id: sheetMusic.id },
+          data: { processingStatus: 'completed', updatedAt: new Date() },
+        })
+      } catch (error) {
+        // Same shape as the catch below: the service retries 5xx, so the next
+        // callback gets another chance to repair the row.
+        console.error('OMR callback status repair failed:', jobId, error)
+        return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+      }
     }
 
     return NextResponse.json({

--- a/src/app/api/omr/finalize/route.ts
+++ b/src/app/api/omr/finalize/route.ts
@@ -66,12 +66,27 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Job not found.' }, { status: 404 })
   }
 
+  // `omrJobId` is `String?` in the schema, so this is type narrowing, not a
+  // defence: the row was found by `omrJobId: jobId`, so the value is never
+  // null here and the 409 cannot be reached. It stays because D-018 requires
+  // the fetch target to be the stored identifier rather than request input.
   const storedJobId = sheetMusic.omrJobId
   if (!storedJobId) {
     return NextResponse.json({ error: 'Stored job identifier is missing.' }, { status: 409 })
   }
 
   if (sheetMusic.animationDataUrl) {
+    // Another trigger already stored the score. Normally that write also set
+    // the status, but a storage success followed by a failed status update
+    // leaves the row drifted; the status poll repairs it on its own
+    // short-circuit, and answering `completed` here must do the same.
+    if (sheetMusic.processingStatus !== 'completed') {
+      await prisma.sheetMusic.update({
+        where: { id: sheetMusic.id },
+        data: { processingStatus: 'completed', updatedAt: new Date() },
+      })
+    }
+
     return NextResponse.json({
       success: true,
       jobId,
@@ -83,8 +98,11 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    // Use the identifier read back from the database, not request input, for
-    // the server-side fetch target. The request value is only a lookup key.
+    // What actually keeps request input out of the `/result` URL is the
+    // `UUID_PATTERN` allowlist above and `encodeURIComponent` inside
+    // `fetchAndStoreOmrResult`. Passing the stored identifier is the D-018
+    // rule and the boundary CodeQL's taint tracking sees; by itself it adds
+    // nothing, because the two strings are equal.
     const animationDataUrl = await fetchAndStoreOmrResult(storedJobId, sheetMusic.userId)
     await prisma.sheetMusic.update({
       where: { id: sheetMusic.id },

--- a/src/app/api/omr/status/[jobId]/route.ts
+++ b/src/app/api/omr/status/[jobId]/route.ts
@@ -57,6 +57,9 @@ export async function GET(
       )
     }
 
+    // Type narrowing for the nullable column, not a defence: the row was
+    // found by `omrJobId: jobId`, so the 409 below cannot be reached. Same
+    // shape as the finalize callback (issue #72).
     const storedJobId = sheetMusic.omrJobId
     if (!storedJobId) {
       return NextResponse.json(


### PR DESCRIPTION
## 목적

`src/app/api/omr/finalize/route.ts`가 자신에 대해 사실이 아닌 것을 말하는 두 지점(PR #68 리뷰 R8·R11)을
바로잡습니다. Closes #72.

## 변경 범위

- **R8** — `/result` fetch 위 주석이 DB 왕복을 SSRF 방어 근거로 설명하던 것을, 실제 sanitizer인
  `UUID_PATTERN` allowlist와 `fetchAndStoreOmrResult`의 `encodeURIComponent`를 가리키도록 고쳤습니다.
  왕복 자체는 D-018 규칙이자 CodeQL taint 경계로서 유지하되 "두 문자열은 같다"고 명시합니다.
- **R8** — nullable `omrJobId`의 409 분기가 타입 좁히기일 뿐 도달 불가임을 finalize·status 두 라우트에
  같은 문구로 표기했습니다.
- **R11** — `alreadyStored` 단축 경로가 `processingStatus !== 'completed'`인 행을 `completed`로 보정합니다.
  status 라우트의 대응 분기와 같은 동작이며, 이미 `completed`인 행에는 쓰지 않아 기존 멱등성 테스트가
  그대로 유지됩니다.
- 회귀: 저장은 됐지만 상태가 `failed`로 어긋난 행에 콜백이 오면 200 + `completed` 응답과 함께 update가
  호출되는 케이스. 수정 전 1 failed / 6 passed로 실패를 관측한 뒤(`e77e4a5`) 수정했습니다(`bac8cdd`).

## 제외 범위

- DB 왕복·409 분기 제거 — D-018 Decision 3·Directive를 바꾸는 결정이며, 왕복은 PR #68이 CodeQL
  `js/request-forgery` critical을 닫은 taint 경계이기도 합니다. 결정 변경 없이는 손대지 않습니다.
- 단축 경로의 무조건 update — 중복 콜백마다 쓰기가 생기고 기존 멱등성 기대와 어긋납니다.
- #71(NEXTAUTH_URL fallback), #73(콜백 실패 경로 테스트) — 같은 PR #68 후속이지만 별도 목적입니다.

## 위험과 방어

- 동작 변경은 R11의 조건부 update 한 곳뿐이며, 이미 status 라우트가 같은 상황에 하는 일입니다.
- 정상 경로(첫 콜백·이미 completed인 중복 콜백)의 DB 호출 횟수는 바뀌지 않습니다 — 기존 테스트 6건이
  수정 없이 통과합니다.
- 주석이 이제 sanitizer를 직접 지목하므로, 그 두 곳을 바꾸면 CodeQL을 다시 돌려야 한다는 Directive를
  커밋에 남겼습니다.

## 검증

- `npx jest src/app/api/omr`: 4 suites / 33 tests PASS
- `npm test -- --runInBand`: 85 suites / 778 tests PASS (777 → 778)
- `npx tsc --noEmit`: exit 0
- `npm run lint`: No ESLint warnings or errors
- `npm run build`: PASS
- `git diff --check`: PASS

검증하지 못한 것: 운영 DB에 실제로 어긋난 행이 존재하는지, hosted CodeQL 재분석(PR checks에서 확인).

## 기준선 차이

기존 기준선의 실패는 모두 해소된 상태이며 이번 변경으로 새 실패는 없습니다.

## Rollback

`bac8cdd` revert 한 번으로 라우트가 이전 동작으로 돌아갑니다. 회귀 테스트 커밋 `e77e4a5`는 그 경우
다시 실패하므로 함께 revert합니다. 스키마·마이그레이션·환경변수 변경은 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 점수 데이터가 이미 저장됐지만 처리 상태가 실패로 남는 경우, 상태를 완료로 자동 복구합니다.
  * 복구된 요청은 기존 결과를 재사용하며 중복 업로드나 외부 요청을 수행하지 않습니다.
* **테스트**
  * 상태 드리프트 복구와 완료 응답을 검증하는 테스트를 추가했습니다.
* **문서화**
  * 결과 조회 및 누락 식별자 처리에 대한 내부 설명을 보완했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->