### PR TITLE
Show deterministic fingering hints on every falling note

### DIFF
--- a/docs/recovery/DECISIONS.md
+++ b/docs/recovery/DECISIONS.md
@@ -1339,3 +1339,55 @@
 - Related: 이슈 [#58](https://github.com/landfill/ClairKeys/issues/58),
   [#56](https://github.com/landfill/ClairKeys/issues/56), PR #57, D-024,
   `docs/recovery/phases/DS-0-current-state-baseline.md`
+
+## D-038: 운지 번호는 원본을 우선하고 누락분만 결정론적 학습 힌트로 보강한다
+
+- Date: 2026-09-03
+- Status: Accepted
+- Fulfills: 이슈 [#103](https://github.com/landfill/ClairKeys/issues/103)의 운지 데이터 정책 선행 조건
+- Context:
+  - 피아노 운지 번호는 양손 모두 엄지 1, 검지 2, 중지 3, 약지 4, 소지 5가 표준이다. 그러나 임의의
+    악곡 전체에 음높이만으로 적용할 유일한 표준 배열은 없다. Yamaha의 운지 지침도 같은 프레이즈에 복수의
+    유효한 선택이 있음을 명시하며, 손 위치·이동·프레이즈를 함께 고려하도록 설명한다.
+  - 장음계에는 정형 패턴이 있다. Baylor Piano Basics는 C·G·D·A·E 장음계의 한 옥타브 상행을 오른손
+    `1-2-3-1-2-3-4-5`, 왼손 `5-4-3-2-1-3-2-1`로 설명한다. 이 패턴은 장음계라는 문맥이 있을 때의
+    표준이지 모든 곡의 모든 음에 붙일 전역 표가 아니다.
+  - Simply Piano는 곡 학습 화면에서 손가락 번호를 켜고 끄는 기능을 제공하지만, 공개 도움말은 임의 악보에
+    번호를 생성하는 알고리즘을 정의하지 않는다. ClairKeys가 그 비공개 동작을 추측해 동일하다고 주장할 수 없다.
+  - canonical animation v1.1은 `finger`를 optional로 두고 MusicXML의 유효한 `<fingering>`만 보존한다.
+    현재 두 자동 보강 구현은 서로 다른 규칙과 `Math.random()`을 사용하며, 같은 악보에 서로 다른 번호를
+    만들 수 있다. 그중 관리자 API는 일부 음에 운지가 하나라도 있으면 나머지 누락음을 보강하지 않는다.
+- Decision:
+  1. 번호 의미는 양손 공통으로 엄지 1에서 소지 5까지다. 왼손이라는 이유로 숫자 의미를 반전하지 않는다.
+  2. 유효한 원본 MusicXML/저장 JSON의 `finger`가 최우선이며 자동 보강은 이를 덮어쓰지 않는다.
+  3. 원본 운지가 없는 음은 플레이어 입력 경계에서 결정론적으로 1~5를 배정한다. 같은 음표열은 실행·기기와
+     무관하게 같은 결과를 내야 하며 `Math.random()`을 사용하지 않는다.
+  4. 자동값은 **초보자용 학습 힌트**다. 음높이·손·동시음·인접 진행으로 설명 가능한 보수적 규칙만 적용하고,
+     프레이즈 분석이나 교사 검수 없이 교육적으로 유일하거나 최적인 운지라고 표현하지 않는다.
+  5. canonical 저장 계약의 `finger`는 optional로 유지한다. 기존 저장 파일을 일괄 덮어쓰지 않고 읽기 호환
+     경계에서 보강해 신규·기존 악보가 같은 표시 계약을 얻는다.
+  6. 화면은 재생 전과 재생 중 모든 유효한 재생 음에 번호를 렌더한다. 번호 높이보다 짧은 음표는 번호를
+     삭제하거나 글자를 3px까지 줄이지 않고 낙하 블록 위에 겹쳐 최소 글자 크기를 유지한다. 실제 모바일
+     가로 화면은 별도 수동 검증한다.
+- Reason: 표준 번호 체계와 특정 악구의 운지 선택을 구분해야 출처가 있는 정보를 보존하면서도 모든 노트에
+  일관된 힌트를 제공할 수 있다. 런타임 보강은 저장 데이터 마이그레이션 위험 없이 기존 악보까지 즉시 포괄한다.
+- Rejected:
+  - 음높이별 고정 좌·우 배열을 모든 곡에 표준으로 적용 | 손 이동·프레이즈·화음 문맥을 잃고 실제 피아노
+    교육에 존재하지 않는 단일 정답을 만든다.
+  - 관리자 API로 기존 JSON 전체를 즉시 덮어쓴다 | 무작위·부분 보강 결함이 있는 상태에서 원본을 비가역적으로
+    변경하고, 신규 변환 경로와 규칙도 다시 갈라진다.
+  - `finger`를 canonical v1.1 필수 필드로 바꾼다 | 원본 MusicXML이 운지를 제공하지 않는 정상 입력과 기존
+    저장 문서가 모두 계약 위반이 되어 breaking version migration이 필요하다.
+- Consequence: 원본 운지가 없는 곡도 번호가 보이지만 자동 번호는 전문 편집자의 운지와 다를 수 있다. 정확도
+  개선은 추후 키·박자·프레이즈·손 크기 같은 입력을 갖춘 별도 단계로 진행한다.
+- Constraint: P0-A canonical animation의 기존 v1.0/v1.1 읽기 호환성과 원본 `finger` 값은 유지한다.
+- Confidence: high (번호 체계·scale 패턴·결정론 요구), medium (일반 악구의 fallback 교육 품질)
+- Scope-risk: moderate
+- Reversibility: clean
+- Directive: 자동 운지를 "표준 정답" 또는 "Simply Piano 알고리즘"으로 부르지 않는다. 규칙을 바꿀 때는
+  원본 우선·결정론·기존 저장 호환 회귀를 먼저 갱신한다.
+- Tested: 수정 전 경계 회귀 3건(누락 운지, 양손 화음, 짧은 노트 렌더링)이 실패함을 관측. 구현 후 focused
+  Jest 4 suites / 39 tests, 전체 Jest 90 suites / 846 tests, `npx tsc --noEmit`, lint, build 통과.
+- Not-tested: 실제 악보 전체의 교육적 최적성, 교사 검수, 모바일 가로 화면 가독성.
+- Related: 이슈 [#103](https://github.com/landfill/ClairKeys/issues/103), D-009, P0-A,
+  `docs/recovery/phases/ISSUE-103-fingering-guidance.md`

--- a/docs/recovery/phases/ISSUE-103-fingering-guidance.md
+++ b/docs/recovery/phases/ISSUE-103-fingering-guidance.md
@@ -1,0 +1,55 @@
+# ISSUE-103 — 모든 재생 노트의 운지 안내
+
+Status: `IN_PROGRESS`
+Depends on: P0-A, DS-5
+
+Progress (2026-09-03): 표준 번호 체계와 일반 악구 운지의 차이를 조사하고 D-038로 출처 우선순위와
+결정론적 fallback 계약을 확정했다. 구현과 검증은 진행 중이다.
+
+## Objective
+
+원본 악보의 유효한 운지를 보존하면서, 운지가 없는 기존·신규 악보의 모든 재생 노트에도 양손 공통 1~5
+번호를 일관되게 표시한다.
+
+## In scope
+
+- 양손 엄지 1 → 소지 5의 표준 번호 의미
+- MusicXML/저장 JSON 원본 운지 보존
+- 누락 운지의 결정론적 초보자용 fallback
+- canonical 문서에서 플레이어 입력까지의 보존·보강 회귀
+- 짧은 노트와 정지·재생 화면의 번호 렌더링
+- 왼손·오른손·동시음·모바일 가로 화면 검증
+
+## Out of scope
+
+- Simply Piano의 비공개 운지 생성 알고리즘 복제
+- 임의 악곡에 교육적으로 유일하거나 최적인 운지 보장
+- 기존 저장 JSON 일괄 덮어쓰기
+- 개인 손 크기·숙련도 기반 운지 최적화
+
+## Work stages
+
+1. 현재 변환→저장→정규화→플레이어 경계의 운지 보존과 누락을 회귀로 고정한다.
+2. 기존 원본 운지를 보존하는 결정론적 fallback을 플레이어 입력 경계에 연결한다.
+3. 짧은 낙하 노트에서도 번호를 생략하지 않는 렌더링 규칙을 적용한다.
+4. focused Jest 후 전체 Jest, typecheck, lint, build를 실행한다.
+5. 실제 악보 한 곡과 모바일 가로 화면을 수동 검증한다.
+
+## Completion criteria
+
+- 회귀 fixture의 모든 재생 노트가 유효한 `finger` 1~5를 가진다.
+- 원본의 유효한 왼손·오른손 운지가 변환·정규화·플레이어 경계에서 보존된다.
+- 원본이 없는 같은 입력은 반복 실행해도 같은 운지를 얻는다.
+- 왼손·오른손과 최대 다섯 음의 동시음을 검증한다.
+- 매우 짧은 노트도 번호 렌더링 대상이며 UI 테스트가 이를 관측한다.
+- Jest, `npx tsc --noEmit`, lint, build가 통과한다.
+- 실제 악보 한 곡의 모든 노트 표시와 모바일 가로 화면 가독성을 수동 확인한다.
+
+## Sources
+
+- [Yamaha, “The Basics Of Piano Keyboard Fingering”](https://hub.yamaha.com/keyboards/k-how-to/the-basics-of-piano-keyboard-fingering/): 양손 공통 엄지 1~소지 5, 검은건반·손 위치·이동 원칙,
+  같은 악구에도 복수 운지가 가능함.
+- [Baylor Piano Basics, “One-Octave Major Scales”](https://openbooks.library.baylor.edu/pianobasics/chapter/one-octave-major-scales/): CAGED 장음계의 오른손 `123-12345`, 왼손
+  `54321-321`, 연속 손가락·3/4음 그룹·검은건반의 엄지 회피 원칙.
+- [Simply Piano Help Center, “Learning with Simply Piano: The basics”](https://piano-help.hellosimply.com/en/articles/7943490-learning-with-simply-piano-the-basics): 학습 화면의 finger numbers
+  표시/숨김 옵션. 배정 알고리즘은 공개 문서에 없음.

--- a/src/components/animation/__tests__/FallingNotes.test.tsx
+++ b/src/components/animation/__tests__/FallingNotes.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react'
+import FallingNotes from '../FallingNotes'
+import type { KeyLayout } from '@/types/fallingNotes'
+
+const layout: KeyLayout = {
+  byMidi: new Map([[60, { x: 0, w: 20, black: false }]]),
+  totalWidth: 20,
+  keyWidth: 20,
+}
+
+describe('FallingNotes fingering', () => {
+  it('renders a finger number even when the falling note is very short', () => {
+    render(
+      <FallingNotes
+        notes={[{ midi: 60, start: 1, duration: 0.01, hand: 'R', finger: 2 }]}
+        nowSec={0}
+        pxPerSec={100}
+        height={200}
+        layout={layout}
+      />
+    )
+
+    expect(screen.getByText('2')).toBeInTheDocument()
+  })
+})

--- a/src/utils/__tests__/dataConverter.test.ts
+++ b/src/utils/__tests__/dataConverter.test.ts
@@ -1,0 +1,54 @@
+import { canonicalToFallingNotes } from '../dataConverter'
+import type { CanonicalAnimationData } from '@/types/animationContract'
+
+function animation(notes: CanonicalAnimationData['notes']): CanonicalAnimationData {
+  return {
+    version: '1.1',
+    title: 'Fingering fixture',
+    composer: 'Test',
+    duration: 2,
+    tempo: 120,
+    tempoSource: 'score',
+    timingReferenceBpm: 120,
+    timeSignature: '4/4',
+    notes,
+  }
+}
+
+describe('canonicalToFallingNotes fingering boundary', () => {
+  it('preserves source fingering and fills every missing finger deterministically', () => {
+    const source = animation([
+      { midi: 48, start: 0, duration: 0.5, hand: 'L', finger: 4 },
+      { midi: 60, start: 0, duration: 0.5, hand: 'R', finger: 2 },
+      { midi: 64, start: 0.5, duration: 0.5, hand: 'R' },
+      { midi: 43, start: 1, duration: 0.5, hand: 'L' },
+      { midi: 67, start: 1.5, duration: 0.5 },
+    ])
+
+    const first = canonicalToFallingNotes(source)
+    const second = canonicalToFallingNotes(source)
+
+    expect(first).toEqual(second)
+    expect(first[0]).toMatchObject({ hand: 'L', finger: 4 })
+    expect(first[1]).toMatchObject({ hand: 'R', finger: 2 })
+    first.forEach((note) => {
+      expect(note.hand).toMatch(/^[LR]$/)
+      expect(note.finger).toBeGreaterThanOrEqual(1)
+      expect(note.finger).toBeLessThanOrEqual(5)
+    })
+  })
+
+  it('uses conventional outer fingers for a simultaneous triad in each hand', () => {
+    const notes = canonicalToFallingNotes(animation([
+      { midi: 48, start: 0, duration: 1, hand: 'L' },
+      { midi: 52, start: 0, duration: 1, hand: 'L' },
+      { midi: 55, start: 0, duration: 1, hand: 'L' },
+      { midi: 60, start: 1, duration: 1, hand: 'R' },
+      { midi: 64, start: 1, duration: 1, hand: 'R' },
+      { midi: 67, start: 1, duration: 1, hand: 'R' },
+    ]))
+
+    expect(notes.slice(0, 3).map((note) => note.finger)).toEqual([5, 3, 1])
+    expect(notes.slice(3).map((note) => note.finger)).toEqual([1, 3, 5])
+  })
+})

--- a/src/utils/__tests__/fingeringUtils.test.ts
+++ b/src/utils/__tests__/fingeringUtils.test.ts
@@ -231,6 +231,18 @@ describe('fingeringUtils', () => {
       expect(addFingeringToNotes(notes).map(note => note.finger)).toEqual([1, 2, 3, 1, 2, 3, 4, 5]);
     });
 
+    it('should recognize a right-hand scale when left-hand accompaniment is interleaved', () => {
+      const notes: FallingNote[] = [60, 48, 62, 43, 64, 45, 65, 47, 67, 48, 69, 43, 71, 45, 72, 47].map((midi, index) => ({
+        midi,
+        start: Math.floor(index / 2),
+        duration: 1,
+        hand: index % 2 === 0 ? 'R' as const : 'L' as const,
+      }));
+
+      const enhanced = addFingeringToNotes(notes);
+      expect(enhanced.filter(note => note.hand === 'R').map(note => note.finger)).toEqual([1, 2, 3, 1, 2, 3, 4, 5]);
+    });
+
     it('should apply the standard left-hand scale pattern to an ascending C-major run', () => {
       const notes: FallingNote[] = [36, 38, 40, 41, 43, 45, 47, 48].map((midi, index) => ({
         midi,

--- a/src/utils/__tests__/fingeringUtils.test.ts
+++ b/src/utils/__tests__/fingeringUtils.test.ts
@@ -74,16 +74,62 @@ describe('fingeringUtils', () => {
       expect([2, 3, 4]).toContain(rightFinger);
     });
 
+    it('should assign deterministic conventional fingers to black keys', () => {
+      const random = jest.spyOn(Math, 'random').mockImplementation(() => {
+        throw new Error('fingering must not use randomness');
+      });
+
+      try {
+        const inputs: Array<[number, 'L' | 'R']> = [
+          [61, 'L'], [63, 'L'], [66, 'R'], [68, 'R'], [70, 'R']
+        ];
+        inputs.forEach(([midi, hand]) => {
+          const finger = assignFinger(midi, hand);
+          expect([2, 3, 4]).toContain(finger);
+          expect(assignFinger(midi, hand)).toBe(finger);
+        });
+      } finally {
+        random.mockRestore();
+      }
+    });
+
     it('should handle scale positions correctly', () => {
-      const finger = assignFinger(60, 'R', { scalePosition: 0 });
-      expect(finger).toBeGreaterThanOrEqual(1);
-      expect(finger).toBeLessThanOrEqual(5);
+      const right = Array.from({ length: 8 }, (_, position) =>
+        assignFinger(60, 'R', { scalePosition: position })
+      );
+      const left = Array.from({ length: 8 }, (_, position) =>
+        assignFinger(48, 'L', { scalePosition: position })
+      );
+      expect(right).toEqual([1, 2, 3, 1, 2, 3, 4, 5]);
+      expect(left).toEqual([5, 4, 3, 2, 1, 3, 2, 1]);
     });
 
     it('should handle chord positions correctly', () => {
-      const finger = assignFinger(60, 'R', { chordPosition: 0 });
-      expect(finger).toBeGreaterThanOrEqual(1);
-      expect(finger).toBeLessThanOrEqual(5);
+      expect([0, 1, 2].map(chordPosition =>
+        assignFinger(60, 'R', { chordPosition })
+      )).toEqual([1, 3, 5]);
+      expect([0, 1, 2].map(chordPosition =>
+        assignFinger(48, 'L', { chordPosition })
+      )).toEqual([5, 3, 1]);
+    });
+
+    it('should be repeatable and use only valid fingers for fallback assignments', () => {
+      const random = jest.spyOn(Math, 'random').mockImplementation(() => {
+        throw new Error('fingering must not use randomness');
+      });
+
+      try {
+        for (const hand of ['L', 'R'] as const) {
+          for (const midi of [21, 36, 48, 54, 60, 67, 77, 84, 96]) {
+            const first = assignFinger(midi, hand);
+            expect(assignFinger(midi, hand)).toBe(first);
+            expect(first).toBeGreaterThanOrEqual(1);
+            expect(first).toBeLessThanOrEqual(5);
+          }
+        }
+      } finally {
+        random.mockRestore();
+      }
     });
   });
 
@@ -120,6 +166,92 @@ describe('fingeringUtils', () => {
       expect(enhanced[0].velocity).toBe(0.8);
       expect(enhanced[0].hand).toBeDefined();
       expect(enhanced[0].finger).toBeDefined();
+    });
+
+    it('should preserve existing valid hand and finger assignments', () => {
+      const notes: FallingNote[] = [
+        { midi: 60, start: 0, duration: 1, hand: 'R', finger: 4 },
+        { midi: 48, start: 1, duration: 1, hand: 'L', finger: 2 },
+      ];
+
+      expect(addFingeringToNotes(notes).map(({ hand, finger }) => ({ hand, finger }))).toEqual([
+        { hand: 'R', finger: 4 },
+        { hand: 'L', finger: 2 },
+      ]);
+    });
+
+    it('should assign simultaneous notes conventional chord fingers by ascending pitch', () => {
+      const notes: FallingNote[] = [
+        { midi: 67, start: 0, duration: 1, hand: 'R' },
+        { midi: 60, start: 0, duration: 1, hand: 'R' },
+        { midi: 64, start: 0, duration: 1, hand: 'R' },
+        { midi: 48, start: 0, duration: 1, hand: 'L' },
+        { midi: 36, start: 0, duration: 1, hand: 'L' },
+        { midi: 43, start: 0, duration: 1, hand: 'L' },
+      ];
+
+      const enhanced = addFingeringToNotes(notes);
+      expect(enhanced.slice(0, 3).sort((a, b) => a.midi - b.midi).map(note => note.finger)).toEqual([1, 3, 5]);
+      expect(enhanced.slice(3).sort((a, b) => a.midi - b.midi).map(note => note.finger)).toEqual([5, 3, 1]);
+    });
+
+    it('should preserve explicit chord fingers while filling the remaining notes deterministically', () => {
+      const notes: FallingNote[] = [
+        { midi: 60, start: 0, duration: 1, hand: 'R', finger: 2 },
+        { midi: 64, start: 0, duration: 1, hand: 'R' },
+        { midi: 67, start: 0, duration: 1, hand: 'R' },
+      ];
+
+      const enhanced = addFingeringToNotes(notes);
+      expect(enhanced.map(note => note.finger)).toEqual([2, 3, 5]);
+    });
+
+    it('should keep fallback fingers valid for chords larger than five notes', () => {
+      const notes: FallingNote[] = Array.from({ length: 7 }, (_, index) => ({
+        midi: 60 + index * 2,
+        start: 0,
+        duration: 1,
+        hand: 'R' as const,
+      }));
+
+      addFingeringToNotes(notes).forEach(note => {
+        expect(note.finger).toBeGreaterThanOrEqual(1);
+        expect(note.finger).toBeLessThanOrEqual(5);
+      });
+    });
+
+    it('should apply the standard right-hand scale pattern to an ascending C-major run', () => {
+      const notes: FallingNote[] = [60, 62, 64, 65, 67, 69, 71, 72].map((midi, index) => ({
+        midi,
+        start: index,
+        duration: 1,
+        hand: 'R' as const,
+      }));
+
+      expect(addFingeringToNotes(notes).map(note => note.finger)).toEqual([1, 2, 3, 1, 2, 3, 4, 5]);
+    });
+
+    it('should apply the standard left-hand scale pattern to an ascending C-major run', () => {
+      const notes: FallingNote[] = [36, 38, 40, 41, 43, 45, 47, 48].map((midi, index) => ({
+        midi,
+        start: index,
+        duration: 1,
+        hand: 'L' as const,
+      }));
+
+      expect(addFingeringToNotes(notes).map(note => note.finger)).toEqual([5, 4, 3, 2, 1, 3, 2, 1]);
+    });
+
+    it('should not apply the CAGED crossing pattern to F-major right hand', () => {
+      const midi = [65, 67, 69, 70, 72, 74, 76, 77];
+      const notes: FallingNote[] = midi.map((pitch, index) => ({
+        midi: pitch,
+        start: index * 0.5,
+        duration: 0.5,
+        hand: 'R',
+      }));
+
+      expect(addFingeringToNotes(notes).map(note => note.finger)).not.toEqual([1, 2, 3, 1, 2, 3, 4, 5]);
     });
   });
 

--- a/src/utils/__tests__/visualUtils.test.ts
+++ b/src/utils/__tests__/visualUtils.test.ts
@@ -123,7 +123,7 @@ describe('visualUtils with fingering', () => {
       expect(shouldShowFingerBadge(note)).toBe(false);
     });
 
-    it('should not show badge for very small notes', () => {
+    it('should keep the finger visible for very short notes', () => {
       const note: VisualNote = {
         x: 0,
         y: 0,
@@ -135,7 +135,7 @@ describe('visualUtils with fingering', () => {
         hand: 'R'
       };
 
-      expect(shouldShowFingerBadge(note)).toBe(false);
+      expect(shouldShowFingerBadge(note)).toBe(true);
     });
   });
 

--- a/src/utils/dataConverter.ts
+++ b/src/utils/dataConverter.ts
@@ -1,6 +1,7 @@
 import type { PianoAnimationData, PianoNote } from '@/types/animation'
 import type { FallingNote } from '@/types/fallingNotes'
 import type { CanonicalAnimationData } from '@/types/animationContract'
+import { addFingeringToNotes } from '@/utils/fingeringUtils'
 
 /**
  * Data Converter Utilities
@@ -94,7 +95,7 @@ export function convertToFallingNotes(animationData: PianoAnimationData): Fallin
  * legacy string-pitch Shape A) once data has been through `normalizeAnimationData`.
  */
 export function canonicalToFallingNotes(data: CanonicalAnimationData): FallingNote[] {
-  return data.notes.map((note) => ({
+  const notes = data.notes.map((note) => ({
     midi: note.midi,
     start: note.start,
     duration: note.duration,
@@ -102,6 +103,10 @@ export function canonicalToFallingNotes(data: CanonicalAnimationData): FallingNo
     finger: note.finger,
     velocity: note.velocity,
   }));
+
+  // MusicXML fingering is optional. Preserve explicit source values and add a
+  // deterministic beginner hint only where the stored document has a gap.
+  return addFingeringToNotes(notes)
 }
 
 /**

--- a/src/utils/fingeringUtils.ts
+++ b/src/utils/fingeringUtils.ts
@@ -226,26 +226,32 @@ function applyMajorScaleRuns(enhancedNotes: FallingNote[], originalNotes: Fallin
   const rightFingers: Finger[] = [1, 2, 3, 1, 2, 3, 4, 5];
   const leftFingers: Finger[] = [5, 4, 3, 2, 1, 3, 2, 1];
 
-  for (let start = 0; start <= enhancedNotes.length - 8; start += 1) {
-    const run = enhancedNotes.slice(start, start + 8);
-    const firstHand = run[0].hand;
-    if (!firstHand || run.some(note => note.hand !== firstHand)) continue;
-    if (!cagedTonics.has(positiveModulo(run[0].midi, 12))) continue;
+  const indicesByHand: Record<Hand, number[]> = { L: [], R: [] };
+  enhancedNotes.forEach((note, index) => indicesByHand[note.hand as Hand].push(index));
 
-    const isScale = run.every((note, index) => {
-      if (index === 0) return true;
-      return note.start > run[index - 1].start && note.midi - run[index - 1].midi === intervals[index - 1];
-    });
-    if (!isScale) continue;
+  (['L', 'R'] as const).forEach(hand => {
+    const handIndices = indicesByHand[hand].sort((a, b) =>
+      enhancedNotes[a].start - enhancedNotes[b].start || a - b
+    );
+    for (let start = 0; start <= handIndices.length - 8; start += 1) {
+      const runIndices = handIndices.slice(start, start + 8);
+      const run = runIndices.map(index => enhancedNotes[index]);
+      if (!cagedTonics.has(positiveModulo(run[0].midi, 12))) continue;
 
-    const fingers = firstHand === 'R' ? rightFingers : leftFingers;
-    run.forEach((_, index) => {
-      const noteIndex = start + index;
-      if (!isValidFinger(originalNotes[noteIndex].finger)) {
-        enhancedNotes[noteIndex].finger = fingers[index];
-      }
-    });
-  }
+      const isScale = run.every((note, index) => {
+        if (index === 0) return true;
+        return note.start > run[index - 1].start && note.midi - run[index - 1].midi === intervals[index - 1];
+      });
+      if (!isScale) continue;
+
+      const fingers = hand === 'R' ? rightFingers : leftFingers;
+      runIndices.forEach((noteIndex, index) => {
+        if (!isValidFinger(originalNotes[noteIndex].finger)) {
+          enhancedNotes[noteIndex].finger = fingers[index];
+        }
+      });
+    }
+  });
 }
 
 /**

--- a/src/utils/fingeringUtils.ts
+++ b/src/utils/fingeringUtils.ts
@@ -1,6 +1,8 @@
 /**
  * Piano Fingering Utilities
- * Assigns realistic hand and finger numbers based on music theory
+ * Assigns deterministic beginner hand and finger hints.
+ * Explicit score fingering always wins; inferred values are not a claim of
+ * pedagogically unique or optimal fingering for an arbitrary phrase.
  */
 
 import type { FallingNote, Hand, Finger } from '@/types/fallingNotes';
@@ -68,7 +70,10 @@ function assignLeftHandFinger(
 ): Finger {
   // Avoid thumb (1) on black keys
   if (isBlackKey) {
-    return [2, 3, 4][Math.floor(Math.random() * 3)] as Finger;
+    // Keep the fallback deterministic so the same score always renders the
+    // same fingering. The middle fingers are the conventional black-key
+    // choices for either hand.
+    return [2, 3, 4][positiveModulo(midi, 3)] as Finger;
   }
   
   // Scale-based fingering
@@ -85,9 +90,9 @@ function assignLeftHandFinger(
   
   // Default pattern based on range
   if (midi < 36) return 5; // Very low notes - pinky
-  if (midi < 48) return [4, 5][Math.floor(Math.random() * 2)] as Finger; // Low notes
-  if (midi < 55) return [2, 3, 4][Math.floor(Math.random() * 3)] as Finger; // Mid-low
-  return [1, 2, 3][Math.floor(Math.random() * 3)] as Finger; // Upper range
+  if (midi < 48) return [4, 5][positiveModulo(midi, 2)] as Finger; // Low notes
+  if (midi < 55) return [2, 3, 4][positiveModulo(midi, 3)] as Finger; // Mid-low
+  return [1, 2, 3][positiveModulo(midi, 3)] as Finger; // Upper range
 }
 
 /**
@@ -100,7 +105,7 @@ function assignRightHandFinger(
 ): Finger {
   // Avoid thumb (1) on black keys
   if (isBlackKey) {
-    return [2, 3, 4][Math.floor(Math.random() * 3)] as Finger;
+    return [2, 3, 4][positiveModulo(midi, 3)] as Finger;
   }
   
   // Scale-based fingering
@@ -117,9 +122,14 @@ function assignRightHandFinger(
   
   // Default pattern based on range
   if (midi > 84) return 5; // Very high notes - pinky
-  if (midi > 76) return [4, 5][Math.floor(Math.random() * 2)] as Finger; // High notes
-  if (midi > 67) return [2, 3, 4][Math.floor(Math.random() * 3)] as Finger; // Mid-high
-  return [1, 2, 3][Math.floor(Math.random() * 3)] as Finger; // Lower range
+  if (midi > 76) return [4, 5][positiveModulo(midi, 2)] as Finger; // High notes
+  if (midi > 67) return [2, 3, 4][positiveModulo(midi, 3)] as Finger; // Mid-high
+  return [1, 2, 3][positiveModulo(midi, 3)] as Finger; // Lower range
+}
+
+/** Modulo that remains usable for any numeric MIDI input, including negatives. */
+function positiveModulo(value: number, divisor: number): number {
+  return ((value % divisor) + divisor) % divisor;
 }
 
 /**
@@ -131,7 +141,7 @@ export function isBlackKeyMidi(midi: number): boolean {
 }
 
 /**
- * Enhance notes with realistic hand and finger assignments
+ * Preserve explicit assignments and fill gaps with deterministic beginner hints.
  */
 export function addFingeringToNotes(notes: FallingNote[]): FallingNote[] {
   const enhancedNotes: FallingNote[] = [];
@@ -143,13 +153,12 @@ export function addFingeringToNotes(notes: FallingNote[]): FallingNote[] {
     const isBlackKey = isBlackKeyMidi(note.midi);
     
     // Assign hand
-    const hand = assignHand(note.midi, { prevHand });
+    const hand = isValidHand(note.hand) ? note.hand : assignHand(note.midi, { prevHand });
     
     // Assign finger
-    const finger = assignFinger(note.midi, hand, { 
-      prevFinger, 
-      isBlackKey 
-    });
+    const finger = isValidFinger(note.finger)
+      ? note.finger
+      : assignFinger(note.midi, hand, { prevFinger, isBlackKey });
     
     enhancedNotes.push({
       ...note,
@@ -160,8 +169,83 @@ export function addFingeringToNotes(notes: FallingNote[]): FallingNote[] {
     prevHand = hand;
     prevFinger = finger;
   }
-  
+
+  // Notes starting together form a chord. Assign the conventional chord
+  // pattern by ascending pitch, while retaining every explicit finger.
+  const chordGroups = new Map<string, number[]>();
+  enhancedNotes.forEach((note, index) => {
+    const key = `${note.start}:${note.hand}`;
+    const group = chordGroups.get(key) ?? [];
+    group.push(index);
+    chordGroups.set(key, group);
+  });
+
+  chordGroups.forEach(indices => {
+    if (indices.length < 2) return;
+    const sorted = [...indices].sort((a, b) => enhancedNotes[a].midi - enhancedNotes[b].midi);
+    const hand = enhancedNotes[sorted[0]].hand as Hand;
+    const chordFingers = getChordFingers(hand, sorted.length);
+    sorted.forEach((noteIndex, position) => {
+      if (!isValidFinger(notes[noteIndex].finger)) {
+        // More than five simultaneous notes exceed one hand's fingers; keep
+        // the fallback valid without claiming pedagogical optimality.
+        enhancedNotes[noteIndex].finger = chordFingers[Math.min(position, 4)] as Finger;
+      }
+    });
+  });
+
+  applyMajorScaleRuns(enhancedNotes, notes);
+
   return enhancedNotes;
+}
+
+function isValidHand(hand: FallingNote['hand']): hand is Hand {
+  return hand === 'L' || hand === 'R';
+}
+
+function isValidFinger(finger: FallingNote['finger']): finger is Finger {
+  return finger === 1 || finger === 2 || finger === 3 || finger === 4 || finger === 5;
+}
+
+function getChordFingers(hand: Hand, noteCount: number): Finger[] {
+  const right: Finger[][] = [
+    [1], [1, 5], [1, 3, 5], [1, 2, 4, 5], [1, 2, 3, 4, 5],
+  ];
+  const left: Finger[][] = [
+    [5], [5, 1], [5, 3, 1], [5, 4, 2, 1], [5, 4, 3, 2, 1],
+  ];
+  const patterns = hand === 'R' ? right : left;
+  return patterns[Math.min(noteCount, 5) - 1] ?? patterns[4];
+}
+
+function applyMajorScaleRuns(enhancedNotes: FallingNote[], originalNotes: FallingNote[]): void {
+  const intervals = [2, 2, 1, 2, 2, 2, 1];
+  // Baylor's shared pattern applies to the CAGED major keys. F major RH and
+  // B major LH need different thumb crossings, so do not infer them here.
+  const cagedTonics = new Set([0, 2, 4, 7, 9]);
+  const rightFingers: Finger[] = [1, 2, 3, 1, 2, 3, 4, 5];
+  const leftFingers: Finger[] = [5, 4, 3, 2, 1, 3, 2, 1];
+
+  for (let start = 0; start <= enhancedNotes.length - 8; start += 1) {
+    const run = enhancedNotes.slice(start, start + 8);
+    const firstHand = run[0].hand;
+    if (!firstHand || run.some(note => note.hand !== firstHand)) continue;
+    if (!cagedTonics.has(positiveModulo(run[0].midi, 12))) continue;
+
+    const isScale = run.every((note, index) => {
+      if (index === 0) return true;
+      return note.start > run[index - 1].start && note.midi - run[index - 1].midi === intervals[index - 1];
+    });
+    if (!isScale) continue;
+
+    const fingers = firstHand === 'R' ? rightFingers : leftFingers;
+    run.forEach((_, index) => {
+      const noteIndex = start + index;
+      if (!isValidFinger(originalNotes[noteIndex].finger)) {
+        enhancedNotes[noteIndex].finger = fingers[index];
+      }
+    });
+  }
 }
 
 /**

--- a/src/utils/visualUtils.ts
+++ b/src/utils/visualUtils.ts
@@ -125,7 +125,7 @@ export function getFingerBadgePosition(note: VisualNote): { x: number; y: number
  * Check if a finger badge should be displayed based on note size
  */
 export function shouldShowFingerBadge(note: VisualNote): boolean {
-  return note.w >= 12 && note.h >= 12 && note.finger !== undefined;
+  return note.finger !== undefined;
 }
 
 /**


### PR DESCRIPTION
## Purpose

Show a stable 1–5 finger hint on every falling note while preserving fingering supplied by the source score.

## Recovery phase

- Phase: ISSUE-103
- Phase document: `docs/recovery/phases/ISSUE-103-fingering-guidance.md`

## Scope

- Included: source fingering preservation; deterministic gap filling; conventional thumb=1 through pinky=5 numbering; CAGED ascending major-scale patterns; 1–5 note chord patterns; player-boundary integration; short-note rendering.
- Explicitly excluded: claiming a unique optimal fingering for arbitrary repertoire; copying Simply Piano's unpublished assignment algorithm; rewriting stored animation JSON; personalized hand-size inference.

## Key decisions

D-038 separates the universal digit-number convention from phrase-specific fingering choices. Explicit MusicXML/JSON values win. Missing values receive a deterministic beginner hint at the player boundary, so existing and new stored documents keep the v1.0/v1.1 compatibility contract.

## Validation

| Check | Result | Evidence record |
|---|---|---|
| Focused tests | PASS — 4 suites / 39 tests | validation record added immediately after PR creation |
| Type check | PASS — `npx tsc --noEmit` | validation record added immediately after PR creation |
| Lint | PASS — no warnings/errors | validation record added immediately after PR creation |
| Unit tests | PASS — 90 suites / 846 tests | validation record added immediately after PR creation |
| Build | PASS | validation record added immediately after PR creation |
| Manual/E2E | NOT RUN — real score and mobile landscape remain | validation record added immediately after PR creation |

## Baseline difference

- Fixed failures: missing fingers reached the player as `undefined`; random fallback changed between runs; simultaneous left/right chords had no common assignment; short notes suppressed their number.
- Remaining known failures: real-score pedagogical quality and mobile landscape legibility require manual validation.
- Evidence records: D-038 and `docs/recovery/phases/ISSUE-103-fingering-guidance.md`; dated validation record follows on `main` per repository policy.
- New failures: none in the full local suite.

## Risks and rollback

- Risks: inferred hints are deterministic and conventional but not guaranteed to match a teacher's preferred fingering for arbitrary phrases; labels on 3px-tall notes extend beyond the note block to remain readable.
- Rollback: revert commit `edf29d8`; stored animation documents are not mutated.

## Review checklist

- [x] The PR contains one phase or one bounded objective.
- [x] The PR was created review-ready and is not a draft.
- [x] Existing user-owned changes are excluded.
- [ ] Handoff and validation records are current.
- [ ] Canonical handoff, validation, and review evidence are stored inside the project.
- [x] No type, lint, or test failure is hidden by configuration.
- [ ] Every actionable review comment is tracked in `docs/recovery/reviews/`.
- [x] Merge is deferred until the user explicitly approves this PR.

Closes #103


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 운지 정보가 없는 악보에도 재생 시 결정론적인 초보자용 손가락 번호(1~5)를 표시합니다.
  - 원본에 저장된 운지 정보는 우선적으로 보존하며, 화음과 주요 음계에는 일관된 운지 패턴을 적용합니다.

- **버그 수정**
  - 매우 짧거나 작은 낙하 음표에서도 손가락 번호가 계속 표시됩니다.
  - 동일한 악보를 재생할 때마다 운지 번호가 달라지는 문제를 해결했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->