### PR TITLE
헤더 계정 메뉴를 디자인 시스템에 맞추고 긴 주소를 담게 한다

### DIFF
--- a/src/components/auth/LogoutButton.tsx
+++ b/src/components/auth/LogoutButton.tsx
@@ -10,7 +10,7 @@ interface LogoutButtonProps {
 }
 
 export default function LogoutButton({ 
-  className = "text-sm text-gray-700 hover:text-gray-900 transition-colors",
+  className = "text-sm text-ink-muted hover:text-ink transition-colors",
   children = "로그아웃",
   callbackUrl = "/"
 }: LogoutButtonProps) {
@@ -34,8 +34,8 @@ export default function LogoutButton({
       className={`${className} ${isLoading ? 'opacity-50 cursor-not-allowed' : ''}`}
     >
       {isLoading ? (
-        <div className="flex items-center space-x-2">
-          <div className="w-3 h-3 border border-gray-400 border-t-transparent rounded-full animate-spin"></div>
+        <div className="flex items-center gap-2">
+          <div className="h-3 w-3 animate-spin rounded-full border border-rule-strong border-t-transparent"></div>
           <span>로그아웃 중...</span>
         </div>
       ) : (

--- a/src/components/auth/UserProfile.tsx
+++ b/src/components/auth/UserProfile.tsx
@@ -110,7 +110,10 @@ export default function UserProfile({
         ref={triggerRef}
         type="button"
         onClick={() => setIsDropdownOpen(!isDropdownOpen)}
-        aria-haspopup="true"
+        // No aria-haspopup: "true" is defined as equivalent to "menu", so it
+        // announces "menu button" and invites the arrow-key navigation this
+        // popup does not implement — the same promise dropping role="menu"
+        // removed. aria-expanded alone is the disclosure pattern.
         aria-expanded={isDropdownOpen}
         // The visible name has to survive into the accessible name (WCAG 2.5.3):
         // a bare "계정 메뉴" label leaves voice control unable to address the
@@ -167,7 +170,10 @@ export default function UserProfile({
               {user.name && (
                 <div
                   data-testid="account-menu-name"
-                  className="truncate text-sm font-medium text-ink"
+                  // break-words, not truncate: this is the one block whose job
+                  // is to say which account is signed in, and the address below
+                  // it wraps rather than clipping for the same reason.
+                  className="break-words text-sm font-medium text-ink"
                 >
                   {user.name}
                 </div>

--- a/src/components/auth/UserProfile.tsx
+++ b/src/components/auth/UserProfile.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 import Image from 'next/image'
 import { useSession } from 'next-auth/react'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import LogoutButton from './LogoutButton'
 
 interface UserProfileProps {
@@ -16,6 +16,9 @@ const MENU_LINKS = [
   { href: '/library', label: '내 악보' }
 ]
 
+const ITEM_CLASSES =
+  'block px-4 py-2 text-sm text-ink-muted transition-colors hover:bg-surface-muted hover:text-ink'
+
 export default function UserProfile({
   showDropdown = true,
   className = ""
@@ -23,6 +26,7 @@ export default function UserProfile({
   const { data: session, status } = useSession()
   const [isDropdownOpen, setIsDropdownOpen] = useState(false)
   const [isAdmin, setIsAdmin] = useState(false)
+  const triggerRef = useRef<HTMLButtonElement>(null)
 
   // Check admin status when user is logged in
   useEffect(() => {
@@ -37,12 +41,16 @@ export default function UserProfile({
   }, [session])
 
   // The backdrop closes the menu on a click, but a keyboard user has no way to
-  // reach it. Escape is the one that matters for them.
+  // reach it. Escape also has to hand focus back: if it closes while focus is
+  // on a menu item, that element unmounts and focus falls to <body>, so the
+  // next Tab restarts from the top of the document instead of the header.
   useEffect(() => {
     if (!isDropdownOpen) return
 
     const closeOnEscape = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') setIsDropdownOpen(false)
+      if (event.key !== 'Escape') return
+      setIsDropdownOpen(false)
+      triggerRef.current?.focus()
     }
 
     document.addEventListener('keydown', closeOnEscape)
@@ -78,14 +86,20 @@ export default function UserProfile({
 
   if (!showDropdown) {
     return (
-      <div className={`flex min-w-0 items-center gap-2 ${className}`}>
+      <div className={`flex min-w-0 items-center gap-3 ${className}`}>
         {avatar}
         <span
           data-testid="account-menu-label"
-          className="truncate text-sm text-ink"
+          className="min-w-0 flex-1 truncate text-sm text-ink"
         >
           {label}
         </span>
+        {/*
+          Logout used to live only in the desktop dropdown, so the mobile menu —
+          which renders this variant and nothing else for the account — offered
+          no way to sign out at all.
+        */}
+        <LogoutButton className="shrink-0 text-sm text-state-error transition-colors hover:brightness-90" />
       </div>
     )
   }
@@ -93,11 +107,15 @@ export default function UserProfile({
   return (
     <div className={`relative ${className}`}>
       <button
+        ref={triggerRef}
         type="button"
         onClick={() => setIsDropdownOpen(!isDropdownOpen)}
-        aria-haspopup="menu"
+        aria-haspopup="true"
         aria-expanded={isDropdownOpen}
-        aria-label="계정 메뉴"
+        // The visible name has to survive into the accessible name (WCAG 2.5.3):
+        // a bare "계정 메뉴" label leaves voice control unable to address the
+        // control the user is looking at, and hides which account is signed in.
+        aria-label={`${label} 계정 메뉴`}
         // The focus ring comes from the global :focus-visible rule, as it does
         // for Button — a per-component ring makes focus differ page to page.
         className="flex max-w-[14rem] items-center gap-2 rounded-full p-1 text-sm text-ink-muted transition-colors hover:text-ink"
@@ -105,6 +123,7 @@ export default function UserProfile({
         {avatar}
         <span
           data-testid="account-menu-label"
+          aria-hidden="true"
           className="max-w-[9rem] truncate"
         >
           {label}
@@ -128,10 +147,21 @@ export default function UserProfile({
             onClick={() => setIsDropdownOpen(false)}
           />
 
+          {/*
+            Deliberately not role="menu". That role obliges arrow-key navigation
+            and a roving tabindex, neither of which is implemented here, and it
+            may only own menuitems — which drops the identity block and the
+            logout button for screen-reader users in menu mode. Plain links and
+            a button, reached by Tab, are what this actually is.
+
+            No `overflow-hidden` either: globals.css draws focus as an outline
+            with a positive offset, and the full-width items have no room for it
+            inside a clipped box. Hiding the global ring right after deleting
+            this component's own one would leave keyboard users worse off.
+          */}
           <div
-            role="menu"
-            aria-label="계정"
-            className="absolute right-0 z-20 mt-2 w-64 overflow-hidden rounded-lg border border-rule bg-surface py-1 shadow-lg"
+            data-testid="account-menu"
+            className="absolute right-0 z-20 mt-2 w-64 rounded-lg border border-rule bg-surface py-1 shadow-lg"
           >
             <div className="border-b border-rule px-4 py-3">
               {user.name && (
@@ -155,8 +185,7 @@ export default function UserProfile({
               <Link
                 key={link.href}
                 href={link.href}
-                role="menuitem"
-                className="block px-4 py-2 text-sm text-ink-muted transition-colors hover:bg-surface-muted hover:text-ink"
+                className={ITEM_CLASSES}
                 onClick={() => setIsDropdownOpen(false)}
               >
                 {link.label}
@@ -166,7 +195,6 @@ export default function UserProfile({
             {isAdmin && (
               <Link
                 href="/admin/update-finger-data"
-                role="menuitem"
                 className="block px-4 py-2 text-sm font-medium text-accent transition-colors hover:bg-surface-muted"
                 onClick={() => setIsDropdownOpen(false)}
               >
@@ -174,8 +202,10 @@ export default function UserProfile({
               </Link>
             )}
 
-            <div className="border-t border-rule px-4 py-2">
-              <LogoutButton className="text-sm text-state-error transition-colors hover:brightness-90" />
+            <div className="mt-1 border-t border-rule pt-1">
+              <LogoutButton
+                className={`w-full text-left ${ITEM_CLASSES} text-state-error hover:text-state-error`}
+              />
             </div>
           </div>
         </>

--- a/src/components/auth/UserProfile.tsx
+++ b/src/components/auth/UserProfile.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { useSession } from 'next-auth/react'
+import Link from 'next/link'
 import Image from 'next/image'
+import { useSession } from 'next-auth/react'
 import { useState, useEffect } from 'react'
 import LogoutButton from './LogoutButton'
 
@@ -10,7 +11,12 @@ interface UserProfileProps {
   className?: string
 }
 
-export default function UserProfile({ 
+const MENU_LINKS = [
+  { href: '/profile', label: '프로필' },
+  { href: '/library', label: '내 악보' }
+]
+
+export default function UserProfile({
   showDropdown = true,
   className = ""
 }: UserProfileProps) {
@@ -30,11 +36,24 @@ export default function UserProfile({
     }
   }, [session])
 
+  // The backdrop closes the menu on a click, but a keyboard user has no way to
+  // reach it. Escape is the one that matters for them.
+  useEffect(() => {
+    if (!isDropdownOpen) return
+
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setIsDropdownOpen(false)
+    }
+
+    document.addEventListener('keydown', closeOnEscape)
+    return () => document.removeEventListener('keydown', closeOnEscape)
+  }, [isDropdownOpen])
+
   if (status === 'loading') {
     return (
-      <div className={`flex items-center space-x-2 ${className}`}>
-        <div className="w-8 h-8 bg-gray-200 rounded-full animate-pulse"></div>
-        <div className="w-20 h-4 bg-gray-200 rounded animate-pulse"></div>
+      <div className={`flex items-center gap-2 ${className}`}>
+        <div className="h-8 w-8 animate-pulse rounded-full bg-surface-muted" />
+        <div className="h-4 w-20 animate-pulse rounded bg-surface-muted" />
       </div>
     )
   }
@@ -44,21 +63,28 @@ export default function UserProfile({
   }
 
   const { user } = session
+  // The name is optional on the session; the address is what is always there.
+  const label = user.name || user.email || '계정'
+
+  const avatar = user.image ? (
+    <Image
+      src={user.image}
+      alt=""
+      width={32}
+      height={32}
+      className="h-8 w-8 shrink-0 rounded-full object-cover"
+    />
+  ) : null
 
   if (!showDropdown) {
     return (
-      <div className={`flex items-center space-x-2 ${className}`}>
-        {user.image && (
-          <Image
-            src={user.image}
-            alt={user.name || 'User'}
-            width={32}
-            height={32}
-            className="rounded-full"
-          />
-        )}
-        <span className="text-sm text-gray-700">
-          {user.name || user.email}
+      <div className={`flex min-w-0 items-center gap-2 ${className}`}>
+        {avatar}
+        <span
+          data-testid="account-menu-label"
+          className="truncate text-sm text-ink"
+        >
+          {label}
         </span>
       </div>
     )
@@ -67,24 +93,28 @@ export default function UserProfile({
   return (
     <div className={`relative ${className}`}>
       <button
+        type="button"
         onClick={() => setIsDropdownOpen(!isDropdownOpen)}
-        className="flex items-center space-x-2 text-sm text-gray-700 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 rounded-md p-1"
+        aria-haspopup="menu"
+        aria-expanded={isDropdownOpen}
+        aria-label="계정 메뉴"
+        // The focus ring comes from the global :focus-visible rule, as it does
+        // for Button — a per-component ring makes focus differ page to page.
+        className="flex max-w-[14rem] items-center gap-2 rounded-full p-1 text-sm text-ink-muted transition-colors hover:text-ink"
       >
-        {user.image && (
-          <Image
-            src={user.image}
-            alt={user.name || 'User'}
-            width={32}
-            height={32}
-            className="rounded-full"
-          />
-        )}
-        <span>{user.name || user.email}</span>
+        {avatar}
+        <span
+          data-testid="account-menu-label"
+          className="max-w-[9rem] truncate"
+        >
+          {label}
+        </span>
         <svg
-          className={`w-4 h-4 transition-transform ${isDropdownOpen ? 'rotate-180' : ''}`}
+          className={`h-4 w-4 shrink-0 transition-transform ${isDropdownOpen ? 'rotate-180' : ''}`}
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
+          aria-hidden="true"
         >
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
         </svg>
@@ -97,44 +127,55 @@ export default function UserProfile({
             className="fixed inset-0 z-10"
             onClick={() => setIsDropdownOpen(false)}
           />
-          
-          {/* Dropdown */}
-          <div className="absolute right-0 mt-2 w-48 bg-white rounded-md shadow-lg py-1 z-20 border">
-            <div className="px-4 py-2 text-sm text-gray-900 border-b">
-              <div className="font-medium">{user.name}</div>
-              <div className="text-gray-500">{user.email}</div>
+
+          <div
+            role="menu"
+            aria-label="계정"
+            className="absolute right-0 z-20 mt-2 w-64 overflow-hidden rounded-lg border border-rule bg-surface py-1 shadow-lg"
+          >
+            <div className="border-b border-rule px-4 py-3">
+              {user.name && (
+                <div
+                  data-testid="account-menu-name"
+                  className="truncate text-sm font-medium text-ink"
+                >
+                  {user.name}
+                </div>
+              )}
+              {user.email && (
+                // A 32-character address is one unbroken token; without
+                // break-all it has nowhere to wrap and runs past the menu.
+                <div className="break-all text-xs text-ink-muted">
+                  {user.email}
+                </div>
+              )}
             </div>
-            
-            <a
-              href="/profile"
-              className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
-              onClick={() => setIsDropdownOpen(false)}
-            >
-              프로필 설정
-            </a>
-            
-            <a
-              href="/library"
-              className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
-              onClick={() => setIsDropdownOpen(false)}
-            >
-              내 악보
-            </a>
-            
-            {isAdmin && (
-              <a
-                href="/admin/update-finger-data"
-                className="block px-4 py-2 text-sm text-orange-600 hover:bg-orange-50 font-medium"
+
+            {MENU_LINKS.map(link => (
+              <Link
+                key={link.href}
+                href={link.href}
+                role="menuitem"
+                className="block px-4 py-2 text-sm text-ink-muted transition-colors hover:bg-surface-muted hover:text-ink"
                 onClick={() => setIsDropdownOpen(false)}
               >
-                🛠️ 관리자 도구
-              </a>
+                {link.label}
+              </Link>
+            ))}
+
+            {isAdmin && (
+              <Link
+                href="/admin/update-finger-data"
+                role="menuitem"
+                className="block px-4 py-2 text-sm font-medium text-accent transition-colors hover:bg-surface-muted"
+                onClick={() => setIsDropdownOpen(false)}
+              >
+                관리자 도구
+              </Link>
             )}
-            
-            <div className="border-t">
-              <div className="px-4 py-2">
-                <LogoutButton className="text-sm text-red-600 hover:text-red-800" />
-              </div>
+
+            <div className="border-t border-rule px-4 py-2">
+              <LogoutButton className="text-sm text-state-error transition-colors hover:brightness-90" />
             </div>
           </div>
         </>

--- a/src/components/auth/__tests__/UserProfile.test.tsx
+++ b/src/components/auth/__tests__/UserProfile.test.tsx
@@ -73,6 +73,19 @@ describe('the account menu holds a long name and address', () => {
     expect(label.className).toMatch(/max-w-/)
   })
 
+  it('wraps a long name in the identity block rather than clipping it', async () => {
+    mockSession.data.user.name = 'Alexandra Konstantinopoulos-Whitfield'
+
+    await renderProfile()
+    openMenu()
+
+    // This block exists to say which account is signed in; truncating it there
+    // defeats the point, and the address beside it already wraps.
+    const name = screen.getByTestId('account-menu-name')
+    expect(name.className).not.toMatch(/\btruncate\b/)
+    expect(name).toHaveTextContent('Alexandra Konstantinopoulos-Whitfield')
+  })
+
   it('falls back to the address when the account has no name', async () => {
     mockSession.data.user.name = null as unknown as string
 
@@ -136,10 +149,12 @@ describe('the account menu uses the design system', () => {
 })
 
 describe('the account menu can be operated from the keyboard', () => {
-  it('announces that it opens something, keeping the visible name in its label', async () => {
+  it('announces expansion without promising menu navigation, and keeps the visible name', async () => {
     await renderProfile()
 
-    expect(trigger()).toHaveAttribute('aria-haspopup', 'true')
+    // aria-haspopup="true" means "menu", which would re-make the promise that
+    // dropping role="menu" was meant to withdraw.
+    expect(trigger()).not.toHaveAttribute('aria-haspopup')
     expect(trigger()).toHaveAttribute('aria-expanded', 'false')
     // WCAG 2.5.3: the accessible name must contain the visible text, or voice
     // control cannot address the control the user is looking at.

--- a/src/components/auth/__tests__/UserProfile.test.tsx
+++ b/src/components/auth/__tests__/UserProfile.test.tsx
@@ -1,0 +1,154 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import UserProfile from '../UserProfile'
+
+const mockSession = {
+  data: {
+    user: {
+      id: 'user-1',
+      name: 'BYOUNG KWANG KIM',
+      email: 'letthelightsurroundyou@gmail.com',
+      image: null as string | null
+    }
+  },
+  status: 'authenticated' as const
+}
+
+jest.mock('next-auth/react', () => ({
+  useSession: () => mockSession,
+  signOut: jest.fn()
+}))
+
+const originalFetch = global.fetch
+
+beforeEach(() => {
+  mockSession.data.user.name = 'BYOUNG KWANG KIM'
+  mockSession.data.user.email = 'letthelightsurroundyou@gmail.com'
+  mockSession.data.user.image = null
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ isAdmin: false })
+  }) as unknown as typeof fetch
+})
+
+afterEach(() => {
+  global.fetch = originalFetch
+  jest.clearAllMocks()
+})
+
+const openMenu = () => {
+  fireEvent.click(screen.getByRole('button', { name: /계정 메뉴/ }))
+}
+
+/**
+ * The account this was reported against: a 16-character display name and a
+ * 32-character address, which overflowed the fixed 12rem dropdown.
+ */
+describe('the account menu holds a long name and address', () => {
+  it('lets the address wrap instead of running past the menu', () => {
+    render(<UserProfile />)
+    openMenu()
+
+    const email = screen.getByText('letthelightsurroundyou@gmail.com')
+    // A single unbroken token only wraps if it is allowed to break mid-word.
+    expect(email.className).toMatch(/\bbreak-all\b/)
+  })
+
+  it('keeps the header trigger from growing with the name', () => {
+    render(<UserProfile />)
+
+    const label = screen.getByTestId('account-menu-label')
+    expect(label.className).toMatch(/\btruncate\b/)
+    expect(label.className).toMatch(/max-w-/)
+  })
+
+  it('falls back to the address when the account has no name', () => {
+    mockSession.data.user.name = null as unknown as string
+
+    render(<UserProfile />)
+    openMenu()
+
+    // Previously rendered an empty <div> where the name would be.
+    expect(screen.queryByTestId('account-menu-name')).not.toBeInTheDocument()
+    expect(
+      screen.getAllByText('letthelightsurroundyou@gmail.com').length
+    ).toBeGreaterThan(0)
+  })
+})
+
+describe('the account menu uses the design system', () => {
+  it('paints itself with tokens rather than the default palette', () => {
+    render(<UserProfile />)
+    openMenu()
+
+    const menu = screen.getByRole('menu')
+    const classes = [menu, ...menu.querySelectorAll('*')]
+      .map(element => element.className)
+      .filter((value): value is string => typeof value === 'string')
+      .join(' ')
+
+    // bg-white and the gray/blue/orange/red ramps are what this menu used
+    // while every other part of the header was already on tokens.
+    expect(classes).not.toMatch(/\bbg-white\b/)
+    expect(classes).not.toMatch(/\b(?:text|bg|border|ring)-(?:gray|blue|orange|red)-\d/)
+  })
+
+  it('gives the menu border an explicit colour', () => {
+    render(<UserProfile />)
+    openMenu()
+
+    // A bare `border` inherits currentColor, which rendered the menu outlined
+    // in full-strength ink instead of the hairline every other surface uses.
+    const menu = screen.getByRole('menu')
+    expect(menu.className).toMatch(/\bborder-rule\b/)
+  })
+
+  it('does not override the global focus ring', () => {
+    render(<UserProfile />)
+
+    // Button.tsx: a per-component ring colour makes focus look different from
+    // screen to screen. globals.css owns :focus-visible.
+    const trigger = screen.getByRole('button', { name: /계정 메뉴/ })
+    expect(trigger.className).not.toMatch(/\bfocus:ring-/)
+  })
+})
+
+describe('the account menu can be operated from the keyboard', () => {
+  it('announces that it opens a menu', () => {
+    render(<UserProfile />)
+
+    const trigger = screen.getByRole('button', { name: /계정 메뉴/ })
+    expect(trigger).toHaveAttribute('aria-haspopup', 'menu')
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+
+    openMenu()
+    expect(trigger).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('closes on Escape, which the backdrop click alone never covered', () => {
+    render(<UserProfile />)
+    openMenu()
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+})
+
+describe('the compact variant used by the mobile menu', () => {
+  it('shows the account without a dropdown', () => {
+    render(<UserProfile showDropdown={false} />)
+
+    expect(screen.queryByRole('button', { name: /계정 메뉴/ })).not.toBeInTheDocument()
+    expect(screen.getByText('BYOUNG KWANG KIM')).toBeInTheDocument()
+  })
+
+  it('keeps a long address from widening the mobile menu', () => {
+    mockSession.data.user.name = null as unknown as string
+
+    render(<UserProfile showDropdown={false} />)
+
+    const label = screen.getByTestId('account-menu-label')
+    expect(label.className).toMatch(/\btruncate\b/)
+  })
+})

--- a/src/components/auth/__tests__/UserProfile.test.tsx
+++ b/src/components/auth/__tests__/UserProfile.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import UserProfile from '../UserProfile'
 
 const mockSession = {
@@ -19,15 +19,17 @@ jest.mock('next-auth/react', () => ({
 }))
 
 const originalFetch = global.fetch
+let isAdminResponse = false
 
 beforeEach(() => {
   mockSession.data.user.name = 'BYOUNG KWANG KIM'
   mockSession.data.user.email = 'letthelightsurroundyou@gmail.com'
   mockSession.data.user.image = null
-  global.fetch = jest.fn().mockResolvedValue({
+  isAdminResponse = false
+  global.fetch = jest.fn().mockImplementation(async () => ({
     ok: true,
-    json: async () => ({ isAdmin: false })
-  }) as unknown as typeof fetch
+    json: async () => ({ isAdmin: isAdminResponse })
+  })) as unknown as typeof fetch
 })
 
 afterEach(() => {
@@ -35,17 +37,27 @@ afterEach(() => {
   jest.clearAllMocks()
 })
 
-const openMenu = () => {
-  fireEvent.click(screen.getByRole('button', { name: /계정 메뉴/ }))
+/**
+ * The admin check fires on mount and resolves immediately, so rendering outside
+ * act() leaves a setState pending after the test body. Flushing it here keeps a
+ * real act violation introduced later from hiding under the noise.
+ */
+const renderProfile = async (props: Parameters<typeof UserProfile>[0] = {}) => {
+  await act(async () => {
+    render(<UserProfile {...props} />)
+  })
 }
+
+const trigger = () => screen.getByRole('button', { name: /계정 메뉴/ })
+const openMenu = () => fireEvent.click(trigger())
 
 /**
  * The account this was reported against: a 16-character display name and a
  * 32-character address, which overflowed the fixed 12rem dropdown.
  */
 describe('the account menu holds a long name and address', () => {
-  it('lets the address wrap instead of running past the menu', () => {
-    render(<UserProfile />)
+  it('lets the address wrap instead of running past the menu', async () => {
+    await renderProfile()
     openMenu()
 
     const email = screen.getByText('letthelightsurroundyou@gmail.com')
@@ -53,18 +65,18 @@ describe('the account menu holds a long name and address', () => {
     expect(email.className).toMatch(/\bbreak-all\b/)
   })
 
-  it('keeps the header trigger from growing with the name', () => {
-    render(<UserProfile />)
+  it('keeps the header trigger from growing with the name', async () => {
+    await renderProfile()
 
     const label = screen.getByTestId('account-menu-label')
     expect(label.className).toMatch(/\btruncate\b/)
     expect(label.className).toMatch(/max-w-/)
   })
 
-  it('falls back to the address when the account has no name', () => {
+  it('falls back to the address when the account has no name', async () => {
     mockSession.data.user.name = null as unknown as string
 
-    render(<UserProfile />)
+    await renderProfile()
     openMenu()
 
     // Previously rendered an empty <div> where the name would be.
@@ -76,11 +88,11 @@ describe('the account menu holds a long name and address', () => {
 })
 
 describe('the account menu uses the design system', () => {
-  it('paints itself with tokens rather than the default palette', () => {
-    render(<UserProfile />)
+  it('paints itself with tokens rather than the default palette', async () => {
+    await renderProfile()
     openMenu()
 
-    const menu = screen.getByRole('menu')
+    const menu = screen.getByTestId('account-menu')
     const classes = [menu, ...menu.querySelectorAll('*')]
       .map(element => element.className)
       .filter((value): value is string => typeof value === 'string')
@@ -92,63 +104,139 @@ describe('the account menu uses the design system', () => {
     expect(classes).not.toMatch(/\b(?:text|bg|border|ring)-(?:gray|blue|orange|red)-\d/)
   })
 
-  it('gives the menu border an explicit colour', () => {
-    render(<UserProfile />)
+  it('gives the menu border an explicit colour', async () => {
+    await renderProfile()
     openMenu()
 
     // A bare `border` inherits currentColor, which rendered the menu outlined
     // in full-strength ink instead of the hairline every other surface uses.
-    const menu = screen.getByRole('menu')
-    expect(menu.className).toMatch(/\bborder-rule\b/)
+    expect(screen.getByTestId('account-menu').className).toMatch(/\bborder-rule\b/)
   })
 
-  it('does not override the global focus ring', () => {
-    render(<UserProfile />)
+  it('does not override the global focus ring', async () => {
+    await renderProfile()
 
     // Button.tsx: a per-component ring colour makes focus look different from
     // screen to screen. globals.css owns :focus-visible.
-    const trigger = screen.getByRole('button', { name: /계정 메뉴/ })
-    expect(trigger.className).not.toMatch(/\bfocus:ring-/)
+    expect(trigger().className).not.toMatch(/\bfocus:ring-/)
+  })
+
+  it('does not clip the focus ring it defers to', async () => {
+    await renderProfile()
+    openMenu()
+
+    // globals.css draws focus as an outline with a positive offset, which lands
+    // outside each full-width item's border box. `overflow-hidden` on the menu
+    // would cut it away — deleting the trigger's own ring and then hiding the
+    // global one leaves keyboard users worse off than before.
+    expect(screen.getByTestId('account-menu').className).not.toMatch(
+      /\boverflow-hidden\b/
+    )
   })
 })
 
 describe('the account menu can be operated from the keyboard', () => {
-  it('announces that it opens a menu', () => {
-    render(<UserProfile />)
+  it('announces that it opens something, keeping the visible name in its label', async () => {
+    await renderProfile()
 
-    const trigger = screen.getByRole('button', { name: /계정 메뉴/ })
-    expect(trigger).toHaveAttribute('aria-haspopup', 'menu')
-    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    expect(trigger()).toHaveAttribute('aria-haspopup', 'true')
+    expect(trigger()).toHaveAttribute('aria-expanded', 'false')
+    // WCAG 2.5.3: the accessible name must contain the visible text, or voice
+    // control cannot address the control the user is looking at.
+    expect(trigger()).toHaveAccessibleName(
+      expect.stringContaining('BYOUNG KWANG KIM') as unknown as string
+    )
 
     openMenu()
-    expect(trigger).toHaveAttribute('aria-expanded', 'true')
+    expect(trigger()).toHaveAttribute('aria-expanded', 'true')
   })
 
-  it('closes on Escape, which the backdrop click alone never covered', () => {
-    render(<UserProfile />)
+  it('closes on Escape, which the backdrop click alone never covered', async () => {
+    await renderProfile()
     openMenu()
-    expect(screen.getByRole('menu')).toBeInTheDocument()
+    expect(screen.getByTestId('account-menu')).toBeInTheDocument()
 
     fireEvent.keyDown(document, { key: 'Escape' })
 
+    expect(screen.queryByTestId('account-menu')).not.toBeInTheDocument()
+  })
+
+  it('returns focus to the trigger when Escape closes the menu', async () => {
+    await renderProfile()
+    openMenu()
+
+    // Focus has moved into the menu, as it would after one Tab.
+    const firstItem = screen.getByRole('link', { name: '프로필' })
+    firstItem.focus()
+    expect(document.activeElement).toBe(firstItem)
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    // Without this the focused element unmounts and focus falls to <body>, so
+    // the next Tab restarts from the top of the document.
+    expect(document.activeElement).toBe(trigger())
+  })
+
+  it('does not claim to be an ARIA menu it has not implemented', async () => {
+    await renderProfile()
+    openMenu()
+
+    // role="menu" obliges arrow-key navigation and a roving tabindex, and it
+    // also requires every child to be a menuitem — which silently dropped the
+    // identity block and the logout button for screen-reader users.
     expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    expect(screen.queryAllByRole('menuitem')).toHaveLength(0)
+  })
+})
+
+describe('every account action stays reachable', () => {
+  it('offers logout in the dropdown', async () => {
+    await renderProfile()
+    openMenu()
+
+    expect(screen.getByRole('button', { name: '로그아웃' })).toBeInTheDocument()
+  })
+
+  it('offers logout in the compact variant too', async () => {
+    // The mobile menu renders this variant, and it was the only account UI
+    // there — so a phone had no way to sign out at all.
+    await renderProfile({ showDropdown: false })
+
+    expect(screen.getByRole('button', { name: '로그아웃' })).toBeInTheDocument()
+  })
+
+  it('shows the admin link only to an admin', async () => {
+    await renderProfile()
+    openMenu()
+    expect(screen.queryByRole('link', { name: /관리자/ })).not.toBeInTheDocument()
+  })
+
+  it('shows the admin link when the account is an admin', async () => {
+    isAdminResponse = true
+
+    await renderProfile()
+    openMenu()
+
+    expect(screen.getByRole('link', { name: /관리자/ })).toHaveAttribute(
+      'href',
+      '/admin/update-finger-data'
+    )
   })
 })
 
 describe('the compact variant used by the mobile menu', () => {
-  it('shows the account without a dropdown', () => {
-    render(<UserProfile showDropdown={false} />)
+  it('shows the account without a dropdown', async () => {
+    await renderProfile({ showDropdown: false })
 
     expect(screen.queryByRole('button', { name: /계정 메뉴/ })).not.toBeInTheDocument()
     expect(screen.getByText('BYOUNG KWANG KIM')).toBeInTheDocument()
   })
 
-  it('keeps a long address from widening the mobile menu', () => {
+  it('keeps a long address from widening the mobile menu', async () => {
     mockSession.data.user.name = null as unknown as string
 
-    render(<UserProfile showDropdown={false} />)
+    await renderProfile({ showDropdown: false })
 
-    const label = screen.getByTestId('account-menu-label')
-    expect(label.className).toMatch(/\btruncate\b/)
+    expect(screen.getByTestId('account-menu-label').className).toMatch(/\btruncate\b/)
   })
 })


### PR DESCRIPTION
브라우저 피드백에서 온 작업이다 — 헤더 계정 드롭다운의 UI가 앱과 어긋나고 긴 이메일이 메뉴를 넘쳤다. **이 메뉴는 헤더에 있으므로 모든 페이지에 나타난다.**

> 본문은 head `4a2288c` 기준이다. 리뷰 두 라운드로 범위가 넓어졌고, **모바일 로그아웃 추가**는 최초 구현 이후에 들어왔다. 전체 분류는 `docs/recovery/reviews/PR-115.md`에 있다.

## 1. 왜 앱과 달라 보였나 (보고된 것)

이 메뉴는 헤더에서 **유일하게 기본 팔레트에 남아 있던 부분**이다. `Header.tsx` 본체는 이미 전부 토큰인데 이 드롭다운만 `bg-white`, `text-gray-*`, `text-orange-*`, `text-red-*`였다.

**테두리가 가장 눈에 띄는 부분이었다.** `border`에 색이 없으면 `currentColor`를 상속하므로, 헤어라인 대신 **잉크색 실선**이 그려진다. 피드백의 computed style에 그대로 있다 — `border: 1px solid rgb(27, 31, 42)`.

## 2. 넘침은 두 곳이었다 (보고된 것 + 하나 더)

- **메뉴 안**: 32자 단일 토큰은 `w-48` 안에서 줄바꿈할 자리가 없다 → `w-64` + `break-all`.
- **헤더 트리거**: 이름을 그대로 렌더해 긴 이름이 레이아웃을 밀었다 → `max-w` + `truncate`.

## 3. 같은 읽기에서 나온 것

1. 이름 없는 계정에 **빈 `<div>`** 렌더 (`/profile`에서 고친 것과 같은 패턴)
2. **`<a href>`라 메뉴를 고를 때마다 앱 전체 리로드** — 헤더의 나머지는 `Link`
3. **자체 `focus:ring-blue-500`** — `Button.tsx`가 기록한 규약 위반
4. **Escape로 닫히지 않음**, `aria-expanded` 부재

라벨도 바꿨다: `프로필 설정` → `프로필`. 이슈 #104가 그 설정들을 제거해 옛 라벨은 존재하지 않는 화면을 가리켰다.

## 4. 리뷰 1차가 찾은 것 — 접근성 주장이 두 곳에서 스스로를 무너뜨렸다

- **`overflow-hidden`이 포커스 링을 잘랐다.** 트리거의 커스텀 링을 "전역 `:focus-visible`이 담당한다"며 지웠는데, 메뉴가 그 전역 링을 클리핑하고 있었다. 링을 지우고 대체물을 가리면 이 브랜치 이전보다 나쁘다.
- **`role="menu"`는 구현하지 않은 약속이었다.** 화살표 키 네비게이션과 roving tabindex가 없고, 신원 블록과 로그아웃 버튼이 `menuitem`이 아니라 스크린리더가 메뉴 모드에서 **로그아웃에 도달하지 못한다.** role을 제거했다.
- **WCAG 2.5.3 위반** — `aria-label="계정 메뉴"`가 보이는 이름을 통째로 덮어써, 음성 제어가 `BYOUNG KWANG KIM`을 부를 수 없었다.
- **Escape 후 포커스가 `<body>`로 떨어짐** — 다음 Tab이 문서 맨 위에서 재시작.
- **act() 경고 20건** — 진짜 위반을 가릴 노이즈.

### 그 지적이 드러낸 결함 — **모바일에서 로그아웃할 방법이 없었다**

로그아웃은 데스크톱 드롭다운에만 있었고, 모바일 메뉴가 쓰는 compact 변형은 아바타와 이름만 렌더했다. 보고에도 최초 구현에도 없던 것이다. **이 PR은 이제 모바일 계정 행에 로그아웃을 추가한다** — 파괴적 동작이므로 병합 시 모바일 메뉴 레이아웃이 바뀐다.

## 5. 리뷰 2차가 찾은 것

- **`aria-haspopup="true"`는 `"menu"`와 동등하다.** `role="menu"`를 뺐는데 이게 남아 여전히 "menu button"이라 알리고 Arrow Down을 유도했다. **1차 수정이 만든 회귀가 이것을 고정하고 있었다.** 제거했다.
- **이름 행의 `truncate`가 37자 이름을 30자에서 잘랐다** — 신원을 말하는 블록인데. 바로 아래 이메일은 감싸진다. `break-words`로 바꿨다.

## 회귀

`UserProfile`에는 테스트가 **하나도 없었다**. 두 변형(드롭다운, 모바일 compact)을 모두 덮는 **18건**이다.

**jsdom은 넘침도 outline 클리핑도 판정하지 못하므로**, 그런 항목은 레이아웃이 아니라 그것을 허용/차단하는 클래스로 단언한다. 한계를 테스트 주석과 커밋에 적었다.

## 검증

- `npx jest` — **88 suites / 833 tests 통과**
- `npx tsc --noEmit` 통과 / `npm run lint` 무경고 / `npm run build` 성공

**검증하지 못한 것**: 브라우저 확인이 없다. jsdom이 판정 못 한 넘침·포커스 링 클리핑·줄바꿈된 이름의 높이·**로그아웃이 추가된 모바일 행**은 화면으로만 확인할 수 있다.