### PR TITLE
Fix nested main landmarks in shared page layouts

### DIFF
--- a/src/app/__tests__/layout.test.tsx
+++ b/src/app/__tests__/layout.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import RootLayout, { viewport } from '../layout'
+import MainLayout from '@/components/layout/MainLayout'
 
 jest.mock('next/font/google', () => ({
   Geist: () => ({ variable: '--font-geist-sans' }),
@@ -46,5 +47,23 @@ describe('RootLayout accessibility contract', () => {
     )
 
     expect(landmarks).toHaveLength(1)
+  })
+
+  it('keeps one main landmark when a page uses the shared MainLayout', () => {
+    const page = MainLayout({ children: <div>Page</div> })
+    const tree = RootLayout({ children: page })
+
+    function countMainLandmarks(node: React.ReactNode): number {
+      if (Array.isArray(node)) {
+        return node.reduce((count, child) => count + countMainLandmarks(child), 0)
+      }
+      if (!React.isValidElement<{ children?: React.ReactNode }>(node)) {
+        return 0
+      }
+
+      return (node.type === 'main' ? 1 : 0) + countMainLandmarks(node.props.children)
+    }
+
+    expect(countMainLandmarks(tree)).toBe(1)
   })
 })

--- a/src/app/profile/__tests__/page.test.tsx
+++ b/src/app/profile/__tests__/page.test.tsx
@@ -80,22 +80,12 @@ describe('profile page shell', () => {
   it('renders inside the shared app shell rather than its own page frame', async () => {
     render(<ProfilePage />)
 
-    // MainLayout is what puts the page inside a <main> landmark; the old page
-    // built its own bg-gray-50 wrapper and never entered the shell.
-    //
-    // This renders the page without the root layout, which contributes a <main>
-    // of its own — so in the browser /profile actually ships two nested ones,
-    // as do library, explore, upload and sheet/[id]. That is a pre-existing
-    // repo-wide defect tracked separately, not something this page introduced,
-    // but it means the assertion below describes the page component rather than
-    // the production DOM.
-    const main = await screen.findByRole('main')
-
-    // PageHeader renders the title as the page's only h1, inside that shell.
+    // The root layout owns the page's single <main> landmark. Page-level tests
+    // render below that boundary, so assert the shared shell wrapper instead.
     const headings = screen.getAllByRole('heading', { level: 1 })
     expect(headings).toHaveLength(1)
     expect(headings[0]).toHaveTextContent('프로필')
-    expect(main).toContainElement(headings[0])
+    expect(headings[0].closest('.min-h-screen')).toBeInTheDocument()
   })
 
   it('shows the account the user actually signed in with', async () => {

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -18,9 +18,7 @@ export default function MainLayout({
         함께 제거된 `/processing`으로 가는 것이었다 (D-026 G1-4). 대체 도달 경로는 내 악보의 상태
         배지이며 DS-4가 만든다.
       */}
-      <main className="flex-1">
-        {children}
-      </main>
+      {children}
     </div>
   )
 }


### PR DESCRIPTION
## Purpose

루트 레이아웃과 `MainLayout`이 각각 `<main>`을 렌더해 주요 다섯 페이지에 중첩 랜드마크가 생기는 이슈 #114를 해소합니다.

## Recovery phase

- Phase: 독립 이슈 #114 — shared main landmark ownership
- Phase document: 별도 phase 문서 없음. [HANDOFF](https://github.com/landfill/ClairKeys/blob/main/docs/recovery/HANDOFF.md)와 [validation record](https://github.com/landfill/ClairKeys/blob/main/docs/recovery/validation/2026-09-03-issue-114-main-landmark.md)가 범위와 근거를 보존합니다.

## Scope

- Included:
  - `RootLayout` + `MainLayout`을 함께 구성해 `<main>`이 정확히 하나인지 검사하는 회귀
  - `MainLayout` 내부 `<main>` 제거와 기존 중립 래퍼 유지
  - 프로필 페이지 단위 테스트를 루트 레이아웃의 랜드마크 소유권에 맞게 갱신
- Explicitly excluded:
  - 페이지별 시각 디자인 변경
  - 인증된 브라우저에서의 다섯 페이지 수동 비교
  - `MainLayout` 컴포넌트 자체 제거

## Key decisions

- 애플리케이션의 유일한 `<main>`은 모든 페이지를 감싸는 `RootLayout`이 소유합니다.
- `MainLayout`은 기존 `min-h-screen` 래퍼를 유지해 DOM 변경을 필요한 한 요소로 제한합니다.
- 회귀는 페이지 단위가 아니라 두 레이아웃을 합성한 트리를 검사합니다.

## Validation

| Check | Result | Evidence record |
|---|---|---|
| Focused tests | PASS — 2 suites / 18 tests | [validation](https://github.com/landfill/ClairKeys/blob/main/docs/recovery/validation/2026-09-03-issue-114-main-landmark.md) |
| Type check | PASS — `npx tsc --noEmit` | [validation](https://github.com/landfill/ClairKeys/blob/main/docs/recovery/validation/2026-09-03-issue-114-main-landmark.md) |
| Lint | PASS — `npm run lint` | [validation](https://github.com/landfill/ClairKeys/blob/main/docs/recovery/validation/2026-09-03-issue-114-main-landmark.md) |
| Unit tests | PASS — 88 suites / 834 tests | [validation](https://github.com/landfill/ClairKeys/blob/main/docs/recovery/validation/2026-09-03-issue-114-main-landmark.md) |
| Build | PASS | [validation](https://github.com/landfill/ClairKeys/blob/main/docs/recovery/validation/2026-09-03-issue-114-main-landmark.md) |
| Manual/E2E | Hosted E2E PASS; authenticated visual comparison NOT RUN | [review log](https://github.com/landfill/ClairKeys/blob/main/docs/recovery/reviews/PR-116.md) |

## Baseline difference

- Fixed failures: composed-layout regression failed before the fix with `Expected: 1`, `Received: 2`; it now passes.
- Remaining known failures: none. The existing ProfilePage React `act(...)` console warning is non-failing and recorded in [validation](https://github.com/landfill/ClairKeys/blob/main/docs/recovery/validation/2026-09-03-issue-114-main-landmark.md).
- Evidence records: [validation](https://github.com/landfill/ClairKeys/blob/main/docs/recovery/validation/2026-09-03-issue-114-main-landmark.md), [review log](https://github.com/landfill/ClairKeys/blob/main/docs/recovery/reviews/PR-116.md).
- New failures: none; all hosted checks pass.

## Risks and rollback

- Risks: low. DOM element 하나를 제거하지만 기존 `min-h-screen` 래퍼와 자식 구조는 유지합니다. 인증된 실제 페이지 시각 비교는 아직 수행하지 않았습니다.
- Rollback: 두 커밋을 역순으로 revert하면 기존 중첩 구조와 테스트 계약으로 돌아갑니다.

## Review checklist

- [x] The PR contains one phase or one bounded objective.
- [x] The PR was created review-ready and is not a draft.
- [x] Existing user-owned changes are excluded.
- [x] Handoff and validation records are current.
- [x] Canonical handoff, validation, and review evidence are stored inside the project.
- [x] No type, lint, or test failure is hidden by configuration.
- [x] Every actionable review comment is tracked in `docs/recovery/reviews/`.
- [x] Merge is deferred until the user explicitly approves this PR.

Closes #114
