### PR TITLE
AGENTS.md의 Project Reference에서 코드로 유도 가능한 내용을 걷어낸다

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,54 +115,7 @@ HANDOFF의 canonical entrypoint는 `docs/recovery/HANDOFF.md`다. 세부 근거�
 
 ClairKeys is an AI-powered piano learning application that converts PDF sheet music into interactive piano animations. The app features real-time piano visualization, audio playback with Tone.js, and mobile-optimized touch interfaces.
 
-### Core Commands
-
-#### Development
-```bash
-npm run dev              # Start development server on localhost:3000
-npm run build            # Build for production (includes Prisma generate)
-npm run start            # Start production server
-npm run lint             # Run ESLint
-npm test                 # Run Jest unit tests
-npm run test:watch       # Run tests in watch mode
-npm run test:coverage    # Generate test coverage report
-npm run test:e2e         # Run Playwright E2E tests
-npm run test:e2e:ui      # Run E2E tests with UI
-```
-
-#### Database & Storage
-```bash
-npm run db:generate      # Generate Prisma client
-npm run db:push          # Push schema changes to database (development)
-npm run db:migrate       # Run database migrations
-npm run db:studio        # Open Prisma Studio
-npm run seed             # Populate database with sample data
-npm run init-storage     # Initialize Supabase storage buckets
-npm run check-data-status # Verify database and storage integrity
-```
-
-#### Testing Single Components
-```bash
-# Run specific test file
-npm test -- --testNamePattern="ComponentName"
-npm test src/components/ui/__tests__/Button.test.tsx
-
-# Run tests for specific directory
-npm test src/services/__tests__/
-
-# Run E2E test for specific workflow
-npx playwright test application-smoke.spec.ts
-```
-
 ### Architecture Overview
-
-#### Core Technology Stack
-- **Next.js 15** with App Router - Full-stack React framework
-- **PostgreSQL + Prisma ORM** - Database layer with type-safe queries
-- **Supabase** - Database hosting and file storage for animation data
-- **NextAuth.js** - Authentication with Google/GitHub OAuth
-- **Tone.js + Web Audio API** - Piano sound synthesis
-- **Tailwind CSS** - Utility-first styling
 
 #### Key Data Flow
 
@@ -174,91 +127,12 @@ The application follows this core data pipeline:
 4. **Storage** → Animation data stored in Supabase Storage buckets
 5. **Playback** → `src/services/animationEngine.ts` coordinates audio and visual
 
-#### Database Schema
-
-The main entities and their relationships:
-
-- **User** - OAuth users (Google/GitHub)
-- **Category** - User-created sheet music categories
-- **SheetMusic** - Core entity with `animationDataUrl` pointing to Supabase Storage
-- **PracticeSession** - User practice tracking and statistics
-- **ProcessingJob** - Background processing queue for PDF conversion
-
 #### Authentication Architecture
 
 Using JWT-based sessions with manual user ID handling:
 - `src/lib/auth/config.ts` - NextAuth configuration with custom callbacks
 - Database user records are manually synchronized during OAuth flow
 - Custom callbacks ensure consistent user IDs between JWT and database
-
-### Component Architecture
-
-#### Layout Components (`src/components/layout/`)
-- `MainLayout.tsx` - Root layout with Header/Footer
-- `Header.tsx` - Navigation with authentication state
-- `Container.tsx` - Responsive content wrapper
-
-#### Piano Components (`src/components/piano/`)
-- `PianoKeyboard.tsx` - Core 88-key piano visualization
-- `EnhancedPianoKeyboard.tsx` - Version with advanced features
-- `SimplePianoKeyboard.tsx` - Minimal version for testing
-
-#### Mobile-Optimized (`src/components/mobile/`)
-- `FullScreenPiano.tsx` - Fullscreen API integration for mobile
-- `LandscapePianoInterface.tsx` - Landscape mode optimization
-- `MobileGestures.tsx` - Touch gesture handling (pinch, swipe)
-- `MobileTouchOptimizer.tsx` - Performance optimization for touch
-
-#### Animation & Playback (`src/components/`)
-- `animation/AnimationPlayer.tsx` - Core animation engine wrapper
-- `playback/PlaybackControls.tsx` - Play/pause/speed/loop controls
-- `practice/PracticeGuideControls.tsx` - Practice mode features
-
-#### Upload System (`src/components/upload/`)
-- `FileUpload.tsx` - PDF drag-and-drop interface
-- `OMRUploadForm.tsx` - Form for OMR service integration
-- `ProcessingStatus.tsx` - Real-time upload progress tracking
-
-### Key Services
-
-#### Animation Engine (`src/services/animationEngine.ts`)
-Core service that orchestrates:
-- Time-based animation playback at 60fps
-- Audio-visual synchronization with Tone.js
-- Practice mode with step-by-step guidance
-- Loop sections and tempo control
-
-#### Audio Service (`src/services/audioService.ts`)
-- Tone.js integration for piano sound synthesis
-- Note triggering with velocity and duration
-- Audio context management for mobile compatibility
-
-#### File Storage (`src/services/fileStorageService.ts`)
-- Supabase Storage integration for animation JSON files
-- Signed URL generation for private files
-- File upload/download with error handling
-
-#### Background Processing (`src/services/backgroundProcessor.ts`)
-- Queue system for PDF processing
-- Integration with Python OMR service
-- Status tracking and error handling
-
-### Mobile Features
-
-#### PWA Configuration
-- Service worker at `/public/sw.js`
-- Manifest in `/public/manifest.json`
-- Apple-specific meta tags in `src/app/layout.tsx`
-
-#### Mobile Optimization Hooks
-- `useMobileGestures.ts` - Touch gesture recognition
-- `useFullScreenAPI.ts` - Fullscreen mode management
-- `useMobileKeyboardSize.ts` - Dynamic piano sizing
-
-#### Cross-Platform Considerations
-- Fullscreen API implementation works across Chrome, Safari, Firefox
-- Touch events optimized for iOS and Android
-- Audio context initialization requires user gesture on mobile
 
 ### OMR Service Integration
 
