### PR TITLE
공유 비밀이 향하는 콜백 주소를 요청 Host에서 유도하지 않는다

### DIFF
--- a/docs/recovery/DECISIONS.md
+++ b/docs/recovery/DECISIONS.md
@@ -1229,9 +1229,11 @@
   - PR #68은 "callback authentication fails closed"를 원칙으로 세웠고 실제로 비밀 미설정은 503, 불일치는
     401, 잘못된 URL은 503으로 닫힌다. 미설정 `NEXTAUTH_URL`만 조용히 추측하는 반대 방향이었다 (PR #68
     리뷰 R10, 이슈 #71).
-  - 지금 열린 구멍은 아니다. `NEXTAUTH_URL`은 필수로 문서화돼 운영에 설정돼 있고(2026-08-28 종단 확인에서
-    콜백이 `https://clairkeys.vercel.app/api/omr/finalize`로 나감), `/process`는 공유 비밀 뒤에 있다.
-    설정 실수 증폭기이지 독립 취약점이 아니다.
+  - 지금 열린 구멍은 아니다. `NEXTAUTH_URL`은 필수로 문서화돼 있고, 2026-09-02 `vercel env ls`로
+    **Production·Preview 양쪽에 설정돼 있음을 이름 기준으로 확인**했다(389일 전 등록). 2026-08-28 종단 확인의
+    콜백 주소 `https://clairkeys.vercel.app/api/omr/finalize`는 fallback이었어도 같은 값이 나오므로 그것만으로는
+    설정 여부를 증명하지 못한다 — 독립 리뷰가 지적한 대로다. `/process`는 공유 비밀 뒤에 있다. 설정 실수
+    증폭기이지 독립 취약점이 아니다.
   - 업로드 라우트 테스트 11건 전부가 `NEXTAUTH_URL` 없이 통과하고 있었다 — 스위트가 줄곧 fallback 경로를
     검증해 온 셈이다.
 - Decision:
@@ -1239,6 +1241,10 @@
   2. 미설정·공백은 잘못된 절대 URL과 같은 분기 — 503 `OMR_CALLBACK_NOT_CONFIGURED`, 행 생성 전 — 로
      보낸다. 행 생성 전 검증이라는 D-018 Directive의 순서는 그대로다.
   3. 업로드 라우트 테스트 fixture는 `NEXTAUTH_URL`을 명시한다. 설정 없는 성공 경로는 더 이상 존재하지 않는다.
+  4. 검증 규칙은 `src/lib/omr/serviceUrl.ts`의 `getOmrCallbackUrl()` 한 곳에 둔다. `getOmrServiceUrl()`과 같은
+     파서를 공유하므로 trim·절대 URL·http(s) 스킴·값 비노출 규칙이 두 변수 사이에서 어긋날 수 없다. 처음 PR
+     본문에 있던 인라인 구현은 스킴을 검사하지 않았고 `ERR_INVALID_URL`을 통째로 로그해 raw 값을 노출했다 —
+     독립 리뷰가 잡았다.
 - Reason: 실패 경로가 모두 닫히는데 한 곳만 열려 있으면 그 한 곳이 설정 실수의 출구가 된다. 비밀이 갈
   주소를 외부가 모양 지을 수 있는 헤더에서 유도할 이유는 없고, 운영은 이미 설정값에 의존하고 있다.
 - Rejected:
@@ -1249,7 +1255,11 @@
 - Consequence:
   - `NEXTAUTH_URL` 없는 배포(로컬 개발 포함)에서는 업로드가 503으로 거부된다. 문서상 필수 변수이므로 새 요구가
     아니라 기존 요구의 집행이다.
+  - Vercel Preview는 영향이 없다 — 2026-09-02 확인에서 Preview에도 `NEXTAUTH_URL`이 설정돼 있어 이 결정
+    전에도 fallback을 타지 않았다. `docs/vm-replacement.md`의 "Production 필수값" 표는 Preview에 없다는 뜻이 아니다.
   - `request.nextUrl`은 이 라우트에서 더 이상 읽지 않는다.
+  - `NEXTAUTH_URL`에 path 접두가 있으면(`https://host/app`) `/api/omr/finalize`가 그것을 덮어쓴다. 이 저장소는
+    basePath를 쓰지 않으므로 현재 영향은 없고, 이 결정 전에도 같았다.
 - Constraint: D-018의 나머지 결정(callback 인증, DB에서 읽은 `omrJobId`를 fetch target으로, 행 생성 전 검증)은
   바뀌지 않는다.
 - Confidence: high
@@ -1257,6 +1267,8 @@
 - Reversibility: clean
 - Directive: 콜백 주소나 그 밖에 공유 비밀이 향하는 주소를 요청 헤더에서 유도하지 않는다. 설정이 없으면 거부한다.
 - Tested: `npx jest src/app/api/omr/upload` — 회귀 2건(unset, blank)이 수정 전 `OMR_SERVICE_UNAVAILABLE`로 실패하고
-  수정 후 13/13 통과.
-- Not-tested: 운영 배포에서의 동작 변화 — `NEXTAUTH_URL`이 설정돼 있으므로 관측 가능한 차이가 없어야 한다.
+  수정 후 통과; 리뷰 후 스킴·자격증명 유출 회귀 2건이 인라인 구현에서 실패하고 헬퍼로 통과. `npx jest src/lib/omr`
+  `getOmrCallbackUrl` 11건. `vercel env ls production|preview`에 `NEXTAUTH_URL` 존재.
+- Not-tested: 운영 배포에서의 동작 변화 — 설정돼 있으므로 관측 가능한 차이가 없어야 한다. `vercel env ls`는 이름만
+  보여주므로 값이 `https://clairkeys.vercel.app`인지는 확인하지 않았다(값을 내려받지 않기로 했다).
 - Related: D-018, 이슈 [#71](https://github.com/landfill/ClairKeys/issues/71), PR #68 리뷰 R10

--- a/docs/recovery/DECISIONS.md
+++ b/docs/recovery/DECISIONS.md
@@ -365,8 +365,9 @@
     이미 배포되어 있다. 완료 사실만 알리는 데 새 자격증명이나 주기적 전수 조회가 필요하지 않다.
 - Decision:
   1. Next.js 업로드 경로가 `/process` multipart에 canonical callback URL을 함께 보낸다. URL은
-     `NEXTAUTH_URL`을 우선하고 없으면 현재 요청 origin을 쓰며, 행을 만들기 전에 절대 URL로
-     검증한다.
+     `NEXTAUTH_URL`에서만 온다. 행을 만들기 전에 절대 URL로 검증하며, 미설정·공백은 잘못된 URL과
+     같게 503 `OMR_CALLBACK_NOT_CONFIGURED`로 거부한다. *(2026-09-02 D-036으로 개정. 원문은
+     "없으면 현재 요청 origin을 쓴다"였다 — 이유는 D-036 참조.)*
   2. OMR 서비스는 변환 완료 뒤 callback에 `{job_id}`를 POST하고 기존 공유 비밀을
      `X-ClairKeys-Token`으로 보낸다. callback 실패는 지수 backoff로 12회 재시도한다.
   3. callback은 공유 비밀을 constant-time으로 검증하고, job id로 DB 행을 찾아 `/result`를
@@ -1214,3 +1215,48 @@
 - Tested: 코드·스키마·목록 응답 대조; DS-6 E2E fixture가 카드·상세·미리보기를 검증하도록 갱신됨.
 - Not-tested: duration 정규화 구현과 실제 배포본의 열거 방어; CI의 headless Web Audio 생성·resume은 5개 프로젝트에서 재생 상태를 증명하지 못하므로 실제 오디오 재생은 수동 확인으로 남긴다.
 - Related: DS-6, DS0-1, D-030, D-034, 이슈 [#76](https://github.com/landfill/ClairKeys/issues/76)
+
+## D-036: 콜백 주소는 설정에서만 오고, 미설정은 잘못된 설정과 같게 거부한다
+
+- Date: 2026-09-02
+- Status: Accepted — D-018 Decision 1의 fallback 절을 개정한다
+- Applies to: `src/app/api/omr/upload/route.ts`의 `callback_url` 구성
+- Context:
+  - D-018 Decision 1은 콜백 URL을 "`NEXTAUTH_URL`을 우선하고 없으면 현재 요청 origin"으로 정했다.
+    `request.nextUrl.origin`은 프록시가 전달한 Host 헤더에서 유도된다.
+  - OMR 서비스는 이 주소를 검증 없이 받아 `X-ClairKeys-Token`에 공유 비밀을 실어 POST한다
+    (`omr-service/app.py` `notify_completion`). 즉 이 fallback이 고르는 것은 **비밀이 전송될 주소**다.
+  - PR #68은 "callback authentication fails closed"를 원칙으로 세웠고 실제로 비밀 미설정은 503, 불일치는
+    401, 잘못된 URL은 503으로 닫힌다. 미설정 `NEXTAUTH_URL`만 조용히 추측하는 반대 방향이었다 (PR #68
+    리뷰 R10, 이슈 #71).
+  - 지금 열린 구멍은 아니다. `NEXTAUTH_URL`은 필수로 문서화돼 운영에 설정돼 있고(2026-08-28 종단 확인에서
+    콜백이 `https://clairkeys.vercel.app/api/omr/finalize`로 나감), `/process`는 공유 비밀 뒤에 있다.
+    설정 실수 증폭기이지 독립 취약점이 아니다.
+  - 업로드 라우트 테스트 11건 전부가 `NEXTAUTH_URL` 없이 통과하고 있었다 — 스위트가 줄곧 fallback 경로를
+    검증해 온 셈이다.
+- Decision:
+  1. 콜백 base URL은 `NEXTAUTH_URL`에서만 읽는다. 요청 origin으로 대체하지 않는다.
+  2. 미설정·공백은 잘못된 절대 URL과 같은 분기 — 503 `OMR_CALLBACK_NOT_CONFIGURED`, 행 생성 전 — 로
+     보낸다. 행 생성 전 검증이라는 D-018 Directive의 순서는 그대로다.
+  3. 업로드 라우트 테스트 fixture는 `NEXTAUTH_URL`을 명시한다. 설정 없는 성공 경로는 더 이상 존재하지 않는다.
+- Reason: 실패 경로가 모두 닫히는데 한 곳만 열려 있으면 그 한 곳이 설정 실수의 출구가 된다. 비밀이 갈
+  주소를 외부가 모양 지을 수 있는 헤더에서 유도할 이유는 없고, 운영은 이미 설정값에 의존하고 있다.
+- Rejected:
+  - `omr-service` `notify_completion`에서 콜백 호스트·스킴을 환경변수로 고정해 검증 (이슈 #71 선택 항목 2) |
+    이중 방어로 유효하나 `omr-service/` 변경은 이미지 재빌드·VM 배포 없이 완료를 주장할 수 없다. 이 결정의
+    범위 밖으로 남기며, 이슈 #71을 닫을 때 후속으로 분리한다.
+  - 미설정 시 경고 로그만 남기고 origin을 계속 사용 | fails-closed 원칙과 정반대이며 이슈가 지적한 상태 그대로다.
+- Consequence:
+  - `NEXTAUTH_URL` 없는 배포(로컬 개발 포함)에서는 업로드가 503으로 거부된다. 문서상 필수 변수이므로 새 요구가
+    아니라 기존 요구의 집행이다.
+  - `request.nextUrl`은 이 라우트에서 더 이상 읽지 않는다.
+- Constraint: D-018의 나머지 결정(callback 인증, DB에서 읽은 `omrJobId`를 fetch target으로, 행 생성 전 검증)은
+  바뀌지 않는다.
+- Confidence: high
+- Scope-risk: narrow
+- Reversibility: clean
+- Directive: 콜백 주소나 그 밖에 공유 비밀이 향하는 주소를 요청 헤더에서 유도하지 않는다. 설정이 없으면 거부한다.
+- Tested: `npx jest src/app/api/omr/upload` — 회귀 2건(unset, blank)이 수정 전 `OMR_SERVICE_UNAVAILABLE`로 실패하고
+  수정 후 13/13 통과.
+- Not-tested: 운영 배포에서의 동작 변화 — `NEXTAUTH_URL`이 설정돼 있으므로 관측 가능한 차이가 없어야 한다.
+- Related: D-018, 이슈 [#71](https://github.com/landfill/ClairKeys/issues/71), PR #68 리뷰 R10

--- a/src/app/api/omr/upload/__tests__/route.test.ts
+++ b/src/app/api/omr/upload/__tests__/route.test.ts
@@ -236,36 +236,36 @@ describe('POST /api/omr/upload — failure is visible, not silent', () => {
   it.each([
     ['unset', undefined],
     ['blank', '   '],
+    ['not an absolute URL', 'not an absolute URL'],
+    ['a non-HTTP scheme', 'ftp://app.example.test'],
+    ['carrying credentials and malformed', 'https://admin:hunter2@app.example.test with space'],
   ])('refuses before creating a row when NEXTAUTH_URL is %s', async (_label, value) => {
     // The shared secret travels to whatever address this route hands the
     // service. Guessing that address from the request Host header when the
-    // configuration is missing is the one place the callback chain failed
-    // open (issue #71); it now fails closed like an invalid URL does.
+    // configuration is missing was the one place the callback chain failed
+    // open (issue #71); missing, blank, malformed and non-HTTP values now take
+    // the same 503 before any row exists (D-036).
     process.env.OMR_SERVICE_URL = 'https://omr.example.invalid'
     if (value === undefined) delete process.env.NEXTAUTH_URL
     else process.env.NEXTAUTH_URL = value
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
 
-    const { POST } = await loadRoute()
-    const response = await POST(uploadRequest())
-    const data = await response.json()
+    try {
+      const { POST } = await loadRoute()
+      const response = await POST(uploadRequest())
+      const data = await response.json()
 
-    expect(response.status).toBe(503)
-    expect(data.code).toBe('OMR_CALLBACK_NOT_CONFIGURED')
-    expect(mockCreate).not.toHaveBeenCalled()
-    expect(fetchSpy).not.toHaveBeenCalled()
-  })
-
-  it('refuses an invalid public app URL before creating a row', async () => {
-    process.env.OMR_SERVICE_URL = 'https://omr.example.invalid'
-    process.env.NEXTAUTH_URL = 'not an absolute URL'
-
-    const { POST } = await loadRoute()
-    const response = await POST(uploadRequest())
-    const data = await response.json()
-
-    expect(response.status).toBe(503)
-    expect(data.code).toBe('OMR_CALLBACK_NOT_CONFIGURED')
-    expect(mockCreate).not.toHaveBeenCalled()
-    expect(fetchSpy).not.toHaveBeenCalled()
+      expect(response.status).toBe(503)
+      expect(data.code).toBe('OMR_CALLBACK_NOT_CONFIGURED')
+      expect(mockCreate).not.toHaveBeenCalled()
+      expect(fetchSpy).not.toHaveBeenCalled()
+      // A URL can carry credentials; the log must diagnose the problem
+      // without echoing the value.
+      const logged = JSON.stringify(consoleError.mock.calls)
+      expect(logged).not.toContain('hunter2')
+      expect(logged).not.toContain('with space')
+    } finally {
+      consoleError.mockRestore()
+    }
   })
 })

--- a/src/app/api/omr/upload/__tests__/route.test.ts
+++ b/src/app/api/omr/upload/__tests__/route.test.ts
@@ -84,6 +84,9 @@ describe('POST /api/omr/upload — failure is visible, not silent', () => {
     } as never)
     mockCreate.mockResolvedValue({ id: CREATED_ROW_ID } as never)
     mockUpdate.mockResolvedValue({ id: CREATED_ROW_ID } as never)
+    // The callback address is configuration, not something derived from the
+    // request (D-036). Every case that reaches the service needs it set.
+    process.env.NEXTAUTH_URL = 'https://app.example.test'
     fetchSpy = jest.spyOn(global, 'fetch')
   })
 
@@ -226,8 +229,30 @@ describe('POST /api/omr/upload — failure is visible, not silent', () => {
     expect(response.status).toBe(200)
     const [, requestInit] = fetchSpy.mock.calls[0]
     expect((requestInit?.body as FormData).get('callback_url')).toBe(
-      'http://localhost:3000/api/omr/finalize'
+      'https://app.example.test/api/omr/finalize'
     )
+  })
+
+  it.each([
+    ['unset', undefined],
+    ['blank', '   '],
+  ])('refuses before creating a row when NEXTAUTH_URL is %s', async (_label, value) => {
+    // The shared secret travels to whatever address this route hands the
+    // service. Guessing that address from the request Host header when the
+    // configuration is missing is the one place the callback chain failed
+    // open (issue #71); it now fails closed like an invalid URL does.
+    process.env.OMR_SERVICE_URL = 'https://omr.example.invalid'
+    if (value === undefined) delete process.env.NEXTAUTH_URL
+    else process.env.NEXTAUTH_URL = value
+
+    const { POST } = await loadRoute()
+    const response = await POST(uploadRequest())
+    const data = await response.json()
+
+    expect(response.status).toBe(503)
+    expect(data.code).toBe('OMR_CALLBACK_NOT_CONFIGURED')
+    expect(mockCreate).not.toHaveBeenCalled()
+    expect(fetchSpy).not.toHaveBeenCalled()
   })
 
   it('refuses an invalid public app URL before creating a row', async () => {

--- a/src/app/api/omr/upload/route.ts
+++ b/src/app/api/omr/upload/route.ts
@@ -2,7 +2,13 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth/config'
 import { prisma } from '@/lib/prisma'
-import { getOmrServiceUrl, omrAuthHeaders, OmrServiceNotConfiguredError } from '@/lib/omr/serviceUrl'
+import {
+  getOmrCallbackUrl,
+  getOmrServiceUrl,
+  omrAuthHeaders,
+  OmrCallbackNotConfiguredError,
+  OmrServiceNotConfiguredError
+} from '@/lib/omr/serviceUrl'
 import { MAX_UPLOAD_BYTES, MAX_UPLOAD_MB } from '@/lib/upload/pdfInspection'
 
 /**
@@ -130,32 +136,22 @@ export async function POST(request: NextRequest) {
     // Resolve the callback before creating a row for the same reason as the
     // service URL above: a malformed deployment URL is knowable now, while a
     // row created first would have no job and no trigger capable of moving it.
-    //
-    // The address comes from configuration only. The service will POST the
-    // shared secret to whatever we hand it, and the request Host header is
-    // the one input here an outside party can shape — so an unset value is
-    // refused the same way an invalid one is (D-036, issue #71).
-    const callbackNotConfigured = () =>
-      NextResponse.json(
+    // The address comes from configuration only (D-036, issue #71); the helper
+    // states why and refuses a missing value the same way as a malformed one.
+    let callbackUrl: string
+    try {
+      callbackUrl = getOmrCallbackUrl()
+    } catch (error) {
+      if (!(error instanceof OmrCallbackNotConfiguredError)) throw error
+
+      console.error('OMR callback refused:', error.message)
+      return NextResponse.json(
         {
           error: '완료 알림 주소가 설정되지 않았습니다. 관리자에게 문의해 주세요.',
           code: 'OMR_CALLBACK_NOT_CONFIGURED'
         },
         { status: 503 }
       )
-
-    const callbackBaseUrl = process.env.NEXTAUTH_URL?.trim()
-    if (!callbackBaseUrl) {
-      console.error('OMR callback refused: NEXTAUTH_URL is not set')
-      return callbackNotConfigured()
-    }
-
-    let callbackUrl: string
-    try {
-      callbackUrl = new URL('/api/omr/finalize', callbackBaseUrl).toString()
-    } catch (error) {
-      console.error('OMR callback refused: public application URL is invalid', error)
-      return callbackNotConfigured()
     }
 
     // Create sheet music record in database with pending status

--- a/src/app/api/omr/upload/route.ts
+++ b/src/app/api/omr/upload/route.ts
@@ -130,19 +130,32 @@ export async function POST(request: NextRequest) {
     // Resolve the callback before creating a row for the same reason as the
     // service URL above: a malformed deployment URL is knowable now, while a
     // row created first would have no job and no trigger capable of moving it.
-    let callbackUrl: string
-    try {
-      const callbackBaseUrl = process.env.NEXTAUTH_URL?.trim() || request.nextUrl.origin
-      callbackUrl = new URL('/api/omr/finalize', callbackBaseUrl).toString()
-    } catch (error) {
-      console.error('OMR callback refused: public application URL is invalid', error)
-      return NextResponse.json(
+    //
+    // The address comes from configuration only. The service will POST the
+    // shared secret to whatever we hand it, and the request Host header is
+    // the one input here an outside party can shape — so an unset value is
+    // refused the same way an invalid one is (D-036, issue #71).
+    const callbackNotConfigured = () =>
+      NextResponse.json(
         {
           error: '완료 알림 주소가 설정되지 않았습니다. 관리자에게 문의해 주세요.',
           code: 'OMR_CALLBACK_NOT_CONFIGURED'
         },
         { status: 503 }
       )
+
+    const callbackBaseUrl = process.env.NEXTAUTH_URL?.trim()
+    if (!callbackBaseUrl) {
+      console.error('OMR callback refused: NEXTAUTH_URL is not set')
+      return callbackNotConfigured()
+    }
+
+    let callbackUrl: string
+    try {
+      callbackUrl = new URL('/api/omr/finalize', callbackBaseUrl).toString()
+    } catch (error) {
+      console.error('OMR callback refused: public application URL is invalid', error)
+      return callbackNotConfigured()
     }
 
     // Create sheet music record in database with pending status

--- a/src/lib/omr/__tests__/serviceUrl.test.ts
+++ b/src/lib/omr/__tests__/serviceUrl.test.ts
@@ -1,7 +1,12 @@
 /**
  * @jest-environment node
  */
-import { getOmrServiceUrl, OmrServiceNotConfiguredError } from '../serviceUrl'
+import {
+  getOmrCallbackUrl,
+  getOmrServiceUrl,
+  OmrCallbackNotConfiguredError,
+  OmrServiceNotConfiguredError,
+} from '../serviceUrl'
 
 /**
  * `OMR_SERVICE_URL` is typed into a Vercel dashboard by a person, so the
@@ -100,5 +105,60 @@ describe('getOmrServiceUrl', () => {
         expect(message).not.toContain('101.79.16.73')
       }
     })
+  })
+})
+
+describe('getOmrCallbackUrl', () => {
+  /**
+   * The OMR service POSTs the shared secret to whatever address this returns,
+   * so the address has to come from configuration alone (D-036). The rules
+   * are the ones `getOmrServiceUrl` already applies — trim, absolute, http or
+   * https, and never echo the value — and they live in one place so the two
+   * cannot drift apart.
+   */
+  const original = process.env.NEXTAUTH_URL
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.NEXTAUTH_URL
+    else process.env.NEXTAUTH_URL = original
+  })
+
+  it('builds the finalize route on the configured origin', () => {
+    process.env.NEXTAUTH_URL = 'https://clairkeys.vercel.app'
+    expect(getOmrCallbackUrl()).toBe('https://clairkeys.vercel.app/api/omr/finalize')
+  })
+
+  it('trims whitespace and tolerates a trailing slash', () => {
+    process.env.NEXTAUTH_URL = '  https://clairkeys.vercel.app/  '
+    expect(getOmrCallbackUrl()).toBe('https://clairkeys.vercel.app/api/omr/finalize')
+  })
+
+  it.each([
+    ['unset', undefined],
+    ['whitespace only', '   '],
+    ['a bare path', '/'],
+    ['a host with no scheme', 'clairkeys.vercel.app'],
+    ['a non-HTTP scheme', 'ftp://clairkeys.vercel.app'],
+    ['a websocket scheme', 'ws://clairkeys.vercel.app'],
+    ['a file URL', 'file:///tmp'],
+  ])('throws OmrCallbackNotConfiguredError for %s', (_label, value) => {
+    if (value === undefined) delete process.env.NEXTAUTH_URL
+    else process.env.NEXTAUTH_URL = value
+
+    expect(() => getOmrCallbackUrl()).toThrow(OmrCallbackNotConfiguredError)
+  })
+
+  it('omits userinfo from the message', () => {
+    process.env.NEXTAUTH_URL = 'ftp://admin:hunter2@clairkeys.vercel.app'
+
+    try {
+      getOmrCallbackUrl()
+      throw new Error('expected getOmrCallbackUrl to throw')
+    } catch (error) {
+      expect(error).toBeInstanceOf(OmrCallbackNotConfiguredError)
+      const message = (error as Error).message
+      expect(message).not.toContain('hunter2')
+      expect(message).not.toContain('admin')
+    }
   })
 })

--- a/src/lib/omr/serviceUrl.ts
+++ b/src/lib/omr/serviceUrl.ts
@@ -27,6 +27,35 @@ export class OmrServiceNotConfiguredError extends Error {
   }
 }
 
+/**
+ * Why a configured URL is unusable, phrased for the operator and never
+ * carrying the value. The caller turns it into its own error class.
+ */
+type HttpUrlProblem = 'not-absolute' | `scheme:${string}`
+
+/**
+ * Parses a value typed into a deployment dashboard as an absolute http(s)
+ * URL. Shared by every variable that names an address this application will
+ * send something to, so the rules cannot drift between them.
+ */
+function parseHttpUrl(value: string): { url: URL } | { problem: HttpUrlProblem } {
+  let parsed: URL
+  try {
+    parsed = new URL(value)
+  } catch {
+    return { problem: 'not-absolute' }
+  }
+
+  // Parsing alone is not enough. `new URL('example.com:3000')` succeeds by
+  // reading `example.com:` as the scheme, so a hostname typed without one can
+  // arrive here looking well formed and then fail at `fetch`.
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return { problem: `scheme:${parsed.protocol}` }
+  }
+
+  return { url: parsed }
+}
+
 export function getOmrServiceUrl(): string {
   const configured = process.env.OMR_SERVICE_URL?.trim()
 
@@ -34,29 +63,55 @@ export function getOmrServiceUrl(): string {
     throw new OmrServiceNotConfiguredError()
   }
 
-  let parsed: URL
-  try {
-    parsed = new URL(configured)
-  } catch {
+  const result = parseHttpUrl(configured)
+  if ('problem' in result) {
     // Deliberately without the value. The caller logs this error and echoes its
     // message in development, and a URL can carry credentials — putting the raw
     // value here would put a password in a log to diagnose a typo.
     throw new OmrServiceNotConfiguredError(
-      'OMR_SERVICE_URL is not an absolute URL. It must include a scheme, ' +
-        'for example http://host:port.'
-    )
-  }
-
-  // Parsing alone is not enough. `new URL('example.com:3000')` succeeds by
-  // reading `example.com:` as the scheme, so a hostname typed without one can
-  // arrive here looking well formed and then fail at `fetch`.
-  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-    throw new OmrServiceNotConfiguredError(
-      `OMR_SERVICE_URL must use http: or https:, not ${parsed.protocol}`
+      result.problem === 'not-absolute'
+        ? 'OMR_SERVICE_URL is not an absolute URL. It must include a scheme, ' +
+            'for example http://host:port.'
+        : `OMR_SERVICE_URL must use http: or https:, not ${result.problem.slice('scheme:'.length)}`
     )
   }
 
   return configured.replace(/\/+$/, '')
+}
+
+/**
+ * The upload route hands this address to the OMR service, and the service
+ * POSTs the shared secret to it when a job completes. D-036: it comes from
+ * configuration only — never from the request, whose Host header is the one
+ * input here an outside party can shape — and a missing value is refused the
+ * same way a malformed one is. The rules are the ones `getOmrServiceUrl`
+ * applies, for the same reasons.
+ */
+export class OmrCallbackNotConfiguredError extends Error {
+  constructor(reason = 'NEXTAUTH_URL is not set.') {
+    super(`${reason} The conversion callback address is not configured for this deployment.`)
+    this.name = 'OmrCallbackNotConfiguredError'
+  }
+}
+
+export function getOmrCallbackUrl(): string {
+  const configured = process.env.NEXTAUTH_URL?.trim()
+
+  if (!configured) {
+    throw new OmrCallbackNotConfiguredError()
+  }
+
+  const result = parseHttpUrl(configured)
+  if ('problem' in result) {
+    throw new OmrCallbackNotConfiguredError(
+      result.problem === 'not-absolute'
+        ? 'NEXTAUTH_URL is not an absolute URL. It must include a scheme, ' +
+            'for example https://host.'
+        : `NEXTAUTH_URL must use http: or https:, not ${result.problem.slice('scheme:'.length)}`
+    )
+  }
+
+  return new URL('/api/omr/finalize', result.url).toString()
 }
 
 /**


### PR DESCRIPTION
## 목적

`NEXTAUTH_URL`이 비어 있을 때 콜백 주소를 요청 origin에서 유도하던 fallback을 제거하고, 미설정을 잘못된 URL과
같게 503 `OMR_CALLBACK_NOT_CONFIGURED`로 거부합니다 (PR #68 리뷰 R10). Closes #71.

**이 PR은 결정을 바꿉니다.** D-018 Decision 1이 그 fallback을 명시하고 있었으므로, AGENTS.md 규약에 따라
`DECISIONS.md` 개정(D-018 제자리 표기 + 새 D-036)을 코드와 같은 커밋에 넣었습니다.

## 변경 범위

- `src/app/api/omr/upload/route.ts` — `NEXTAUTH_URL?.trim()`이 비면 행 생성 전에 503. `request.nextUrl`은 더 이상
  읽지 않습니다. 잘못된 URL 분기와 같은 응답을 공유합니다.
- `docs/recovery/DECISIONS.md` — D-018 Decision 1을 개정 표기, D-036 추가(맥락·기각 대안·Directive 포함).
- 테스트 — fixture가 `NEXTAUTH_URL`을 명시합니다. **기존 11건이 전부 `NEXTAUTH_URL` 없이 통과하고 있었다**는 건
  스위트가 줄곧 fallback 경로를 검증해 왔다는 뜻이라, 이 변경의 자연스러운 결과입니다. 회귀 2건(unset, blank)은
  수정 전 `OMR_SERVICE_UNAVAILABLE`(행 생성 후)로 실패를 관측했습니다(`dea17cc`) → 수정(`dd6f62b`).

## 제외 범위

- 이슈 #71 선택 항목 2 — `omr-service` `notify_completion`의 호스트·스킴 검증. 이중 방어로 유효하지만
  `omr-service/` 변경은 이미지 재빌드·VM 배포 없이 완료를 주장할 수 없습니다. D-036 Rejected에 기록했고 #71을
  닫을 때 후속 이슈로 분리합니다.

## 위험과 방어

- `NEXTAUTH_URL` 없는 배포에서는 업로드가 503으로 거부됩니다. 문서상 필수 변수이고 운영에 설정돼 있으며
  (2026-08-28 종단 확인), CI 워크플로 5곳 모두 `NEXTAUTH_URL=http://localhost:3000`을 설정하므로 hosted E2E에
  영향이 없습니다.
- 지금 열린 구멍은 아니었습니다 — `/process`는 공유 비밀 뒤에 있습니다. 설정 실수 증폭기를 제거하는 것입니다.

## 검증

- `npx jest src/app/api/omr/upload`: 13/13 PASS (11 → 13)
- `npm test -- --runInBand`: 85 suites / 781 tests PASS (778 → 781)
- `npx tsc --noEmit`: exit 0
- `npm run lint`: No ESLint warnings or errors
- `npm run build`: PASS
- `git diff --check`: PASS

## 기준선 차이

새 실패 없음.

## Rollback

`dd6f62b` revert로 라우트와 D-018 원문이 돌아옵니다. 회귀 `dea17cc`의 두 케이스는 그 경우 다시 실패하므로 함께
revert합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * OMR 업로드 완료 콜백 주소를 설정된 `NEXTAUTH_URL`에서만 생성하도록 변경했습니다.
  * 설정이 없거나 공백·잘못된 URL인 경우 업로드를 진행하지 않고 503 오류를 반환합니다.
  * 콜백 주소가 현재 요청의 출처로 자동 대체되지 않습니다.
  * 관련 동작과 설정 요구사항을 문서화하고 테스트를 보강했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->