### PR TITLE
Fix animation freezing after the first A-B loop

### DIFF
--- a/docs/recovery/phases/AUDIT-playback-loop.md
+++ b/docs/recovery/phases/AUDIT-playback-loop.md
@@ -1,0 +1,35 @@
+# AUDIT — A-B 반복의 프레임 수명주기
+
+Status: `IN_PROGRESS`
+Depends on: DS-5 (기존 A-B 구간 반복)
+
+## Objective
+
+2026-09-05 감사에서 확인한 첫 A-B 복귀 이후 애니메이션 중단을 복구한다.
+오디오 seek가 끝난 뒤 다음 프레임을 예약하고, 기다리는 사이 정지·pause·unmount 또는
+effect 교체가 일어나면 이전 루프가 다시 살아나지 않게 한다.
+
+## Work stages
+
+1. 실제 audio hook처럼 안정된 콜백을 쓰는 회귀 테스트로 B 통과 이후 프레임 누락을 재현한다.
+2. 비동기 seek와 effect cleanup을 연결해 프레임 수명주기를 복구한다.
+3. 연속 반복, 진행 중 pause/stop/unmount, 실패한 재시작을 검증한다.
+4. focused/전체 Jest, typecheck, lint, build 후 독립 review-ready PR을 제출한다.
+
+## Completion criteria
+
+- 두 번 이상의 B→A 복귀 후에도 시각 시계가 오디오 시계를 따라간다.
+- seek가 지연돼도 중복 seek나 중복 프레임 루프가 발생하지 않는다.
+- 정지·pause·unmount 후 지연된 seek가 프레임을 되살리지 않는다.
+- 재시작 실패 시 재생 상태가 해제된다.
+- 관련 회귀 테스트가 수정 전 실패하고 수정 후 통과한다.
+- 필수 검증과 PR 리뷰 대응이 기록되고 명시적 승인 후 병합된다.
+
+## Out of scope
+
+- 오디오 sample 로딩 정책과 프레임 처리 성능 최적화.
+- #134/#137 템포, #135 유지음, #130 운지 비용 모델.
+- A-B의 음표 잘라내기나 새로운 반복 음악 표현 계약.
+
+Evidence: [감사](../validation/2026-09-05-codebase-audit.md),
+[실행 가능한 진단](../validation/2026-09-05-codebase-audit-evidence.md).

--- a/src/hooks/__tests__/useFallingNotesPlayer.test.ts
+++ b/src/hooks/__tests__/useFallingNotesPlayer.test.ts
@@ -1,41 +1,140 @@
 import { act, renderHook } from '@testing-library/react'
 import { useFallingNotesPlayer } from '../useFallingNotesPlayer'
+import type { FallingNote } from '@/types/fallingNotes'
+
+let mockClock = 0
+const mockAudio = {
+  startAudio: jest.fn(async (_notes: FallingNote[], offset: number) => {
+    mockClock = offset
+    return true
+  }),
+  stopAudio: jest.fn(),
+  getCurrentTime: jest.fn(() => mockClock),
+  updateTempoScale: jest.fn(),
+  setOffsetTime: jest.fn((time: number) => { mockClock = time }),
+  setVolume: jest.fn((value: number) => value),
+  sampleStatus: 'ready',
+  reset: jest.fn(() => { mockClock = 0 }),
+}
 
 jest.mock('../useFallingNotesAudio', () => ({
   DEFAULT_MASTER_GAIN: 0.8,
-  useFallingNotesAudio: () => ({
-    startAudio: jest.fn(async () => true),
-    stopAudio: jest.fn(),
-    getCurrentTime: jest.fn(() => 0),
-    updateTempoScale: jest.fn(),
-    setOffsetTime: jest.fn(),
-    setVolume: jest.fn((value: number) => value),
-    sampleStatus: 'ready',
-    reset: jest.fn(),
-  }),
+  // Match the real hook's stable callbacks: new mocks per render would restart
+  // the effect and conceal the missing frame after a successful seek.
+  useFallingNotesAudio: () => mockAudio,
 }))
 