@@ -275,17 +149,8 @@ Core service that orchestrates:
 
 ### Testing Strategy
 
-#### Unit Tests (Jest)
-- Components: `src/components/**/__tests__/`
-- Services: `src/services/__tests__/`
-- Hooks: `src/hooks/__tests__/`
-- Utils: `src/utils/__tests__/`
-
 #### E2E Tests (Playwright)
 - `e2e/application-smoke.spec.ts` - Public-route cross-browser smoke checks (home page, viewport/zoom, explore navigation); replaces the earlier dashboard/auth-fixture specs that PR #12 removed as aspirational (issue #7)
-
-#### Coverage Configuration
-Jest configured to collect coverage from all source directories except stories and type definitions.
 
 ### Environment Configuration
 
@@ -310,54 +175,10 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=...
 SUPABASE_SERVICE_ROLE_KEY=...
 ```
 
-### Common Development Patterns
-
-#### API Route Structure
-- RESTful API routes in `src/app/api/`
-- Error handling with consistent JSON responses
-- Authentication middleware using NextAuth sessions
-- Database queries through Prisma ORM
-
-#### Component Patterns
-- TypeScript interfaces defined in `src/types/`
-- Custom hooks for complex state management
-- Props interfaces exported from component files
-- Consistent error boundary patterns
-
-#### State Management
-- React hooks for local state
-- Custom hooks for cross-component state (e.g., `useSheetMusic.ts`)
-- No global state library - leveraging React's built-in state management
-
-### Performance Considerations
-
-#### Next.js Optimizations
-- Image optimization with Next.js Image component
-- Dynamic imports for code splitting
-- Development caching disabled for piano keyboard issues
-
-#### Audio/Animation Performance
-- 60fps animation loop using requestAnimationFrame
-- Audio context optimization for mobile browsers
-- Canvas-based piano rendering for performance
-- Lazy loading of animation data
-
-#### Mobile Performance
-- Touch event debouncing and throttling
-- Responsive piano sizing based on viewport
-- Gesture recognition optimized for 60fps
-- PWA caching strategies for offline usage
-
 ### Deployment Notes
-
-#### Vercel Configuration
-- Build command includes `prisma generate`
-- Environment variables configured in Vercel dashboard
-- Image optimization configured for Google/GitHub avatars
 
 #### Database Migrations
 - Use `npm run db:migrate` for production schema changes
 - `npm run db:push` for development rapid prototyping
 - Seed data available via `npm run seed`
 
-This codebase emphasizes mobile-first piano education with real-time audio-visual synchronization and cross-platform compatibility.


### PR DESCRIPTION
## 배경

`CLAUDE.md`는 모든 세션에 `AGENTS.md`를 시작 전 필독하도록 지시한다. 따라서 `AGENTS.md`의 길이는 세션마다 고정으로 지불하는 비용이다.

그런데 `## Project Reference` 섹션은 **파일 자신이 이미 신뢰하지 말라고 표시**하고 있었다.

> 작업 규약이 아니라 코드베이스에 대한 설명이므로, 위 규약 섹션들과 달리 코드가 바뀌면 낡아질 수 있다 — 불확실하면 실제 코드를 우선한다.

즉 세션은 그 내용을 읽는 비용을 치른 뒤, 믿지 말라는 말을 함께 듣고 있었다.

## 변경

`363행 20,654자` → `184행 14,082자` (약 1,640 토큰/세션 절감). **규약 섹션(1~109행)은 한 글자도 바뀌지 않았다.**

### 걷어낸 것 — 몇 번의 도구 호출로 복원 가능

| 절 | 유도 출처 |
|---|---|
| Core Commands (Development / Database & Storage / Testing Single Components) | `package.json`의 `scripts` |
| Core Technology Stack | `package.json` 의존성 |
| Database Schema | `prisma/schema.prisma` |
| Component Architecture 6개 절 | `ls src/components/` |
| Key Services 5개 절 | `ls src/services/` |
| Mobile Features 4개 절 | 파일 목록 |
| Unit Tests / Coverage Configuration | `jest.config.js` + 디렉터리 |
| Common Development Patterns / Performance Considerations | 일반 모범사례 |
| Vercel Configuration | `vercel.json`, `next.config` |

### 남긴 것 — 코드가 설명하지 못하는 것

- **Authentication Architecture** — OAuth 흐름에서 DB 사용자 레코드를 **수동 동기화**한다는 함정
- **OMR Service Integration** — Podman 컨테이너, systemd 관리, NAVER Cloud VM. 이 저장소에 없는 사실이다
- **Environment Configuration** — `.env.example`이 존재하지 않음을 확인했다. 유도할 출처가 없다
- **E2E Tests** — 이전 spec을 PR #12가 제거한 경위(이슈 #7)
- **Database Migrations** — prod는 `db:migrate`, dev는 `db:push`라는 정책
- **Project Overview / Key Data Flow** — 도메인 맥락과 파이프라인 전체 그림

## 검증

- `.env.example` 부재를 확인한 뒤 Environment Configuration을 유지 대상으로 되돌렸다
- 잘라낸 명령어가 실제로 `package.json` scripts에 존재함을 확인했다
- 코드 변경이 없으므로 Jest·typecheck·lint·build 대상이 아니다

## 후속

`Directive`로 남긴 규칙: 다시 채워 넣기 전에 묻는다. 코드를 읽어 얻을 수 있는 내용이면 여기 두지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XibCVXWYs4wHengbF3vB7L