### PR TITLE
Fix mobile playback controls overflow

### DIFF
--- a/e2e/playback-controls-responsive.spec.ts
+++ b/e2e/playback-controls-responsive.spec.ts
@@ -1,0 +1,107 @@
+import { expect, test } from '@playwright/test'
+
+const animation = {
+  version: '1.0',
+  title: '모바일 컨트롤 회귀',
+  composer: '테스트 작곡가',
+  duration: 3,
+  tempo: 100,
+  tempoSource: 'score',
+  timingReferenceBpm: 100,
+  timeSignature: '4/4',
+  notes: [{ midi: 60, start: 0, duration: 1 }],
+}
+
+test('keeps the six labeled primary controls inside narrow viewports', async ({ page }) => {
+  await page.addInitScript(() => {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register = async () => {
+        throw new Error('service worker disabled for route fixture')
+      }
+    }
+  })
+
+  await page.route('**/api/sheet/1', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        sheetMusic: {
+          id: 1,
+          title: '모바일 컨트롤 회귀',
+          composer: '테스트 작곡가',
+          category: null,
+          isPublic: true,
+          provenance: 'omr',
+          availability: 'ready',
+          animationDataUrl: '/playback-controls.json',
+          createdAt: '2026-09-03T00:00:00.000Z',
+          updatedAt: '2026-09-03T00:00:00.000Z',
+          owner: null,
+        },
+      }),
+    })
+  })
+  await page.route('**/playback-controls.json', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(animation),
+    })
+  })
+
+  const widths = [320, 375, 390, 412, 430, 525, 550, 1024, 1440]
+  for (const width of widths) {
+    await page.setViewportSize({ width, height: 900 })
+    await page.goto('/sheet/1')
+    await expect(page.getByTestId('playback-primary-controls')).toBeVisible()
+
+    const layout = await page.getByTestId('playback-primary-controls').evaluate(element => {
+      const buttons = Array.from(element.querySelectorAll('button')).map(button => {
+        const rect = button.getBoundingClientRect()
+        return {
+          label: button.textContent?.trim(),
+          left: rect.left,
+          right: rect.right,
+          width: rect.width,
+          height: rect.height,
+        }
+      })
+      const loop = element.querySelector('[data-testid="playback-loop"]')
+
+      return {
+        documentWidth: document.documentElement.scrollWidth,
+        bodyWidth: document.body.scrollWidth,
+        primaryDisplay: getComputedStyle(element).display,
+        loopDisplay: loop ? getComputedStyle(loop).display : null,
+        buttons,
+      }
+    })
+
+    expect(layout.documentWidth, `document overflow at ${width}px`).toBeLessThanOrEqual(width)
+    expect(layout.bodyWidth, `body overflow at ${width}px`).toBeLessThanOrEqual(width)
+    expect(layout.buttons.map(button => button.label)).toEqual([
+      '재생',
+      '일시정지',
+      '중지',
+      'A 시작',
+      'B 종료',
+      '초기화',
+    ])
+    for (const button of layout.buttons) {
+      expect(button.left, `${button.label} starts outside ${width}px viewport`).toBeGreaterThanOrEqual(0)
+      expect(button.right, `${button.label} ends outside ${width}px viewport`).toBeLessThanOrEqual(width)
+      expect(button.width).toBeGreaterThanOrEqual(44)
+      expect(button.height).toBeGreaterThanOrEqual(44)
+    }
+
+    if (width < 768) {
+      expect(layout.primaryDisplay).toBe('grid')
+      expect(layout.loopDisplay).toBe('grid')
+    } else {
+      expect(layout.primaryDisplay).toBe('flex')
+      expect(layout.loopDisplay).toBe('flex')
+    }
+  }
+})

