### PR TITLE
Make tempo units explicit and let owners retime stored scores

### DIFF
--- a/docs/recovery/DECISIONS.md
+++ b/docs/recovery/DECISIONS.md
@@ -1755,6 +1755,23 @@
   옳게 순위를 매기는지는 미확인.
 - Related: D-038, D-039, D-041, D-042, D-043, 이슈 [#130](https://github.com/landfill/ClairKeys/issues/130)
 
+## D-046: 템포 입력의 음표 단위와 저장된 시간축 수정
+
+- Date: 2026-09-05
+- Status: Proposed with issue #137 implementation
+- Context: #134 원본의 점4분음표=46은 quarter BPM 69로 인식됐지만 사용자 입력 46이 덮어썼다. 라이브러리 편집은 제목만 노출한다.
+- Decision:
+  1. UI에서 입력 숫자와 음표 단위를 함께 받고 quarter BPM으로 환산해 기존 API에 보낸다. 빈 입력은 자동 인식, 인식값도 없을 때만 미상이다.
+  2. 기존 악보 템포 수정은 `timingReferenceBpm / newQuarterBpm`으로 모든 start/duration와 전체 duration를 균일하게 변환한다. 원본의 상대적 템포 변화는 보존한다. 업로드의 고정 템포 override와 이 편집의 균일 속도 조절 의미를 구별한다.
+  3. 새 데이터는 canonical v1.1, tempoSource=user, tempo/timingReferenceBpm=새 값으로 저장하고 scoreTempo는 유지한다. 기존 JSON 객체를 덮어쓰지 않고 새 URL로 교체한다.
+  4. 소유자 검증 후 앱의 기존 Supabase 권한으로만 읽고 쓴다. URL은 구성된 Supabase의 animation-data 버킷으로 제한한다. DB는 기존 URL과 updatedAt을 비교해 한 편집만 반영한다.
+  5. 동시 편집으로 확실히 반영되지 않은 새 객체는 제거한다. DB 통신 실패로 반영 여부가 불확실하면 새 객체를 보존한다. 이전 객체는 공유 참조나 복구에 필요할 수 있어 삭제하지 않는다; 수명주기 정리는 별도다.
+- Rejected: 메타데이터 숫자만 수정 | 노트 시간은 이미 초로 저장돼 있어 실제 재생이 바뀌지 않는다.
+- Constraint: 기존 악보 재등록 허용(D-040)은 유지한다. 이 변경으로 박자표나 OMR 음표 오류를 보정하지 않는다.
+- Confidence: high
+- Scope-risk: moderate
+- Related: #134, #137, 2026-09-05 codebase audit
+
 ## D-045: 손 이동을 재는 지표는 아르페지오에서 전부 뒤집힌다 — 검증 세트는 결함이 사는 악구를 포함해야 한다
 
 - Date: 2026-09-05

--- a/docs/recovery/phases/ISSUE-137-tempo-controls.md
+++ b/docs/recovery/phases/ISSUE-137-tempo-controls.md
@@ -1,0 +1,34 @@
+# ISSUE-137 — 템포 단위 입력과 저장된 악보의 빠르기 수정
+
+Status: `IN_PROGRESS`
+Depends on: P1-A, canonical v1.1 tempo provenance
+
+## Objective
+
+악보의 점4분음표=46을 4분음표=46으로 오입력하는 경로를 제거하고,
+스크롤로 숫자가 바뀌지 않는 입력·슬라이더와 기존 악보의 템포 수정 경로를 제공한다.
+
+## Work stages
+
+1. 단위 환산·빈 값·업로드 전송값·기존 악보 시간 변환 회귀를 먼저 작성한다.
+2. quarter/dotted-quarter/eighth/half 단위 선택과 슬라이더, 자동 인식 안내를 제공한다.
+3. 소유자 템포 수정은 기존 JSON을 읽어 전체 시간축을 균일 배율로 변환한 새 객체를 저장한다.
+4. 기존 URL/updatedAt을 비교하는 DB 갱신으로 동시 편집을 검출한다. 실패하면 기존 악보를 보존한다.
+5. focused/전체 Jest, typecheck, lint, build와 review-ready PR 및 리뷰 대응을 기록한다.
+
+## Completion criteria
+
+- 점4분음표 46 입력은 API에 quarter BPM 69로 전달된다.
+- 빈 업로드 입력은 자동 인식을 사용하고, 자동 인식도 없을 때만 미상으로 표시한다.
+- 키 입력 영역은 wheel로 값이 바뀌지 않으며 슬라이더와 단위가 접근 가능한 label을 가진다.
+- 소유자는 라이브러리 편집창에서 템포를 지정할 수 있다. 빈 편집 값은 기존 템포 유지다.
+- 템포 수정은 note start/duration와 전체 duration를 함께 바꾸고 MIDI/hand/finger를 보존한다.
+- 권한 실패·잘못된 BPM·저장 실패·동시 편집은 기존 URL과 데이터를 훼손하지 않는다.
+- 필수 검증, 리뷰 대응, 명시적 승인에 따른 병합까지 기록한다.
+
+## Out of scope
+
+- #134의 9/8→6/8 인식 원인 및 음표 인식 수정. 메타데이터 템포 수정으로 이슈 전체를 닫지 않는다.
+- 원본 MusicXML 보관, 페달 계약, 운지 모델.
+
+Decision: D-046. 사용자 승인 없는 기존 운영 악보 일괄 수정은 하지 않는다.

--- a/src/app/api/sheet/[id]/__tests__/tempo.test.ts
+++ b/src/app/api/sheet/[id]/__tests__/tempo.test.ts
@@ -1,0 +1,61 @@
+/** @jest-environment node */
+import { NextRequest } from 'next/server'
+import { PUT } from '../route'
+import { getServerSession } from 'next-auth'
+import { prisma } from '@/lib/prisma'
+import { saveSheetTempo } from '@/services/sheetTempoService'
+
+jest.mock('next-auth')
+jest.mock('@/lib/prisma', () => ({ prisma: { sheetMusic: { findUnique: jest.fn(), update: jest.fn() } } }))
+jest.mock('@/services/sheetTempoService')
+
+const source = {
+  id: 1, userId: 'owner', title: 'score', composer: 'composer', isPublic: false,
+  animationDataUrl: 'https://score.supabase.co/storage/v1/object/public/animation-data/owner/score.json',
+  updatedAt: new Date('2026-09-05T00:00:00Z'), categoryId: null, category: null,
+  createdAt: new Date('2026-09-05T00:00:00Z'), processingStatus: 'completed', omrJobId: null,
+  provenance: 'omr' as const,
+}
+const request = (body: unknown) => PUT(new NextRequest('http://localhost/api/sheet/1', {
+  method: 'PUT', body: JSON.stringify(body),
+}), { params: Promise.resolve({ id: '1' }) })
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  jest.mocked(getServerSession).mockResolvedValue({ user: { id: 'owner' } })
+  jest.mocked(prisma.sheetMusic.findUnique).mockResolvedValue(source as Awaited<ReturnType<typeof prisma.sheetMusic.findUnique>>)
+  jest.mocked(saveSheetTempo).mockResolvedValue({ ...source, animationDataUrl: 'new-url' } as Awaited<ReturnType<typeof saveSheetTempo>>)
+})
+
+it('routes owner edits through time rescaling and returns the new animation URL', async () => {
+  const response = await request({ title: 'renamed', tempo: 69 })
+  expect(response.status).toBe(200)
+  expect(saveSheetTempo).toHaveBeenCalledWith({
+    id: 1, userId: 'owner', animationDataUrl: source.animationDataUrl, updatedAt: source.updatedAt,
+  }, 69, { title: 'renamed' })
+  expect((await response.json()).sheetMusic.animationDataUrl).toBe('new-url')
+  expect(prisma.sheetMusic.update).not.toHaveBeenCalled()
+})
+
+it.each([0, 401, null, '69'])('rejects invalid tempo %s before any storage change', async tempo => {
+  expect((await request({ tempo })).status).toBe(400)
+  expect(saveSheetTempo).not.toHaveBeenCalled()
+})
+
+it('does not let a non-owner rewrite public animation data', async () => {
+  jest.mocked(getServerSession).mockResolvedValue({ user: { id: 'visitor' } })
+  expect((await request({ tempo: 69 })).status).toBe(403)
+  expect(saveSheetTempo).not.toHaveBeenCalled()
+})
+
+it('requires authentication', async () => {
+  jest.mocked(getServerSession).mockResolvedValue(null)
+  expect((await request({ tempo: 69 })).status).toBe(401)
+  expect(saveSheetTempo).not.toHaveBeenCalled()
+})
+
+it('rejects unfinished scores', async () => {
+  jest.mocked(prisma.sheetMusic.findUnique).mockResolvedValue({ ...source, animationDataUrl: '' } as Awaited<ReturnType<typeof prisma.sheetMusic.findUnique>>)
+  expect((await request({ tempo: 69 })).status).toBe(409)
+  expect(saveSheetTempo).not.toHaveBeenCalled()
+})