-jest.mock('@/utils/visualUtils', () => ({
-  calculateSongLength: () => 10,
-  shouldAutoStop: () => false,
-}))
+const notes: FallingNote[] = [{ midi: 60, start: 0, duration: 10 }]
+const frames = new Map<number, FrameRequestCallback>()
+let nextFrame = 0
 
-describe('useFallingNotesPlayer loop markers', () => {
-  it('commits B only when it makes a valid A–B interval', async () => {
-    const { result } = renderHook(() => useFallingNotesPlayer([]))
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockClock = 0
+  frames.clear()
+  nextFrame = 0
+  mockAudio.startAudio.mockImplementation(async (_notes, offset) => {
+    mockClock = offset
+    return true
+  })
+  jest.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
+    frames.set(++nextFrame, callback)
+    return nextFrame
+  })
+  jest.spyOn(window, 'cancelAnimationFrame').mockImplementation(id => { frames.delete(id) })
+})
 
-    await act(async () => {
-      await result.current.seek(4)
-    })
+afterEach(() => { jest.restoreAllMocks() })
+
+async function frameAt(time: number) {
+  await act(async () => {
+    mockClock = time
+    const callbacks = [...frames.values()]
+    frames.clear()
+    callbacks.forEach(callback => callback(0))
+  })
+}
+
+async function playingLoop() {
+  const hook = renderHook(() => useFallingNotesPlayer(notes))
+  await act(async () => { await hook.result.current.seek(2) })
+  act(() => hook.result.current.markLoopStart())
+  await act(async () => { await hook.result.current.seek(4) })
+  act(() => hook.result.current.markLoopEnd())
+  await act(async () => { await hook.result.current.seek(2) })
+  await act(async () => { await hook.result.current.play() })
+  return hook
+}
+
+describe('useFallingNotesPlayer loop lifecycle', () => {
+  it('commits B only when it makes a valid A-B interval', async () => {
+    const { result } = renderHook(() => useFallingNotesPlayer(notes))
+    await act(async () => { await result.current.seek(4) })
     act(() => result.current.markLoopStart())
-
     act(() => result.current.markLoopEnd())
     expect(result.current.loopEnd).toBeNull()
-
-    await act(async () => {
-      await result.current.seek(6)
-    })
+    await act(async () => { await result.current.seek(6) })
     act(() => result.current.markLoopEnd())
     expect(result.current.loopEnd).toBe(6)
+  })
+
+  it('keeps one frame loop and follows the audio clock through repeated wraps', async () => {
+    const { result } = await playingLoop()
+    for (let cycle = 0; cycle < 3; cycle++) {
+      await frameAt(4.1)
+      expect(result.current.currentTime).toBe(2)
+      expect(frames.size).toBe(1)
+      await frameAt(2.5)
+      expect(result.current.currentTime).toBe(2.5)
+    }
+    expect(mockAudio.startAudio).toHaveBeenCalledTimes(4)
+    expect(result.current.isPlaying).toBe(true)
+  })
+
+  it('waits for a delayed seek before scheduling the next frame', async () => {
+    await playingLoop()
+    let finish!: (started: boolean) => void
+    mockAudio.startAudio.mockImplementationOnce(() => new Promise(resolve => { finish = resolve }))
+    await frameAt(4.1)
+    expect(frames.size).toBe(0)
+    await frameAt(4.2)
+    expect(mockAudio.startAudio).toHaveBeenCalledTimes(2)
+    await act(async () => { finish(true) })
+    expect(frames.size).toBe(1)
+  })
+
+  it.each(['pause', 'stop', 'unmount'] as const)(
+    'does not resurrect a pending wrap after %s', async action => {
+      const hook = await playingLoop()
+      let finish!: (started: boolean) => void
+      mockAudio.startAudio.mockImplementationOnce(() => new Promise(resolve => { finish = resolve }))
+      await frameAt(4.1)
+      act(() => {
+        if (action === 'unmount') hook.unmount()
+        else hook.result.current[action]()
+      })
+      await act(async () => { finish(true) })
+      expect(frames.size).toBe(0)
+      if (action !== 'unmount') expect(hook.result.current.isPlaying).toBe(false)
+    },
+  )
+
+  it('does not add a second frame loop when markers change during a pending wrap', async () => {
+    const { result } = await playingLoop()
+    let finish!: (started: boolean) => void
+    mockAudio.startAudio.mockImplementationOnce(() => new Promise(resolve => { finish = resolve }))
+    await frameAt(4.1)
+    act(() => result.current.clearLoop())
+    expect(frames.size).toBe(1)
+    await act(async () => { finish(true) })
+    expect(frames.size).toBe(1)
+  })
+
+  it('stops the frame loop when audio cannot restart', async () => {
+    const { result } = await playingLoop()
+    mockAudio.startAudio.mockResolvedValueOnce(false)
+    await frameAt(4.1)
+    expect(result.current.isPlaying).toBe(false)
+    expect(frames.size).toBe(0)
   })
 })

