### PR TITLE
검은건반을 실제 피아노 기하로 그린다 (이슈 #58)

### DIFF
--- a/docs/recovery/DECISIONS.md
+++ b/docs/recovery/DECISIONS.md
@@ -1272,3 +1272,70 @@
 - Not-tested: 운영 배포에서의 동작 변화 — 설정돼 있으므로 관측 가능한 차이가 없어야 한다. `vercel env ls`는 이름만
   보여주므로 값이 `https://clairkeys.vercel.app`인지는 확인하지 않았다(값을 내려받지 않기로 했다).
 - Related: D-018, 이슈 [#71](https://github.com/landfill/ClairKeys/issues/71), PR #68 리뷰 R10
+
+## D-037: 검은건반 기하는 표준 치수에서 유도하고, 유도 공식을 코드에 남긴다
+
+- Date: 2026-09-02
+- Status: Accepted
+- Fulfills: 이슈 [#58](https://github.com/landfill/ClairKeys/issues/58) 할 일 1 (기준 결정)
+- Context:
+  - 이슈 [#56](https://github.com/landfill/ClairKeys/issues/56)을 PR #57이 고칠 때, spec에는 "표의 값 자체는
+    실제 피아노의 비대칭 배치를 올바르게 반영하므로 버리지 말 것"이라고 적혀 있었다. **이 주장이 틀렸다는 것이
+    #56 검증 과정에서 드러났고, 이슈 #58이 그 사실만 분리해 기록했다.**
+  - `pianoLayout.ts`의 오프셋 `{C# 0.65, D# 0.6, F# 0.65, G# 0.6, A# 0.6}`은 다섯 개 전부에 −0.05~−0.10칸의
+    **균일한 좌측 편향**을 준다. 실제 피아노는 2건반 그룹과 3건반 그룹이 각각 바깥으로 벌어지는 대칭 패턴이므로
+    **D#·A#는 방향이 반대**이고 G#는 경계에 정확히 놓여야 한다. 흑건 폭도 0.6이 아니라 0.583이다.
+  - 2026-09-02 이 결정을 위해 표준 치수(백건 23.5mm, 흑건 13.7mm)로 독립 재계산해 이슈의 표를 재현했다.
+    G#의 편차가 정확히 0이 나오는 것이 이 모델이 자기정합적이라는 근거다 — 3흑건 그룹의 대칭축이기 때문이다.
+  - 기존 테스트 `pianoLayout.test.ts`의 유일한 흑건 위치 검사는 `|중심 − 경계| ≤ 0.35 * keyWidth`라는
+    **절대값 상한**이었다. 부호를 보지 않으므로 방향이 반대인 값도 통과한다.
+  - 이슈 본문은 `PianoKeyboard.tsx`를 "모바일 전체화면·가로모드·데모가 사용"한다고 적었으나, **현재
+    코드베이스에서 그 컴포넌트는 라우트에서 도달할 수 없다.** 유일한 소비자인 `FullScreenPiano.tsx`와
+    `LandscapePianoInterface.tsx`를 import하는 파일이 0개다(README 재작성이 확인한 `src/components/mobile/*`
+    미도달과 같은 사실). 실제 재생 경로는 `FallingNotesPlayer` → `SimplePianoKeyboard` → `buildKeyLayout()`
+    하나뿐이다.
+  - 흑건 오프셋과 흑건 폭은 DS-0 "변경하지 않을 회귀 계약"의 고정 상수 7개에 **포함되지 않는다.** 다만 그 절이
+    `pianoLayout.ts`를 명시하므로 D-024에 따라 결정을 먼저 기록한다.
+- Decision:
+  1. **기준은 표준 피아노 치수 백건 23.5mm · 흑건 13.7mm다.** 흑건 폭 비율 `BLACK_KEY_WIDTH_RATIO`는
+     `13.7 / 23.5`로 정의한다.
+  2. **오프셋은 상수로 적지 않고 유도 함수로 계산한다.** 그룹 내 흰건반의 후면 폭이 균등하다는 가정에서
+     `blackKeyLeftOffset(whites, blacks, index)`가 왼쪽 인접 백건 기준 좌변 오프셋을 낸다. 결과는
+     C# 0.611, D# 0.806, F# 0.563, G# 0.709, A# 0.854다.
+  3. **회귀는 방향 불변식으로 건다.** C#·F#는 경계보다 왼쪽, D#·A#는 오른쪽, G#는 경계와 일치. 테스트는
+     기대값을 **구현에서 import하지 않고 표준 치수에서 직접 유도한다.**
+  4. **이 결정의 범위는 `pianoLayout.ts`와 그 파생값 하나(`SimplePianoKeyboard`의 장식 축척 기준 폭)뿐이다.**
+     이슈 #58 할 일 3(`PianoKeyboard.tsx` 통일)은 그 파일이 죽은 코드이므로 수행하지 않고, HANDOFF의 P2-A
+     죽은 코드 정리로 이관한다.
+- Reason: 값을 세 자리 소수로 적어 두면 다음 세션이 그것을 취향으로 읽고, 이슈 #56의 spec처럼 "이 표는 맞다"는
+  근거 없는 주장이 다시 붙는다. 유도 공식이 코드에 있으면 실제 악기로 검산할 수 있다. 방향 불변식을 절대값
+  상한 대신 쓰는 이유도 같다 — 크기는 취향일 수 있어도 방향은 사실이다.
+- Rejected:
+  - 이슈에 적힌 소수 3자리를 상수로 하드코딩 | 값의 출처가 주석에만 남아, 다음 변경에서 검산 없이 조정된다.
+  - `PianoKeyboard.tsx`를 같은 PR에서 통일 | 라우트에서 도달할 수 없어 회귀를 관측할 수 없고, AGENTS.md의
+    "한 PR에는 하나의 목적"과 충돌한다. 죽은 코드는 통일이 아니라 제거가 맞는 처리다.
+  - 같은 PR에서 죽은 코드 3개 파일 삭제 | 기하 수정과 성격이 다른 변경이라 회귀 원인 분리가 어려워진다.
+  - 기존 `|중심 − 경계| ≤ 0.35` 상한을 조이는 것으로 대체 | 부호를 보지 않는 한 방향 오류는 어떤 상한으로도
+    관측되지 않는다.
+- Consequence:
+  - 흑건이 시각적으로 약 0.1~0.15칸(keyWidth 24에서 2.4~3.5px) 움직이고 폭이 0.4px 좁아진다. `PX_PER_SEC`,
+    `BASE_PLAYBACK_KEY_WIDTH` 등 DS-0 고정 상수 7개는 **한 픽셀도 바뀌지 않는다.**
+  - 낙하 노트의 x는 `buildKeyLayout`에서 오므로 흑건 노트의 낙하 위치도 함께 이동한다. 건반과 노트가 같은
+    출처를 쓰므로 둘은 계속 정렬된다.
+  - `SimplePianoKeyboard`의 장식 축척 기준값 `14.4`(= 24 × 0.6)가 더 이상 흑건 폭과 같지 않게 되므로
+    파생식으로 바꿨다. 이런 파생 상수가 다른 곳에 또 있으면 같은 방식으로 처리한다.
+  - `PianoKeyboard.tsx`는 여전히 실제와 2배 이상 과장된 편차를 그린다. 도달 불가이므로 사용자에게는 보이지
+    않지만, **되살릴 때는 반드시 이 결정에 맞춰야 한다.**
+- Constraint: DS-0 "변경하지 않을 회귀 계약"의 재생 기하 상수 7개와 크롭 불변식은 이 결정의 대상이 아니다.
+- Confidence: high
+- Scope-risk: narrow
+- Reversibility: clean
+- Directive: 흑건 오프셋과 폭을 조정할 때 숫자를 직접 고치지 않는다. `WHITE_KEY_MM`·`BLACK_KEY_MM` 또는 유도
+  가정을 고치고, 방향 불변식을 통과하는지 확인한다. `PianoKeyboard.tsx`를 되살린다면 같은 유도를 쓴다.
+- Tested: 회귀 3건이 수정 전 실패(방향·오프셋·흑건 폭)하고 수정 후 통과하는 것을 관측했다. 전체 Jest
+  85 suites / 796 tests, `tsc --noEmit`, `npm run lint` 통과.
+- Not-tested: 실제 브라우저·실기기에서의 시각 확인. 변경 폭이 2~4px이라 회귀 테스트가 좌표를 판정하고 육안
+  판정은 하지 않았다. `PianoKeyboard.tsx` 경로는 도달 불가라 실행되지 않는다.
+- Related: 이슈 [#58](https://github.com/landfill/ClairKeys/issues/58),
+  [#56](https://github.com/landfill/ClairKeys/issues/56), PR #57, D-024,
+  `docs/recovery/phases/DS-0-current-state-baseline.md`

--- a/src/components/piano/SimplePianoKeyboard.tsx
+++ b/src/components/piano/SimplePianoKeyboard.tsx
@@ -3,6 +3,10 @@
 import React from 'react'
 import type { SimplePianoKeyboardProps } from '@/types/fallingNotes'
 import { Z_INDICES } from '@/utils/visualUtils'
+import {
+  BASE_PLAYBACK_KEY_WIDTH,
+  BLACK_KEY_WIDTH_RATIO
+} from '@/utils/pianoLayout'
 
 /**
  * Simple Piano Keyboard Component (HTML/CSS based)
@@ -16,8 +20,16 @@ export default function SimplePianoKeyboard({
 }: SimplePianoKeyboardProps) {
   const { byMidi, totalWidth } = layout;
 
+  // Borders and shadows shrink with the keys. The reference widths are the ones
+  // a key has at the base density, so they are derived rather than written out —
+  // a literal here silently stops matching when the black-key ratio changes.
+  const referenceWidth = (black: boolean) =>
+    black
+      ? BASE_PLAYBACK_KEY_WIDTH * BLACK_KEY_WIDTH_RATIO
+      : BASE_PLAYBACK_KEY_WIDTH;
+
   const decorationScale = (width: number, black: boolean) =>
-    Math.min(1, width / (black ? 14.4 : 24));
+    Math.min(1, width / referenceWidth(black));
 
   return (
     <div 

--- a/src/utils/__tests__/pianoLayout.test.ts
+++ b/src/utils/__tests__/pianoLayout.test.ts
@@ -5,6 +5,36 @@ import type { FallingNote, KeyLayout } from '@/types/fallingNotes';
 const KEY_WIDTH = 20;
 const BLACK_KEY_PITCH_CLASSES = new Set([1, 3, 6, 8, 10]);
 
+/**
+ * Standard piano dimensions, restated here rather than imported. Deriving the
+ * expectation from the implementation's own constants would only prove that the
+ * implementation equals itself.
+ */
+const WHITE_KEY_MM = 23.5;
+const BLACK_KEY_MM = 13.7;
+const BLACK_WIDTH = BLACK_KEY_MM / WHITE_KEY_MM;
+
+/**
+ * Where a black key's centre sits relative to the boundary of the two white
+ * keys it divides, in white-key widths. Positive is right of the boundary.
+ *
+ * Within a group the white key's back portions are equal, so the k-th black key
+ * of a group with `whites` white keys and `blacks` black keys has its centre at
+ * `k * t + (k - 0.5) * B` where `t = 1 - blacks * B / whites`. Subtracting the
+ * boundary at `k` leaves `B * ((k - 0.5) - k * blacks / whites)`.
+ */
+const centerDeviation = (whites: number, blacks: number, k: number) =>
+  BLACK_WIDTH * (k - 0.5 - (k * blacks) / whites);
+
+/** pitch class -> [white keys in group, black keys in group, index in group] */
+const BLACK_KEY_GROUP_POSITION: Record<number, [number, number, number]> = {
+  1: [3, 2, 1],   // C#
+  3: [3, 2, 2],   // D#
+  6: [4, 3, 1],   // F#
+  8: [4, 3, 2],   // G#
+  10: [4, 3, 3]   // A#
+};
+
 describe('buildKeyLayout', () => {
   const layout = buildKeyLayout(KEY_WIDTH);
   const keys = [...layout.byMidi.entries()].map(([midi, position]) => ({
@@ -46,6 +76,49 @@ describe('buildKeyLayout', () => {
         KEY_WIDTH * 0.35
       );
       expect(rightWhiteKey!.x).toBe(boundary);
+    }
+  });
+
+  it('leans each black key the way a real piano does', () => {
+    const boundaryOf = (blackKey: { midi: number }) => {
+      const leftWhiteKey = layout.byMidi.get(blackKey.midi - 1)!;
+      return leftWhiteKey.x + leftWhiteKey.w;
+    };
+    const deviationOf = (blackKey: { midi: number; x: number; w: number }) =>
+      blackKey.x + blackKey.w / 2 - boundaryOf(blackKey);
+
+    for (const blackKey of blackKeys) {
+      const pitchClass = blackKey.midi % 12;
+      const deviation = deviationOf(blackKey);
+
+      if (pitchClass === 1 || pitchClass === 6) {
+        // C#, F# sit left of the boundary.
+        expect(deviation).toBeLessThan(0);
+      } else if (pitchClass === 3 || pitchClass === 10) {
+        // D#, A# sit right of it — the direction the old table had backwards.
+        expect(deviation).toBeGreaterThan(0);
+      } else {
+        // G# is the axis of the three-black-key group and lands on it.
+        expect(deviation).toBeCloseTo(0, 6);
+      }
+    }
+  });
+
+  it('places black keys at the offsets standard piano dimensions imply', () => {
+    for (const blackKey of blackKeys) {
+      const leftWhiteKey = layout.byMidi.get(blackKey.midi - 1)!;
+      const boundary = leftWhiteKey.x + leftWhiteKey.w;
+      const [whites, blacks, index] =
+        BLACK_KEY_GROUP_POSITION[blackKey.midi % 12];
+
+      const expected = centerDeviation(whites, blacks, index) * KEY_WIDTH;
+      expect(blackKey.x + blackKey.w / 2 - boundary).toBeCloseTo(expected, 6);
+    }
+  });
+
+  it('gives every black key the real black-key width', () => {
+    for (const blackKey of blackKeys) {
+      expect(blackKey.w).toBeCloseTo(BLACK_WIDTH * KEY_WIDTH, 6);
     }
   });
 

--- a/src/utils/pianoLayout.ts
+++ b/src/utils/pianoLayout.ts
@@ -50,8 +50,15 @@ function blackKeyLeftOffset(whites: number, blacks: number, index: number): numb
   return index * backWhiteWidth + (index - 1) * BLACK_KEY_WIDTH_RATIO - (index - 1);
 }
 
-/** pitch class -> [white keys in group, black keys in group, index in group] */
-const BLACK_KEY_GROUP_POSITION: Record<number, [number, number, number]> = {
+type BlackPitchClass = 1 | 3 | 6 | 8 | 10;
+
+/**
+ * pitch class -> [white keys in group, black keys in group, index in group]
+ *
+ * Keyed by the black pitch classes exactly, so the table and `isBlack` cannot
+ * disagree about which notes are black without failing to compile.
+ */
+const BLACK_KEY_GROUP_POSITION: Record<BlackPitchClass, [number, number, number]> = {
   1: [3, 2, 1],   // C#
   3: [3, 2, 2],   // D#
   6: [4, 3, 1],   // F#
@@ -108,17 +115,15 @@ export function buildKeyLayout(
     const black = isBlack(midi);
     
     if (black) {
-      const pitchClass = midi % 12;
+      // Safe because isBlack() admits exactly the five keys of the table.
+      const pitchClass = (midi % 12) as BlackPitchClass;
 
       // Find the white key to the left
       const leftWhiteKeys = keys.filter(k => !k.black && k.midi < midi);
       const leftWhiteIndex = leftWhiteKeys.length - 1;
       const baseX = Math.max(0, leftWhiteIndex) * keyWidth;
 
-      const groupPosition = BLACK_KEY_GROUP_POSITION[pitchClass];
-      const offset = groupPosition
-        ? blackKeyLeftOffset(...groupPosition)
-        : 0.5;
+      const offset = blackKeyLeftOffset(...BLACK_KEY_GROUP_POSITION[pitchClass]);
 
       const x = baseX + offset * keyWidth;
       keys.push({ midi, black: true, x, w: keyWidth * BLACK_KEY_WIDTH_RATIO });

--- a/src/utils/pianoLayout.ts
+++ b/src/utils/pianoLayout.ts
@@ -17,6 +17,48 @@ export const TOTAL_KEYS = C8_MIDI - A0_MIDI + 1; // 88 keys
  */
 export const BASE_PLAYBACK_KEY_WIDTH = 24;
 
+/**
+ * Standard piano key widths. Every black-key dimension below is derived from
+ * these two numbers rather than written out, so the geometry can be checked
+ * against a real instrument instead of taken on faith (D-037, issue #58).
+ */
+const WHITE_KEY_MM = 23.5;
+const BLACK_KEY_MM = 13.7;
+
+/** Black-key width in white-key widths. */
+export const BLACK_KEY_WIDTH_RATIO = BLACK_KEY_MM / WHITE_KEY_MM;
+
+/**
+ * Left edge of each black key, measured from the left edge of the white key
+ * immediately below it, in white-key widths.
+ *
+ * A black key does not sit on the boundary between its neighbours. Within a
+ * group the portions of white key left visible between the black keys are
+ * equal, so a group of `whites` white keys and `blacks` black keys leaves each
+ * white key a back portion of `1 - blacks * BLACK_KEY_WIDTH_RATIO / whites`,
+ * and the k-th black key of the group starts after k of those portions and
+ * k-1 black keys. Subtracting the k-1 whole white keys already counted in the
+ * caller's base position rebases that onto the white key below.
+ *
+ * The result is the pattern a real piano has: the two- and three-key groups
+ * each splay outwards from their own centre. C# and F# lean left, D# and A#
+ * lean right, and G# — the axis of the three-key group — lands on its boundary
+ * exactly.
+ */
+function blackKeyLeftOffset(whites: number, blacks: number, index: number): number {
+  const backWhiteWidth = 1 - (blacks * BLACK_KEY_WIDTH_RATIO) / whites;
+  return index * backWhiteWidth + (index - 1) * BLACK_KEY_WIDTH_RATIO - (index - 1);
+}
+
+/** pitch class -> [white keys in group, black keys in group, index in group] */
+const BLACK_KEY_GROUP_POSITION: Record<number, [number, number, number]> = {
+  1: [3, 2, 1],   // C#
+  3: [3, 2, 2],   // D#
+  6: [4, 3, 1],   // F#
+  8: [4, 3, 2],   // G#
+  10: [4, 3, 3]   // A#
+};
+
 export type KeyboardRange = {
   minMidi: number;
   maxMidi: number;
@@ -66,24 +108,20 @@ export function buildKeyLayout(
     const black = isBlack(midi);
     
     if (black) {
-      const pitchClass = midi % 12 as 1 | 3 | 6 | 8 | 10;
-      
+      const pitchClass = midi % 12;
+
       // Find the white key to the left
       const leftWhiteKeys = keys.filter(k => !k.black && k.midi < midi);
       const leftWhiteIndex = leftWhiteKeys.length - 1;
       const baseX = Math.max(0, leftWhiteIndex) * keyWidth;
-      
-      // Black key offsets relative to the white key on the left
-      const offsets: Record<number, number> = {
-        1: 0.65,  // C#
-        3: 0.6,   // D#
-        6: 0.65,  // F#
-        8: 0.6,   // G#
-        10: 0.6   // A#
-      };
-      
-      const x = baseX + (offsets[pitchClass] ?? 0.5) * keyWidth;
-      keys.push({ midi, black: true, x, w: keyWidth * 0.6 });
+
+      const groupPosition = BLACK_KEY_GROUP_POSITION[pitchClass];
+      const offset = groupPosition
+        ? blackKeyLeftOffset(...groupPosition)
+        : 0.5;
+
+      const x = baseX + offset * keyWidth;
+      keys.push({ midi, black: true, x, w: keyWidth * BLACK_KEY_WIDTH_RATIO });
     }
   }
   


### PR DESCRIPTION
Closes #58 (할 일 1·2·4). 할 일 3은 아래 "범위" 절 참조.

## 문제

`pianoLayout.ts`의 오프셋 `{C# 0.65, D# 0.6, F# 0.65, G# 0.6, A# 0.6}`은 다섯 개 전부에 −0.05~−0.10칸의 **균일한 좌측 편향**을 준다. 실제 피아노는 2건반 그룹과 3건반 그룹이 각각 바깥으로 벌어지는 대칭 패턴이므로 **D#·A#는 방향이 반대**이고, G#는 3흑건 그룹의 대칭축이라 경계에 정확히 놓여야 한다. 흑건 폭도 0.6이 아니라 0.583이다.

이슈 #56의 spec은 "표의 값 자체는 실제 피아노의 비대칭 배치를 올바르게 반영하므로 버리지 말 것"이라고 적었지만 그 주장이 틀렸고, 코드에는 그것을 반박할 근거가 없었다.

## 접근

값을 소수 3자리로 적지 않고 **표준 치수(백건 23.5mm · 흑건 13.7mm)에서 유도**한다. 그룹 내 흰건반의 후면 폭이 균등하다는 가정 하나에서 다섯 오프셋과 흑건 폭이 전부 나온다. 유도가 코드에 있으면 실제 악기로 검산할 수 있고, 다음 세션이 값을 취향으로 읽지 않는다.

| 건반 | 좌변 오프셋 | 중심의 경계 대비 편차 |
|---|---:|---:|
| C# | 0.6113 | −0.0972 |
| D# | 0.8057 | +0.0972 |
| F# | 0.5628 | −0.1457 |
| G# | 0.7085 | 0.0000 |
| A# | 0.8543 | +0.1457 |

## 회귀를 먼저 걸었다

기존 유일한 흑건 위치 검사는 `|중심 − 경계| ≤ 0.35 * keyWidth`라는 **절대값 상한**이라 부호를 보지 않는다 — 방향이 반대인 값도 통과한다. 새 회귀 3건(방향 불변식, 유도값 일치, 흑건 폭)을 먼저 넣어 `1664afd`에서 3 failed / 14 passed를 관측한 뒤 `072e919`로 고쳤다.

기대값은 **구현에서 import하지 않고 테스트가 표준 치수에서 직접 유도한다.** 구현의 표를 베끼면 "구현이 자기 자신과 같다"는 것밖에 확인하지 못한다.

## 범위 — 이슈 할 일 3은 수행하지 않았다

이슈는 `PianoKeyboard.tsx`도 같은 기준으로 통일하라고 하며 그것을 "모바일 전체화면·가로모드·데모가 사용"한다고 적었다. **현재 코드베이스에서 그 컴포넌트는 라우트에서 도달할 수 없다** — 유일한 소비자인 `FullScreenPiano.tsx`·`LandscapePianoInterface.tsx`를 import하는 파일이 `src/components/mobile/` 밖에 0개다. 실제 재생 경로는 `FallingNotesPlayer` → `SimplePianoKeyboard` → `buildKeyLayout()` 하나다.

도달할 수 없으면 회귀를 관측할 수 없고, 죽은 코드는 통일이 아니라 제거가 맞는 처리다. D-037 결정 4로 HANDOFF의 **P2-A 죽은 코드 정리**에 이관했다.

## 결정 문서

D-024가 `pianoLayout.ts`를 회귀 계약 절에 명시하므로 **D-037을 코드와 같은 커밋**에 넣었다. 흑건 오프셋·폭 자체는 DS-0 고정 상수 7개에 포함되지 않으며, `PX_PER_SEC` 등 그 일곱 개는 **한 픽셀도 바뀌지 않았다.**

## 검증

- `npx jest` — **85 suites / 796 tests 통과** (직전 793 + 신규 3)
- `npx tsc --noEmit` 통과 / `npm run lint` 무경고 / `npm run build` 성공
- 상세: `docs/recovery/validation/2026-09-02-issue-58-black-key-geometry.md`

**검증하지 못한 것**: 실제 브라우저·실기기 육안 확인. 변경 폭이 keyWidth 24에서 2~4px이라 회귀 테스트가 좌표를 판정했다.