--- a/src/app/api/sheet/[id]/route.ts
+++ b/src/app/api/sheet/[id]/route.ts
@@ -5,6 +5,8 @@ import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
 import { sheetMusicCache } from '@/services/cacheService'
 import { deriveSheetMusicAvailability } from '@/lib/sheetMusicAvailability'
+import { quarterBpm } from '@/utils/tempoInput'
+import { saveSheetTempo, TempoEditError } from '@/services/sheetTempoService'
 
 export async function GET(
   request: NextRequest,
@@ -113,7 +115,16 @@ export async function PUT(
 
     // Parse request body
     const body = await request.json()
-    const { title, composer, categoryId, isPublic } = body
+    const { title, composer, categoryId, isPublic, tempo } = body
+
+    if (tempo !== undefined) {
+      try {
+        if (typeof tempo !== 'number') throw new Error()
+        quarterBpm(String(tempo), 'quarter')
+      } catch {
+        return NextResponse.json({ error: 'Tempo must be a number between 20 and 400 quarter BPM' }, { status: 400 })
+      }
+    }
 
     // Validate required fields only if they are being updated
     if (title !== undefined && !title?.trim()) {
@@ -182,7 +193,14 @@ export async function PUT(
       updateData.isPublic = isPublic
     }
 
-    const updatedSheet = await prisma.sheetMusic.update({
+    if (tempo !== undefined && deriveSheetMusicAvailability(existingSheet) !== 'ready') {
+      return NextResponse.json({ error: 'The score is not ready for tempo editing' }, { status: 409 })
+    }
+
+    const updatedSheet = tempo !== undefined ? await saveSheetTempo({
+      id: sheetId, userId: session.user.id, animationDataUrl: existingSheet.animationDataUrl,
+      updatedAt: existingSheet.updatedAt,
+    }, tempo, updateData) : await prisma.sheetMusic.update({
       where: { id: sheetId },
       data: updateData,
       include: {
@@ -195,6 +213,13 @@ export async function PUT(
       }
     })
 
+    if (!updatedSheet) return NextResponse.json({ error: 'Sheet music not found' }, { status: 404 })
+
+    sheetMusicCache.invalidateSheet(sheetId)
+    sheetMusicCache.invalidateUser(session.user.id)
+    sheetMusicCache.invalidateSearch()
+    if (existingSheet.isPublic || updatedSheet.isPublic) sheetMusicCache.invalidatePublic()
+
     return NextResponse.json({
       success: true,
       sheetMusic: {
@@ -204,12 +229,16 @@ export async function PUT(
         categoryId: updatedSheet.categoryId,
         category: updatedSheet.category?.name || null,
         isPublic: updatedSheet.isPublic,
+        animationDataUrl: updatedSheet.animationDataUrl,
         updatedAt: updatedSheet.updatedAt
       }
     })
 
   } catch (error) {
     console.error('Update sheet music error:', error)
+    if (error instanceof TempoEditError) {
+      return NextResponse.json({ error: error.message }, { status: error.status })
+    }
     
     return NextResponse.json(
       { error: 'Internal server error' },

--- a/src/components/library/LibrarySheetMusicList.tsx
+++ b/src/components/library/LibrarySheetMusicList.tsx
@@ -8,6 +8,8 @@ import type { SheetMusicWithCategory } from '@/types/sheet-music'
 import Button from '@/components/ui/Button'
 import Loading from '@/components/ui/Loading'
 import StatusState from '@/components/ui/StatusState'
+import TempoInput from '@/components/upload/TempoInput'
+import { quarterBpm, TEMPO_ERROR, type TempoUnit } from '@/utils/tempoInput'
 
 export interface LibrarySheetMusicListProps {
   selectedCategoryId?: number | null
@@ -32,6 +34,10 @@ export function LibrarySheetMusicList({
   const [editingSheet, setEditingSheet] = useState<SheetMusicWithCategory | null>(null)
   const [title, setTitle] = useState('')
   const [titleError, setTitleError] = useState<string | null>(null)
+  const [tempo, setTempo] = useState('')
+  const [tempoUnit, setTempoUnit] = useState<TempoUnit>('quarter')
+  const [tempoError, setTempoError] = useState<string | undefined>()
+  const [saving, setSaving] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
   useEffect(() => {
@@ -112,25 +118,35 @@ export function LibrarySheetMusicList({
   const openTitleEditor = (sheet: SheetMusicWithCategory) => {
     setTitle(sheet.title)
     setTitleError(null)
+    setTempo('')
+    setTempoUnit('quarter')
+    setTempoError(undefined)
     setEditingSheet(sheet)
   }
 
   const saveTitle = async (event: FormEvent) => {
     event.preventDefault()
-    if (!editingSheet) return
+    if (!editingSheet || saving) return
     if (!title.trim()) {
       setTitleError('제목을 입력해 주세요.')
       return
     }
 
+    let bpm: number | null
+    try { bpm = quarterBpm(tempo, tempoUnit) } catch { setTempoError(TEMPO_ERROR); return }
+
     try {
+      setSaving(true)
       setTitleError(null)
+      setTempoError(undefined)
       setErrorMessage(null)
-      await updateSheetMusic(editingSheet.id, { title: title.trim() })
+      await updateSheetMusic(editingSheet.id, { title: title.trim(), ...(bpm !== null ? { tempo: bpm } : {}) })
       setEditingSheet(null)
     } catch (error) {
       console.error('Failed to update sheet music title:', error)
-      setErrorMessage('제목을 저장하지 못했습니다. 잠시 후 다시 시도해 주세요.')
+      setErrorMessage('악보 정보를 저장하지 못했습니다. 새로고침한 뒤 다시 시도해 주세요.')
+    } finally {
+      setSaving(false)
     }
   }
 
@@ -219,7 +235,7 @@ export function LibrarySheetMusicList({
       {editingSheet && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" role="dialog" aria-modal="true" aria-labelledby="edit-sheet-title">
           <form onSubmit={saveTitle} className="w-full max-w-md rounded-lg bg-surface p-6 shadow-xl">
-            <h2 id="edit-sheet-title" className="text-lg font-semibold text-ink">악보 제목 수정</h2>
+            <h2 id="edit-sheet-title" className="text-lg font-semibold text-ink">악보 정보 수정</h2>
             <label className="mt-4 block text-sm font-medium text-ink" htmlFor="sheet-title">제목</label>
             <input
               id="sheet-title"
@@ -234,12 +250,16 @@ export function LibrarySheetMusicList({
               aria-describedby={titleError ? 'sheet-title-error' : undefined}
             />
             {titleError && <p id="sheet-title-error" role="alert" className="mt-2 text-sm text-state-error">{titleError}</p>}
+            {editingSheet.availability === 'ready' && <div className="mt-4">
+              <TempoInput value={tempo} unit={tempoUnit} onChange={setTempo} onUnitChange={setTempoUnit}
+                editing disabled={saving} error={tempoError} />
+            </div>}
             <div className="mt-6 flex justify-end gap-3">
-              <Button type="button" variant="outline" onClick={() => {
+              <Button type="button" variant="outline" disabled={saving} onClick={() => {
                 setTitleError(null)
                 setEditingSheet(null)
               }}>취소</Button>
-              <Button type="submit">저장</Button>
+              <Button type="submit" disabled={saving}>{saving ? '저장 중…' : '저장'}</Button>
             </div>
           </form>
         </div>

--- a/src/components/library/__tests__/LibrarySheetMusicList.test.tsx
+++ b/src/components/library/__tests__/LibrarySheetMusicList.test.tsx
@@ -59,6 +59,15 @@ describe('LibrarySheetMusicList', () => {
     await waitFor(() => expect(updateSheetMusic).toHaveBeenCalledWith(1, { title: '새 제목' }))
   })
 
+  it('submits a printed dotted-quarter tempo as quarter BPM from the live edit dialog', async () => {
+    render(<LibrarySheetMusicList />)
+    fireEvent.click(screen.getByRole('button', { name: '연습 가능 제목 수정' }))
+    fireEvent.change(screen.getByLabelText('빠르기 (BPM)'), { target: { value: '46' } })
+    fireEvent.change(screen.getByLabelText('박 단위'), { target: { value: 'dotted-quarter' } })
+    fireEvent.click(screen.getByRole('button', { name: '저장' }))
+    await waitFor(() => expect(updateSheetMusic).toHaveBeenCalledWith(1, { title: '연습 가능', tempo: 69 }))
+  })
+
   it('explains why a whitespace-only title cannot be saved', async () => {
     render(<LibrarySheetMusicList />)
 

--- a/src/components/upload/OMRUploadForm.tsx
+++ b/src/components/upload/OMRUploadForm.tsx
@@ -4,6 +4,8 @@ import React, { useCallback, useEffect, useId, useRef, useState } from 'react'
 import { useSession } from 'next-auth/react'
 import { Button, StatusState, UploadIcon } from '@/components/ui'
 import type { Category } from '@/types/category'
+import TempoInput from './TempoInput'
+import { quarterBpm, TEMPO_ERROR, type TempoUnit } from '@/utils/tempoInput'
 import { fileSignature, inspectPdfFile, MAX_UPLOAD_MB } from '@/lib/upload/pdfInspection'
 import {
   classifyUploadResponse,
@@ -60,6 +62,7 @@ export default function OMRUploadForm({
   })
 
   const [selectedFile, setSelectedFile] = useState<File | null>(null)
+  const [tempoUnit, setTempoUnit] = useState<TempoUnit>('quarter')
   const [phase, setPhase] = useState<FormPhase>('idle')
   const [failure, setFailure] = useState<UploadFailure | null>(null)
   const [isDragging, setIsDragging] = useState(false)
@@ -133,12 +136,7 @@ export default function OMRUploadForm({
       newErrors.composer = '저작자는 필수 입력 항목입니다.'
     }
 
-    if (formData.tempo.trim()) {
-      const tempo = Number(formData.tempo)
-      if (!Number.isFinite(tempo) || tempo < 20 || tempo > 400) {
-        newErrors.tempo = '빠르기는 20에서 400 사이로 입력해 주세요.'
-      }
-    }
+    try { quarterBpm(formData.tempo, tempoUnit) } catch { newErrors.tempo = TEMPO_ERROR }
 
     if (!selectedFile) {
       newErrors.file = 'PDF 파일을 선택해주세요.'
@@ -239,7 +237,7 @@ export default function OMRUploadForm({
       uploadFormData.append('title', title)
       uploadFormData.append('composer', formData.composer.trim())
       if (formData.tempo.trim()) {
-        uploadFormData.append('tempo', formData.tempo.trim())
+        uploadFormData.append('tempo', String(quarterBpm(formData.tempo, tempoUnit)))
       }
       if (formData.categoryId) {
         uploadFormData.append('categoryId', formData.categoryId.toString())
@@ -422,32 +420,9 @@ export default function OMRUploadForm({
           {errors.composer && <p className="mt-1 text-sm text-state-error">{errors.composer}</p>}
         </div>
 
-        {/* 빠르기 (D-013: 비워두면 미상) */}
-        <div>
-          <label htmlFor="tempo" className="mb-2 block text-sm font-medium text-ink">
-            빠르기 (BPM)
-          </label>
-          <input
-            id="tempo"
-            type="number"
-            min={20}
-            max={400}
-            step="any"
-            value={formData.tempo}
-            onChange={(e) => handleInputChange('tempo', e.target.value)}
-            aria-describedby="tempo-help"
-            aria-invalid={Boolean(errors.tempo)}
-            className={`w-full rounded-2xl border px-3 py-2 transition-colors focus:border-accent ${
-              errors.tempo ? 'border-state-error' : 'border-rule-strong'
-            }`}
-            placeholder="예: 60"
-            disabled={isBusy}
-          />
-          <p id="tempo-help" className="mt-1 text-xs text-ink-muted">
-            선택 입력입니다. 비워두면 빠르기 미상으로 표시됩니다.
-          </p>
-          {errors.tempo && <p className="mt-1 text-sm text-state-error">{errors.tempo}</p>}
-        </div>
+        <TempoInput value={formData.tempo} unit={tempoUnit}
+          onChange={value => handleInputChange('tempo', value)} onUnitChange={setTempoUnit}
+          disabled={isBusy} error={errors.tempo} />
 
         {/* 카테고리 */}
         <div>

--- a/src/components/upload/TempoInput.tsx
+++ b/src/components/upload/TempoInput.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { useId } from 'react'
+import { quarterBpm, TEMPO_UNITS, type TempoUnit } from '@/utils/tempoInput'
+
+interface Props {
+  value: string
+  unit: TempoUnit
+  onChange: (value: string) => void
+  onUnitChange: (unit: TempoUnit) => void
+  disabled?: boolean
+  error?: string
+  editing?: boolean
+}
+
+export default function TempoInput({ value, unit, onChange, onUnitChange, disabled, error, editing }: Props) {
+  const id = useId()
+  const multiplier = TEMPO_UNITS[unit].multiplier
+  let bpm: number | null = null
+  try { bpm = quarterBpm(value, unit) } catch { /* Parent validates on submit. */ }
+  return (
+    <div>
+      <label htmlFor={id} className="mb-2 block text-sm font-medium text-ink">빠르기 (BPM)</label>
+      <div className="flex gap-2">
+        <input id={id} type="text" inputMode="decimal" value={value}
+          onChange={event => onChange(event.target.value)} disabled={disabled}
+          placeholder={editing ? '기존 빠르기 유지' : '자동 인식'}
+          aria-describedby={`${id}-help`} aria-invalid={Boolean(error)}
+          className="min-w-0 flex-1 rounded-2xl border border-rule-strong bg-surface px-3 py-2 text-ink" />
+        <select aria-label="박 단위" value={unit} disabled={disabled}
+          onChange={event => onUnitChange(event.target.value as TempoUnit)}
+          className="rounded-2xl border border-rule-strong bg-surface px-2 text-ink">
+          {Object.entries(TEMPO_UNITS).map(([key, option]) => <option key={key} value={key}>{option.label}</option>)}
+        </select>
+      </div>
+      <input type="range" aria-label="빠르기 슬라이더" min={20 / multiplier} max={400 / multiplier}
+        step="any" value={bpm === null ? 60 / multiplier : bpm / multiplier} disabled={disabled}
+        onChange={event => onChange(String(Math.max(20, Math.min(400, Math.round(Number(event.target.value) * multiplier))) / multiplier))}
+        className="mt-3 w-full accent-accent" />
+      <p id={`${id}-help`} className="mt-1 text-xs text-ink-muted">
+        {editing ? '비워두면 기존 빠르기를 유지합니다. 입력하면 곡 전체의 재생 속도가 바뀝니다.'
+          : '선택 입력입니다. 비워두면 악보의 빠르기를 자동으로 읽습니다. 읽지 못한 경우에만 미상으로 표시됩니다.'}
+        {' '}악보의 숫자와 음표 단위를 함께 선택해 주세요.
+      </p>
+      {bpm !== null && <p className="mt-1 text-xs text-ink-muted">4분음표 기준 ♩={Number(bpm.toFixed(3))}</p>}
+      {error && <p role="alert" className="mt-1 text-sm text-state-error">{error}</p>}
+    </div>
+  )
+}

--- a/src/components/upload/__tests__/OMRUploadForm.test.tsx
+++ b/src/components/upload/__tests__/OMRUploadForm.test.tsx
@@ -71,6 +71,15 @@ describe('OMRUploadForm', () => {
     global.fetch = originalFetch
   })
 
+  it('explains automatic reading and names the selected tempo unit', async () => {
+    render(<OMRUploadForm />)
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    expect(screen.getByText(/악보의 빠르기를 자동으로 읽습니다/)).toBeInTheDocument()
+    fireEvent.change(screen.getByLabelText('박 단위'), { target: { value: 'dotted-quarter' } })
+    fireEvent.change(screen.getByLabelText('빠르기 (BPM)'), { target: { value: '46' } })
+    expect(screen.getByText(/♩=69/)).toBeInTheDocument()
+  })
+
   describe('선택 전', () => {
     it('uses the same rounded field surface for score metadata', async () => {
       render(<OMRUploadForm />)
@@ -225,6 +234,21 @@ describe('OMRUploadForm', () => {
       })
     })
 
+    it('uploads dotted-quarter 46 as quarter BPM 69', async () => {
+      respondToUploadWith({ sheetMusicId: 8, jobId: 'job-8' })
+      const onUploadStart = jest.fn()
+      render(<OMRUploadForm onUploadStart={onUploadStart} />)
+      await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+      await selectFile(pdfFile())
+      await fillRequiredFields()
+      fireEvent.change(screen.getByLabelText('빠르기 (BPM)'), { target: { value: '46' } })
+      fireEvent.change(screen.getByLabelText('박 단위'), { target: { value: 'dotted-quarter' } })
+      await act(async () => { fireEvent.click(screen.getByRole('button', { name: '변환 시작하기' })) })
+      await waitFor(() => expect(onUploadStart).toHaveBeenCalled())
+      const body = fetchMock.mock.calls.find(([url]) => url === '/api/omr/upload')![1].body as FormData
+      expect(body.get('tempo')).toBe('69')
+    })
+
     it('빠르기를 비우면 값을 보내지 않는다 (D-013)', async () => {
       respondToUploadWith({ sheetMusicId: 8, jobId: 'job-8' })
       const onUploadStart = jest.fn()
@@ -343,12 +367,12 @@ describe('OMRUploadForm', () => {
   })
 
   describe('빠르기 입력 (D-013, 이슈 #82)', () => {
-    it('선택 입력이고 비워두면 미상으로 남는다고 알린다', async () => {
+    it('선택 입력이고 악보에서 읽지 못할 때만 미상이라고 알린다', async () => {
       render(<OMRUploadForm />)
 
       expect(screen.getByLabelText('빠르기 (BPM)')).toBeInTheDocument()
       expect(
-        screen.getByText('선택 입력입니다. 비워두면 빠르기 미상으로 표시됩니다.')
+        screen.getByText(/비워두면 악보의 빠르기를 자동으로 읽습니다. 읽지 못한 경우에만 미상/)
       ).toBeInTheDocument()
       await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
     })
@@ -366,7 +390,7 @@ describe('OMRUploadForm', () => {
       })
 
       expect(
-        await screen.findByText('빠르기는 20에서 400 사이로 입력해 주세요.')
+        await screen.findByText('4분음표 기준 빠르기는 20에서 400 사이로 입력해 주세요.')
       ).toBeInTheDocument()
       // 카테고리 조회 한 번뿐 — 업로드 요청은 나가지 않았다.
       expect(fetchMock).toHaveBeenCalledTimes(1)

--- a/src/components/upload/__tests__/TempoInput.test.tsx
+++ b/src/components/upload/__tests__/TempoInput.test.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import TempoInput from '../TempoInput'
+import { quarterBpm, type TempoUnit } from '@/utils/tempoInput'
+
+function Form() {
+  const [value, setValue] = useState('')
+  const [unit, setUnit] = useState<TempoUnit>('quarter')
+  return <><TempoInput value={value} unit={unit} onChange={setValue} onUnitChange={setUnit} />
+    <output data-testid="quarter">{value ? quarterBpm(value, unit) : 'auto'}</output></>
+}
+
+it('keeps automatic reading until the user chooses a tempo and names the note unit', () => {
+  render(<Form />)
+  expect(screen.getByTestId('quarter')).toHaveTextContent('auto')
+  expect(screen.getByText(/악보의 빠르기를 자동으로 읽습니다/)).toBeInTheDocument()
+  fireEvent.change(screen.getByLabelText('박 단위'), { target: { value: 'dotted-quarter' } })
+  fireEvent.change(screen.getByLabelText('빠르기 (BPM)'), { target: { value: '46' } })
+  expect(screen.getByTestId('quarter')).toHaveTextContent('69')
+  fireEvent.change(screen.getByRole('slider'), { target: { value: '60' } })
+  expect(screen.getByTestId('quarter')).toHaveTextContent('90')
+})
+
+it('uses decimal text entry so browser wheel spinbuttons cannot change the tempo', () => {
+  render(<Form />)
+  const input = screen.getByLabelText('빠르기 (BPM)')
+  expect(input).toHaveAttribute('type', 'text')
+  expect(input).toHaveAttribute('inputmode', 'decimal')
+  fireEvent.change(input, { target: { value: '72' } })
+  fireEvent.wheel(input, { deltaY: 100 })
+  expect(input).toHaveValue('72')
+})

--- a/src/services/__tests__/sheetTempoService.test.ts
+++ b/src/services/__tests__/sheetTempoService.test.ts
@@ -1,0 +1,63 @@
+/** @jest-environment node */
+import { saveSheetTempo } from '../sheetTempoService'
+import { getSupabaseServer } from '@/lib/supabase/server'
+import { prisma } from '@/lib/prisma'
+
+jest.mock('@/lib/supabase/server', () => ({ getSupabaseServer: jest.fn() }))
+jest.mock('@/lib/prisma', () => ({ prisma: { sheetMusic: { updateMany: jest.fn(), findUnique: jest.fn() } } }))
+
+const sheet = { id: 1, userId: 'owner', animationDataUrl: 'https://score.supabase.co/storage/v1/object/public/animation-data/owner/source.json', updatedAt: new Date('2026-09-05T00:00:00Z') }
+const source = { version: '1.1', title: 'score', composer: 'composer', duration: 2, tempo: 60, timingReferenceBpm: 60, tempoSource: 'score', scoreTempo: 60, timeSignature: '4/4', notes: [{ midi: 60, start: 0, duration: 2 }] }
+const bucket = {
+  download: jest.fn(), upload: jest.fn(), remove: jest.fn(),
+  getPublicUrl: jest.fn((path: string) => ({ data: { publicUrl: `https://score.supabase.co/storage/v1/object/public/animation-data/${path}` } })),
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://score.supabase.co'
+  jest.mocked(getSupabaseServer).mockReturnValue({ storage: { from: () => bucket } } as unknown as ReturnType<typeof getSupabaseServer>)
+  bucket.download.mockResolvedValue({ data: { text: async () => JSON.stringify(source) }, error: null })
+  bucket.upload.mockResolvedValue({ error: null })
+  bucket.remove.mockResolvedValue({ error: null })
+  jest.mocked(prisma.sheetMusic.updateMany).mockResolvedValue({ count: 1 })
+  jest.mocked(prisma.sheetMusic.findUnique).mockResolvedValue(null)
+})
+
+it('writes a new time-scaled object and switches the URL only if the original revision still matches', async () => {
+  await saveSheetTempo(sheet, 120, { title: 'new title' })
+  expect(bucket.download).toHaveBeenCalledWith('owner/source.json')
+  const [path, body, options] = bucket.upload.mock.calls[0]
+  expect(path).toMatch(/^owner\/tempo_[a-f0-9-]+\.json$/)
+  expect(options.upsert).toBe(false)
+  expect(JSON.parse(body.toString())).toMatchObject({ tempo: 120, scoreTempo: 60, duration: 1, notes: [{ duration: 1 }] })
+  expect(prisma.sheetMusic.updateMany).toHaveBeenCalledWith({
+    where: sheet,
+    data: { title: 'new title', animationDataUrl: expect.stringContaining(path) },
+  })
+  expect(bucket.remove).not.toHaveBeenCalled()
+})
+
+it('rejects foreign storage URLs before using privileged storage', async () => {
+  await expect(saveSheetTempo({ ...sheet, animationDataUrl: 'https://attacker.example/file.json' }, 120, {})).rejects.toThrow()
+  expect(bucket.download).not.toHaveBeenCalled()
+  expect(prisma.sheetMusic.updateMany).not.toHaveBeenCalled()
+})
+
+it('does not update the database if upload fails', async () => {
+  bucket.upload.mockResolvedValue({ error: { message: 'offline' } })
+  await expect(saveSheetTempo(sheet, 120, {})).rejects.toThrow()
+  expect(prisma.sheetMusic.updateMany).not.toHaveBeenCalled()
+})
+
+it('removes only its unreferenced new object after a definite edit conflict', async () => {
+  jest.mocked(prisma.sheetMusic.updateMany).mockResolvedValue({ count: 0 })
+  await expect(saveSheetTempo(sheet, 120, {})).rejects.toMatchObject({ status: 409 })
+  expect(bucket.remove).toHaveBeenCalledWith([bucket.upload.mock.calls[0][0]])
+})
+
+it('preserves the new object when a database failure leaves commit outcome uncertain', async () => {
+  jest.mocked(prisma.sheetMusic.updateMany).mockRejectedValue(new Error('connection lost'))
+  await expect(saveSheetTempo(sheet, 120, {})).rejects.toThrow('connection lost')
+  expect(bucket.remove).not.toHaveBeenCalled()
+})

--- a/src/services/sheetTempoService.ts
+++ b/src/services/sheetTempoService.ts
@@ -1,0 +1,66 @@
+import { randomUUID } from 'node:crypto'
+import type { Prisma } from '@prisma/client'
+import { prisma } from '@/lib/prisma'
+import { getSupabaseServer } from '@/lib/supabase/server'
+import { normalizeAnimationData } from '@/utils/animationContract'
+import { retimeAnimation } from '@/utils/tempoInput'
+
+export class TempoEditError extends Error {
+  constructor(message: string, public readonly status: number) { super(message) }
+}
+
+interface SourceRevision {
+  id: number
+  userId: string
+  animationDataUrl: string
+  updatedAt: Date
+}
+
+/** Called only after the route verifies ownership and validates metadata. */
+export async function saveSheetTempo(source: SourceRevision, bpm: number, metadata: Prisma.SheetMusicUncheckedUpdateManyInput) {
+  const configured = process.env.NEXT_PUBLIC_SUPABASE_URL
+  if (!configured) throw new TempoEditError('Storage is unavailable', 503)
+  const prefix = '/storage/v1/object/public/animation-data/'
+  let path: string
+  try {
+    const url = new URL(source.animationDataUrl)
+    if (url.origin !== new URL(configured).origin || !url.pathname.startsWith(prefix)) throw new Error()
+    path = decodeURIComponent(url.pathname.slice(prefix.length))
+    if (!path || path.split('/').some(segment => !segment || segment === '.' || segment === '..')) throw new Error()
+  } catch {
+    throw new TempoEditError('This score cannot be edited; upload it again', 422)
+  }
+
+  const bucket = getSupabaseServer().storage.from('animation-data')
+  const downloaded = await bucket.download(path)
+  if (downloaded.error || !downloaded.data) throw new TempoEditError('Could not load the score', 502)
+  let updated
+  try {
+    updated = retimeAnimation(normalizeAnimationData(JSON.parse(await downloaded.data.text())), bpm)
+  } catch {
+    throw new TempoEditError('The score data or tempo is invalid', 422)
+  }
+  const newPath = `${source.userId}/tempo_${randomUUID()}.json`
+  const uploaded = await bucket.upload(newPath, Buffer.from(JSON.stringify(updated)), {
+    contentType: 'application/json', cacheControl: '3600', upsert: false,
+  })
+  if (uploaded.error) throw new TempoEditError('Could not save the new tempo', 502)
+  const { data: { publicUrl } } = bucket.getPublicUrl(newPath)
+
+  // An ambiguous DB/network failure may have committed. Do not delete the new
+  // object in a catch block: that could erase the document the row now names.
+  const result = await prisma.sheetMusic.updateMany({
+    where: source,
+    data: { ...metadata, animationDataUrl: publicUrl },
+  })
+  if (result.count !== 1) {
+    await bucket.remove([newPath])
+    throw new TempoEditError('The score changed; reload it before saving again', 409)
+  }
+  // Keep the prior object: another row may reference it and it remains a
+  // recovery copy. Old-object lifecycle is deliberately separate (D-046).
+  return prisma.sheetMusic.findUnique({
+    where: { id: source.id },
+    include: { category: { select: { id: true, name: true } } },
+  })
+}

--- a/src/types/sheet-music.ts
+++ b/src/types/sheet-music.ts
@@ -44,6 +44,8 @@ export interface UpdateSheetMusicRequest {
   composer?: string
   categoryId?: number | null
   isPublic?: boolean
+  /** New quarter-note BPM; omitted leaves the stored timing untouched. */
+  tempo?: number
 }
 
 export interface SheetMusicListResponse {

--- a/src/utils/__tests__/tempoInput.test.ts
+++ b/src/utils/__tests__/tempoInput.test.ts
@@ -1,0 +1,40 @@
+import { quarterBpm, retimeAnimation } from '../tempoInput'
+import { normalizeAnimationData } from '../animationContract'
+
+describe('tempo units and stored score timing', () => {
+  it('turns the printed dotted-quarter 46 into quarter BPM 69', () => {
+    expect(quarterBpm('46', 'dotted-quarter')).toBe(69)
+    expect(quarterBpm('120', 'eighth')).toBe(60)
+    expect(quarterBpm('40', 'half')).toBe(80)
+    expect(quarterBpm('', 'quarter')).toBeNull()
+  })
+
+  it.each(['abc', 'Infinity', '-10', '0', '401'])('rejects invalid quarter BPM %s', value => {
+    expect(() => quarterBpm(value, 'quarter')).toThrow()
+  })
+
+  it('validates the converted value, not just the printed number', () => {
+    expect(() => quarterBpm('300', 'dotted-quarter')).toThrow()
+    expect(quarterBpm('15', 'half')).toBe(30)
+  })
+
+  it('rescales every timestamp without changing pitches or source fingering', () => {
+    const original = normalizeAnimationData({
+      version: '1.1', title: 'score', composer: 'composer', tempo: 46,
+      tempoSource: 'user', timingReferenceBpm: 46, scoreTempo: 69, duration: 12,
+      timeSignature: '9/8', notes: [
+        { midi: 60, start: 3, duration: 6, hand: 'L', finger: 5, staff: 2, voice: 5 },
+        { midi: 72, start: 9, duration: 3, hand: 'R', finger: 1 },
+      ],
+    })
+    const before = JSON.stringify(original)
+    const result = retimeAnimation(original, 69)
+    expect(result).toMatchObject({ tempo: 69, timingReferenceBpm: 69, scoreTempo: 69, tempoSource: 'user', duration: 8 })
+    expect(result.notes).toEqual([
+      { ...original.notes[0], start: 2, duration: 4 },
+      { ...original.notes[1], start: 6, duration: 2 },
+    ])
+    expect(JSON.stringify(original)).toBe(before)
+    expect(retimeAnimation(result, 46).notes).toEqual(original.notes)
+  })
+})

--- a/src/utils/tempoInput.ts
+++ b/src/utils/tempoInput.ts
@@ -1,0 +1,33 @@
+import type { CanonicalAnimationData } from '@/types/animationContract'
+
+export const TEMPO_UNITS = {
+  quarter: { label: '♩ 4분음표', multiplier: 1 },
+  'dotted-quarter': { label: '♩. 점4분음표', multiplier: 1.5 },
+  eighth: { label: '♪ 8분음표', multiplier: 0.5 },
+  half: { label: '𝅗𝅥 2분음표', multiplier: 2 },
+} as const
+export type TempoUnit = keyof typeof TEMPO_UNITS
+export const TEMPO_ERROR = '4분음표 기준 빠르기는 20에서 400 사이로 입력해 주세요.'
+
+/** The wire contract always uses quarter notes per minute. Blank is optional. */
+export function quarterBpm(value: string, unit: TempoUnit): number | null {
+  if (!value.trim()) return null
+  const bpm = Number(value) * TEMPO_UNITS[unit].multiplier
+  if (!Number.isFinite(bpm) || bpm < 20 || bpm > 400) throw new Error(TEMPO_ERROR)
+  return bpm
+}
+
+/** Scale score time uniformly, preserving relative changes already in seconds. */
+export function retimeAnimation(data: CanonicalAnimationData, bpm: number): CanonicalAnimationData {
+  quarterBpm(String(bpm), 'quarter')
+  const scale = data.timingReferenceBpm / bpm
+  return {
+    ...data,
+    version: '1.1',
+    tempo: bpm,
+    tempoSource: 'user',
+    timingReferenceBpm: bpm,
+    duration: data.duration * scale,
+    notes: data.notes.map(note => ({ ...note, start: note.start * scale, duration: note.duration * scale })),
+  }
+}


### PR DESCRIPTION
Entering the printed dotted-quarter=46 as an unlabeled BPM made issue #134 play at quarter=46 despite correctly reading quarter=69 from the score. Upload and library editing now share an explicit note-unit selector, decimal text input (no wheel spinbutton changes), a slider and a quarter-BPM preview. Empty upload input uses automatic reading; empty edit input preserves the existing tempo.

Owners can set a stored score's tempo from the live library dialog. The API rescales all note start/duration values and total duration uniformly, keeps source fingering and score-tempo provenance, uploads a new immutable JSON and switches the row only when its original URL and updatedAt still match. Definite edit conflicts clean up only the new unreferenced object; ambiguous DB failures preserve it. Old objects are retained because another row could reference them and they support recovery (D-046).

Validation: two live UI regressions failed before implementation. Full Jest 98 suites / 937 tests passed; independent typecheck, lint and build passed. The build skips bundled type/lint checks, which were run separately. Chromium at 390x844 verified upload/edit, dotted 46 → quarter 69 in the PUT body, unchanged text after wheel input and a dialog fitting the viewport; session/API responses were mocked, so no production data was written. Tests cover owner-only edits, invalid BPM, unavailable scores, upload failure, concurrent changes and ambiguous DB failures.

This fixes #137. It addresses the tempo-unit part of #134, not its incorrectly recognized meter or note durations. No MusicXML retention or fingering-model change is included. Old-object cleanup is deferred; reverting this PR removes the editing path without invalidating already-written canonical v1.1 documents. Phase: `docs/recovery/phases/ISSUE-137-tempo-controls.md`.