--- a/src/hooks/useFallingNotesPlayer.ts
+++ b/src/hooks/useFallingNotesPlayer.ts
@@ -188,6 +188,7 @@ export function useFallingNotesPlayer(notes: FallingNote[]) {
       return
     }
 
+    let cancelled = false
     const animationLoop = () => {
       // Audio, falling notes, and active keys all consume this one score-time
       // value derived from the AudioContext playback anchor.
@@ -195,7 +196,13 @@ export function useFallingNotesPlayer(notes: FallingNote[]) {
       setCurrentTime(currentAudioTime)
 
       if (loopSection && currentAudioTime >= loopSection.end) {
-        void handleSeek(loopSection.start)
+        // A successful seek keeps isPlaying and this effect's dependencies
+        // unchanged. Resume this loop explicitly, once the audio is ready.
+        // Cleanup owns cancellation if pause/stop/unmount replaces the effect
+        // while the asynchronous seek is still waiting.
+        void handleSeek(loopSection.start).then(() => {
+          if (!cancelled) rafRef.current = requestAnimationFrame(animationLoop)
+        })
         return
       }
 
@@ -211,6 +218,7 @@ export function useFallingNotesPlayer(notes: FallingNote[]) {
     rafRef.current = requestAnimationFrame(animationLoop)
 
     return () => {
+      cancelled = true
       if (rafRef.current) {
         cancelAnimationFrame(rafRef.current)
         rafRef.current = null


### PR DESCRIPTION
A–B playback restarts audio at A but stops updating the screen after the first wrap: the frame callback returns without scheduling its successor. Resume the frame loop after the asynchronous seek, and cancel that continuation when pause, stop, unmount or a changed effect takes ownership.

Stable audio callbacks in the regression harness reproduce the original failure; the previous marker-only test created new callbacks every render and could conceal it. Covers repeated wraps, delayed seeks, cancellation, marker changes and failed restarts.

Validation: before the fix, 2 failed / 6 passed; after, 8 loop tests passed, focused audio/player 16 passed, full Jest 94 suites / 911 tests passed, independent typecheck and lint passed, production build passed. The local build skips its bundled type/lint steps, so those were explicitly run separately. Physical-device playback and browser E2E are not tested locally; hosted CI remains required.

Scope is the existing frame-loop lifecycle. Audio scheduling policy, tempo, fingering and score contracts are unchanged. Rollback is a revert of this PR. Phase: `docs/recovery/phases/AUDIT-playback-loop.md`; baseline: the 2026-09-05 codebase audit. Merge only on explicit approval for this PR.