--- a/src/components/playback/PlaybackControls.tsx
+++ b/src/components/playback/PlaybackControls.tsx
@@ -123,7 +123,10 @@ export default function PlaybackControls({
 
       {/* Main Controls */}
       <div className="flex flex-wrap items-center justify-between gap-4">
-        <div className="flex items-center gap-3">
+        <div
+          data-testid="playback-primary-controls"
+          className="grid min-w-0 grid-cols-3 items-center gap-2 md:flex md:gap-3"
+        >
           {/* Play Button */}
           <Button
             onClick={onPlay}
@@ -167,7 +170,7 @@ export default function PlaybackControls({
           </Button>
 
           {onLoopStart && onLoopEnd && onLoopClear && (
-            <div className="flex items-center gap-1 rounded-full border border-rule bg-surface-muted p-1" data-testid="playback-loop">
+            <div className="col-span-3 grid grid-cols-3 items-center gap-1 rounded-full border border-rule bg-surface-muted p-1 md:flex" data-testid="playback-loop">
               <Button onClick={onLoopStart} variant="outline" size="lg" disabled={!isReady || duration <= 0} className="h-12 w-20 p-0 !px-0 !py-0 border-hand-left text-hand-left text-xs" title="구간 시작 A 설정" aria-label="A 시작">A 시작</Button>
               <Button onClick={onLoopEnd} variant="outline" size="lg" disabled={!isReady || duration <= 0 || loopStart === null} className="h-12 w-20 p-0 !px-0 !py-0 border-hand-right text-hand-right text-xs" title="구간 끝 B 설정" aria-label="B 종료">B 종료</Button>
               <Button onClick={onLoopClear} variant={loopEnd !== null ? 'primary' : 'ghost'} size="lg" disabled={!isReady || loopStart === null} className="h-12 w-20 gap-1 p-0 !px-0 !py-0 text-xs" title="A-B 구간 반복 초기화" aria-label="A-B 구간 반복 초기화">

--- a/src/components/playback/__tests__/PlaybackControls.test.tsx
+++ b/src/components/playback/__tests__/PlaybackControls.test.tsx
@@ -96,6 +96,17 @@ describe('PlaybackControls', () => {
     expect(screen.getByTestId('playback-stop')).toHaveClass('border-rule-strong')
   })
 
+  it('uses a narrow-screen 3-plus-3 layout for all six primary controls', () => {
+    renderControls()
+
+    const primaryControls = screen.getByTestId('playback-primary-controls')
+    const loopControls = screen.getByTestId('playback-loop')
+
+    expect(primaryControls).toHaveClass('grid', 'grid-cols-3')
+    expect(loopControls).toHaveClass('grid', 'grid-cols-3', 'col-span-3')
+    expect(primaryControls).not.toHaveClass('whitespace-nowrap')
+  })
+
   it('presents speed and secondary settings as matching rounded controls', () => {
     renderControls()
 


### PR DESCRIPTION
## Purpose
Resolve issue #118: the six labeled primary playback actions had a 534px intrinsic no-wrap group, causing horizontal document overflow on narrow mobile viewports.

## Scope
- Change only the primary transport and loop layout in PlaybackControls.
- Use a three-column mobile grid so transport actions occupy row one and A/B/초기화 occupy row two.
- Restore the existing desktop flex layout at the md breakpoint and keep all existing callbacks, Korean visible labels, and 48px button heights.
- Add Jest and Chromium Playwright regression coverage.

## Exclusions
- CompactPlaybackBar is unchanged.
- No global overflow hiding, global CSS changes, callback behavior changes, or product redesign.

## Risk
Narrow and reversible CSS/layout risk. The mobile grid changes only the arrangement below md; desktop keeps the prior flex arrangement. Revert corrected commit 5f0b92222f2e0700065a8591f01f109a5faa46d5 to roll back.

## Verification
- Regression-first focused Jest: failed before the fix because the responsive layout contract was absent; PASS after the fix, 6/6 tests.
- Chromium Playwright: PASS, 7/7 tests including existing application smoke; the responsive test checked 320, 375, 390, 412, 430, 525, 550, 1024, and 1440px. Every width had no document/body overflow, all six Korean labels, and buttons at least 44px wide/high; mobile computed as grid and desktop as flex.
- npm run lint: PASS, no warnings or errors.
- npm run build: PASS in the escalated environment; compilation and static page generation succeeded. Existing Prisma Windows engine warnings were emitted during page data collection.
- Full Jest (this checkout): 85/90 suites and 826/848 tests passed. The 5 failing suites/22 tests are environment-local and unrelated to the changed files: Python subprocess failures in converter corpus, converter tempo, OMR runtime, and piano samples, plus Windows path-separator expectations in uploadPathInventory. This session did not compare the result against main.
- npx tsc --noEmit (this checkout): executed and failed because the environment could not resolve the web-vitals module in src/lib/analytics.ts. This is environment-local and unrelated to the changed files; this session did not compare it against main.

## Review and CI
PR is review-ready (not draft), base main. CodeRabbit reports manual review required for this OSS repository. No review comments are present at the last check. CI must finish before merge.

## Baseline difference
The implementation adds one focused Jest contract test and one responsive Playwright spec; no existing production behavior or CompactPlaybackBar contract is intentionally changed.

## Rollback
Revert corrected commit 5f0b92222f2e0700065a8591f01f109a5faa46d5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 좁은 화면에서 재생 및 구간 반복 컨트롤을 3열 그리드로 배치해 사용성을 개선했습니다.
  * 중간 크기 이상의 화면에서는 기존 가로형 레이아웃을 유지합니다.

* **테스트**
  * 다양한 화면 너비에서 컨트롤 표시, 버튼 크기, 라벨, 오버플로 및 반응형 레이아웃을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->