### PR TITLE
Integrate MusicXML tempo at beat positions and surface rhythm diagnostics

### DIFF
--- a/docs/recovery/DECISIONS.md
+++ b/docs/recovery/DECISIONS.md
@@ -1848,3 +1848,21 @@
 - Scope-risk: moderate
 - Not-tested: 페달의 실제 타이밍, 교사의 완곡 연주 평가. 이 안내를 유일한 정답으로 판정하지 않는다.
 - Related: #135, #126, 2026-09-05 codebase audit
+
+## D-048: 먼저 박 위치를 해석하고 나중에 초로 적분한다
+
+- Date: 2026-09-05
+- Status: Accepted when the MusicXML timing implementation merges
+- Context: 기존 변환기는 한 마디에서 찾은 템포 하나를 마디 전체에 적용한다. #134 VM 재현에서는 Audiveris XML 자체의 6/8 오인식과 10개의 초과 마디가 기존 저장본을 완전히 재현했다.
+- Decision:
+  1. note/backup/forward/chord와 divisions를 유리수 quarter 위치로 해석한다. 정규 controlling part는 같은 measure index에서 관측된 최대 길이로 다음 공통 경계를 정한다. 명시적으로 non-controlling인 part는 자신의 경계를 보존하고 다른 part를 밀지 않는다. 박자표 길이로 음표를 강제 축소하거나 늘리지 않는다.
+  2. direction/sound의 위치와 유효한 playback offset을 수집해 전역 템포 지도를 만든다. sound 자신의 offset이 direction offset보다 우선하고, direction offset은 sound=yes일 때만 재생에 반영한다(W3C MusicXML 4.0).
+  3. 시간은 이 지도에서 적분한다. note duration도 시작과 끝 사이의 변화에 따라 적분한다. 같은 위치의 상충된 part 표기는 앞 part 우선, 같은 part의 동일 위치에서는 뒤 direction 우선이다.
+  4. 0박에 표기된 템포만 곡 시작 metadata를 결정한다. 나중에 처음 표기된 경우 시작은 미상이고 기존 기준 BPM 60을 사용하다가 해당 위치에서 바뀐다. 사용자 override는 모든 악보 템포 변경보다 우선하는 기존 계약을 유지한다.
+  5. 명시된 박자표보다 긴 일반 마디는 `metadata.timingWarnings`로 기록한다. implicit/non-controlling/free-meter 및 단순히 짧은 마디는 이 진단으로 오판하지 않는다. 미지원 repeat/ending/jump 순서도 진단한다. 저장 canonical 버전은 1.1이며 기존 reader는 optional metadata를 보존한다.
+  6. 플레이어는 인식 리듬 확인이 필요함을 설명한다. 진단은 교정이 아니며 #134가 음악적으로 해결됐다는 근거로 사용하지 않는다.
+- Rejected: 마디 길이를 박자표에 강제로 맞춘다 | 잘못 인식된 박자표/누락 음표를 재현하지 못하며 정당한 pickup도 훼손한다.
+- Constraint: PDF 미보관(D-040), 현재 fixed user tempo precedence 유지. OMR VM에 저장소 쓰기 자격증명을 주지 않는다.
+- Confidence: high
+- Scope-risk: moderate
+- Related: #134, #44, P0-B, 2026-09-05 VM reproduction

--- a/docs/recovery/phases/AUDIT-musicxml-timing.md
+++ b/docs/recovery/phases/AUDIT-musicxml-timing.md
@@ -1,0 +1,34 @@
+# AUDIT — MusicXML의 박 위치와 시간 변환
+
+Status: `IN_PROGRESS`
+Depends on: P0-B, #134 VM reproduction
+
+## Objective
+
+MusicXML cursor를 먼저 박 단위로 해석한 뒤 전역 템포 지도에 따라 초로 변환한다.
+마디 중간 변경·offset·여러 part의 같은 마디 시작을 일관되게 처리하고, 인식한 박자표보다
+길어진 마디와 미지원 반복 순서를 조용히 정상 결과처럼 취급하지 않는다.
+
+## Work stages
+
+1. 중간 템포·offset·sounding duration·multipart·사용자 override 회귀를 먼저 추가한다.
+2. 유리수 quarter 위치를 수집하고 전역 piecewise tempo 적분으로 start/duration를 만든다(D-048).
+3. #134 실제 MXL을 고정하고 overfull measure 진단을 metadata에 보존한다.
+4. 플레이어에서 진단을 설명하되 원본 박자/음표 길이는 추측으로 고치지 않는다.
+5. corpus/전체 Jest/typecheck/lint/build, PR 체크와 VM 배포 후 변환 smoke를 기록한다.
+
+## Completion criteria
+
+- 마디 내부 템포 변경이 그 이전 음을 재타이밍하지 않으며 변경을 걸친 음은 올바르게 적분된다.
+- sound offset 우선순위와 direction offset의 sound=yes 의미를 따른다.
+- 중간에 처음 등장한 템포는 곡 시작의 tempoSource=score를 조작하지 않는다.
+- 사용자 tempo override는 기존처럼 고정 템포를 적용한다.
+- controlling part는 같은 마디 경계를 공유하고 divisions/backup/forward/chord 위치가 일치한다. 명시적 non-controlling part는 독립 경계를 보존한다.
+- 기존 golden corpus를 유지하고 #134 인식 XML의 모순을 검사·표시한다.
+- 기존 저장 JSON을 소급 교정했다고 주장하지 않는다.
+
+## Out of scope
+
+- Audiveris가 놓친 음표·점·음높이의 복원, 자동 6/8→9/8 교정, 기존 운영 데이터 수정.
+- 반복·ending·D.C./D.S.의 재생 순서 전개(미지원 진단만 추가).
+- 조표·타이 식별 계약 변경과 페달 추론.

--- a/docs/vm-replacement.md
+++ b/docs/vm-replacement.md
@@ -146,7 +146,7 @@ git -C /opt/clairkeys-deploy status --short
 ```bash
 cd /opt/clairkeys-deploy/omr-service
 DEPLOY_SHA=$(git -C /opt/clairkeys-deploy rev-parse --short HEAD)
-podman build -f Dockerfile.audiveris \
+podman build --format docker -f Dockerfile.audiveris \
   -t "clairkeys-omr:${DEPLOY_SHA}" \
   -t clairkeys-omr:current .
 
@@ -357,7 +357,7 @@ git -C /opt/clairkeys fetch origin main
 git -C /opt/clairkeys-deploy checkout --detach origin/main
 cd /opt/clairkeys-deploy/omr-service
 DEPLOY_SHA=$(git -C /opt/clairkeys-deploy rev-parse --short HEAD)
-podman build -f Dockerfile.audiveris \
+podman build --format docker -f Dockerfile.audiveris \
   -t "clairkeys-omr:${DEPLOY_SHA}" \
   -t clairkeys-omr:current .
 systemctl restart clairkeys-omr || true

--- a/fixtures/musicxml-timing/README.md
+++ b/fixtures/musicxml-timing/README.md
@@ -1,0 +1,13 @@
+# MusicXML timing evidence
+
+`clair-de-lune-recognition.json` holds the exact base64-encoded MXL from the 2026-09-05
+same-PDF Audiveris reproduction on the production VM, its hash and the 133 note dictionaries
+from the served issue #134 JSON. It is **known incorrect recognition**, not a gold standard score.
+
+The expected ten overfull measures were measured from this XML during diagnosis. The regression
+requires the converter to report them without inventing replacements for the recognized notes.
+The original PDF says 9/8; this MXL says 6/8. Correcting those musical contents is a separate task.
+
+Source and chain: `docs/recovery/validation/2026-09-05-issue-134-vm-reproduction.md`.
+No PDF or pixel images are retained. The compressed container contains only `input.xml` and
+`META-INF/container.xml`, which D-040 permits retaining for concrete diagnostic needs.

--- a/fixtures/musicxml-timing/clair-de-lune-recognition.json
+++ b/fixtures/musicxml-timing/clair-de-lune-recognition.json
@@ -1,0 +1,1217 @@
+{
+  "sourceIssue": 134,
+  "sourcePdfSha256": "34d06c77398470ea6f9bf15d9cd5724a0db94c904eb81107c5ca29d2f1be5478",
+  "mxlSha256": "298e8a88265fe8d4ede4b4133f476ae2cb1d00c6a1e5c8db47fdd252f585dba5",
+  "mxlBase64": "UEsDBBQACAgIAAVOJV0AAAAAAAAAAAAAAAAJAAAAaW5wdXQueG1s7R1rc6s29nt/BeU7MU9j7zju3NvbdjrT7t7ZtjO7H4lREnYxeAEnTX/9SmCDhHlIQsiQuJ1pA8h6nHN0dN7afPfnPlReQJIGcXSvGne6qoBoF/tB9HSv/vH7j9pK/W77zebbL//4/vd/f/1BSXdxArSDl2SvQQqUr398/uXn7xVVWyz+CeAn30vAYvHl9y/Kr8c02P3r118U+06/s5Svp18sFj/8XVXU5yw7/G2xeH19vdujhnAWd3HytPAzP12ce7+DTyocvDZmOdu8Z9hAUTb7+AXsQZRpWZCFYPt96AWJ4gPll2MENovaV/SDwIfPwWOw8zLYF3oFX+4S4GVxomRvB3Cv7uL9IU5BoqLujrCzL+DhmKZvm8Wp3elXZ3gVj/BFGj9mrxAQ209HP4CzDVLFuTMgbDeL8lPZ9ng4xEmWnsZ8AylEQJjP9l49JEGUqYqXZUnwcMzg9wi8aulbmoG9qrx44fH0ky3s+dTRkJ4P3hMY1q+32+WQ9UL23z4Ab8/+qxwWjb86g/prEv/5lpNjQYsNWDijUPO9DGxN3Vxq+lrTnc2C/FIgfEFiHI50THZgu4BNvIUXeeFbGqSLIE2PwLBsbb03Pr+ZiyA6HLO7g/+Ixs9/UPx6H6Q7EIZeBOJjNXvirfYYgNBXIm8Pl1/8GL4KgcowZkOH9IOlzwBkmqFuDcVULMVWnI4Oa5/y7ba43G8bHzx6x/CMMbjLvRDfRfsgDIM9yOBu3y7vXNeyUMfVu3O7DHb8nG5tuLtOf55mQXS4QbSthd5bfMzKn+bvnkHw9JxtjbVhbxb4G6LVa+Bnz1vD1vVTo+IF0WbvJU9BdCbThzh7Vs8NYJMQPGanJtsV7AV/rlolaGi8GfGiapfFB7wV9li1gTPI4j3ejHxznvwCn/0Zehfw2oRvSbDTHuMoU9B/tEcPouPtXv3Ng2v+DbK5R7X4kAZ/wfUbOtqW1Y8KOsCRjvitH2QKGgq2VysuDN9qr/A0SZVTe+3Pe9VZWWr5DMc1lvZSJaeSXs5ipdZPA7z/YlLFm/4pIcRuz8dC2VH+tnvqhr6yybk7q/65r09Przk9IooK/cbDqH056NDUwiDNyk12PkqVwL9XvxoqRsKwKdr126+BF8WbRfWCaOI9PCTgJSj2Md6U+FBy4XxASFdZckQM+zSs9rOB743qezHgpx1kHBlk2D8lXuQrp1HqrUr6rQ+C8RA/6B08b7R79qIIhFsDMRnsudbskMRPibcvm52fq2YvcQjH2rqrzeL0ZznN2mwqPnXGSYE+AmebbzXtXuH8V9NKIiDRnffK90/RJ4IH8NJjApTouH8ACdosSs4T71VrpWNkhSQNDD6F9FLjxPgXgg81ck9DX7awzwYWumpjoTnoW4fMGezpsw9x4UXwwLZMs2C19Q/fXHRZX98Gtnx8PL0uYWaqJATyNmWvSySqkK/wgbAOcTIt0KIVQ6Dzr5gRJL+LL9UBgCNpU0qFGEQ2UJINkNidbg0IhOoJO5KCPSCWAwU6yOghroo/6p8KxrkqPmNctJgS2RsCzQucj5mv+4WY2Q6SAkaFJESDp2j7E/wR+j/+AUoGAPWW/x8bFnXW1ncdWwP7PqEWZF4QpkqOAi1++A/YZZXwjTep0HWJoE0UZwA/cVwXZ3EJSMm9BgnqAElHg5Rx2H5G+MSemxrGOwT2rV01Pb3B1keOsvGPSXEWQAoo/8YZZQAJ2kBsMiAoO6eE/Mh7hmRAkkUOEPSj4o8SImj55ZMfJBCIcDQFTnR31kweoBKoEgR9alUjPfiJPL/h2WzCozgBIVzCC0DQ1dx1v+ShNx7fv0BeE8MZl+f1eQlt8+maKBSFkziK9wAKLAkSfkEK0hP1kEwx32PHCIoF/zvC4wCJL9WrlqaaH2eL2scDSLR9EEHa29oQr9gjwVjLiVGtsBmrhWYFj3/IvQ7xvbpc51sCvaoQX/bZuhMM0/y4W+ECGMslDoxDkO2eiUXmq/4BdVpb/WmNUPG7XG2tm77lZgE46Uhw6kmGsApfDYcH2ON7VrMgvfjxa5QvZk9DbhBa+VxrkkAAfGK+SpwEyMaR5VYoSI7IRpSvwcehctEbG252z5BDLPqR9dMNWThIwmNCIguTTy+OAxz8S1JBg/raA/grgPwNfluvyif4zbJzRgRHYqETOJ4QMjENQ+YWNla9ZBEfWKmiPIPqRx1x4Eja0uX0RaJF+u694akZTw/e7r/HQxPErAaGB6Uiov1s5WqHR5gwGYUJUrJi50Q2G4WbQw6oNoC0kXidph11ezy00HMdbtcXJUjMCGBGN1RN9DRnQ4xpDzgl2vDy7IWPV0DKVM/tG0YYMFKaJU+PIximzdIwba4rDeuSZ9oUG/F7ecpWO9bNgbqWvWKVzpBrHjexPoCnIMotSPvRKaQXVbRbVqJV44a7Vtw5a4pt9lkUd+0Ska+Pil0cZUF0BCQ2mABIS/xfxiX+WUPU0K3rs35BEGRWvOsQBJE/BHgTYcazhSbaAvLYI4Xw2aGntYGXSvrk2OxX1qlJ1EhnvB8AV7xKdbuNz24wRPTa+Kg0gR9F7cEmM6TCpeD1WGVdBn2vby84PFvhUwPIvDADyVaDFFT8NV1wVqHN28fQy+CEqxejAH2I5VqCWm1V8V6u3qFW09i3Rpb35ahmjjVz1YzPEjayZvEecUc4qeGicB91q0fawh3SWs0j7fZ7pAWp7zTxI02MfnLq+3CU86nvXEEes1A+x4Io3T4aEOyhOfjechxia+mXW4uDter69Y/BqWCZ3cSgT/Bgmi00bRr1RhgL75THmbTSvqATx2ACJbW07TQo3hc65GOcvHqJ3/T7lsic1sibtunWhuBErJSTZGA0IEraatWa+GSxPi8wFX9+F3GxKDRkCHAv+A2dijJiCIXjTgt37HF2klB3Zf3SmoKLfRIMin4PUaqKmuGQyuKS0BadNS7SNki0g4RpoyZNGwY+uGHiYy/7xj6rAG0rdayuwbTe0eRbk6cW4MUReXeleKIxvTmTjPqSjIWxD1bhQaPskXDXixkVFJ7ocHkdx47klQ90yUGDduXdsLCgwTxLV6mq8NRzLWeT3l7PYDfMZdl+7LR2mzWtnSpBfdR0aocmLEOK2Xuo5Nq150ZRrfkY2Cy0AOmwNHSajBthzH/CsOMM9ONKi5Filp8lPO3JeAOvDD52I/x03YBzA+WaxnQrjCd2+jPaQMfjz0D106jhyAYj6YyvBWgDDd6jQ1WRbaUY6ITiklo73KQykSwy0tGYkyWKTz6eX/gpC1J6jSI0YrAwwh5UWoHVRiKdtEXZqbhEa2Fk3OlkvyIOJJutnNJsZetOR1Cu1GikIRnOjMIoqhqo7WO/Vtn79NXbZUcv1BA00q2FIrixZ7xhFCf78oOJcIg9Y0vuGK4hPmVwNhGT//Z4CEFG49B7AGH8msM//wlJCD2OuU6/oGbppLPOxIoqmXlBt9JXZyIhtd8v2eEBrfsF14RfcEl4QC1DWrys1GCrLq/Se9pJUw00LbYScS7WAk1dnCpXOk6UmrkSEWq6lppB+FEozhYepknLuUmW18CmeVIZaeTnWdjtpEcKGisam6eU2OMrw47LZGxaNKLnRyA9Vjun6dJUKRBm51yLg1yPOrWUvYUtgyauZQ40eA2nj7WkCWgb2QcpJ1RatCej/ciXnRfvGDyRjDRSQ4eLaqKGSW0t0DLJVQxlbBP8tGA2sCJrR6aNpXcsf9mWaXM53b5MG9Ol0eo7dCxLnG2zYVlDbJtCN4PLVadtbLv9tOAmwSi8rGIZ9a4CiBM710dLo7FmnUXjOBRoEuZXGVF4HYgGLuGVyjg2h/i5gcBjj1eikf3kePMEF6vv8uZx5wxz1ZanYsByZEWhidlLQdXDqHPhaq6gFekKWhEpYlqDK0j6rQJUmO8wSLDJk/K0BJTwKazmGFfG1gzV0SFAG0iXjYkVvXfgIbbfeAee3X0H3mXmhQRh2K0iJJz6NZW3xJ4aubEl9qzPnHxGiT3uwLoPUzWqa12FB8dxjFGZB4WBckTZWhvokeDLpaCKFJmDXqdJM5vzh2Vo5HXc2tIlSxZYpIjYEJnE4XVfD7x7cTIYlp73ZlrvJf/yGh47cyX1kJsu9PqsHh3Sc8PJ3X9XHA3YhSkonSUlhpX/dpnj7Vj5tdnDr91aGB1RsNE1SG5tsteYsfrOC7M2A3tNhLK6RCSr1lvlhrRfWDX7RW2xJmm+IBbriLVeNBGRmDSjDqPqVK0XPbdYMtovXK4UvOkbfbAy6JGXwRFCytLoA+E78fLoK+zWsdVAp5swm+8Qp5s1UCvocpDOwOs2sHSdOBHqynjgc7sNjJl9N9Bj9rtRKT7C6K7T79YGOt6IiU47t2TP28B4eIFHsVDP24pNcJ+Ak6tDC52IvHMBZFTKQ5yYKLww4fsE28SlvzWl9EfoBNO9TZ7ZbMNRo4RMIP9YsGin5qb6i/2cloGsPtGD0hINyjZ+0glKRn7q0GTNCDt1rnvxvWZ3pylOrvbJmiaWUSZyxiswKww37UZUu8eIWbMrWivC50W6vCy+BPnO+Tl986s55QzCKecS82u48Goo+UmXtUatrSuB3pZ9ue96V6l2m8x9FxyF15AJIkZB6dC1J5zV0XM3DuOZSsW2pURRt8GJ0pzDGOjBukHcvosTVsQGIdidTfBjs7lgSadPy61tRnI3Eh40xCzw0bjuPBviVZKgkkGhuNTJVs4t8k9oSW9rfpF/qBzTEG4/mToOMm8F6mQ4qz4neu2SGkLAM3P5dIATfdVdDsolr4khhA+ua2K66YlWmBz5WqqpEpgIAWMONVaGgo4vlJSqxspHoDz+gK8m6ZwlFZ3RxdNmJezLRF9LLS83zLrV5tmi1mhRvoaIMDRpd0wtpZbHp6i/zH6BuoybWOkQxRfHcaVrXRt85bxbnI6KhB2GnQ7AthAArnrQLO5/GoG0pnyve5Rvk1S+iSBLi1C+ucoyii7lTqOtdGSHCPECX6GU++xcGnxqwNixJe8Yc8KuETZo+KywLTalovLjoEpQYXmD66YcYRvqhqcGPMkw1xqVuRYLvuUrZT8HU0EfcmVa8vocF5rpkM5kyyQsec6SrOzeIEHVZTfclEd6LsjbpW3CjudYFGXdW8dZd4yjWcRAFmExNBrc4+ysjer2tDlYoAWQrrCC7H2k20FNLhFiYAmpxr4aeFPNe8Ixc/C7MTD4nQ14MotO9UW/st7vZoi+Jfrdgu4W1C4CyKxB7Vy5j7eg9mkFtRsmpUg+MI5KxJk3zOo9Qc/7CKo1X6rJyH7DG+L6EWfT3F8gRai8Mh643ONUIrkU7/iVoTeOPC6M7jqFSlZncp8ziqWyjLR69ozqHK+HUe4t7sOCCFiVifkHEVBtumkEEYi8qPtjBBGwetu5gwiobi2TY0oRXEfAYDwFKQyKtLZoIoFKc5e4+dAWXFeaK2qAShMbO2rg+q7lUfSgm8te4T0cRbns6bja2C77Sbh62SB186J/FC+6xWOy+1jFF/wgATs0WsOl6Nj0zq00cgz06S3y9sEuJWtm6qqSgBAu4wUUHmR8BxbIOiyIfhbnjnAotY3bLuCkMVQ+lHNfUGYpcqXR2woCZbetJGFLrTw1pufSEH/DKJ0c2eGYvsyOquVGkTeFW2TVT0NI+vtQ3/SEMMwYS3x1z/R0r0NiudV4HK+0sELUHwts4gx08wDbNUoA3hz55s2R/w4c+XZ1I6iBaQVTK4Ww1mdYCsHezK8Uwurjan8XGbUDTUqTEYpZ7rUcTelZ9yg9tZhrmwi6ttak0iPmFh6LJmX6dgXsJeDc93sFLAsoe8Ek2ptwg1sH3GYZ/T0EbuNFm7CWJef1RZsTuktacBgRizpLd5q2pyvV7IU2eUvQKGdnDXPT4m1XROUEUv87zLSTVbG7rwVnrfPMlXf/LismsMG1lQ/JyrunOg6E0bdcJ75QEudkv++0ZMEYVD5RJ75TOfGxYkC32yS6UiTey4WxCKlTs+M0VDImy20aRF61rRO587YQ3zWNme7zHPAr24xj0lyIIcz+JTUz2Bl03VUPpGiPW2FE9/FAJyzpakagu0Y+esfuNqepLHbmZ0kJ956fgn19mM0vs2AIzKbu9F9WWgSW8dcc/lpIePha2sNfX4H/dNYA/WCP8nEjP1aV9JAAzyev9UFePfIeCisXB/M+cFLoCXu9RMVlQKucuF6diAZAe0FKUK+z5ArqHVquREgt2YGpnmPc5T7BtM+rFvT5eJgTlpPkDrzTToikOyxfl1cSHgVVgmqduKLvervhaQKp1VxRvB0xA2zqz7gX+BldLkhG+X1JUzFGmFoo9M7Xut1foFKj04SCybnwT7B7ZADpXCnApOEmv7bp9hY7oDqCxV3jKfMixx7W3YVbGTqmW+mYxrpHx5SgisnRxWxnvrrY9QX2WSpCkwPbNbKhhOU3yos5MgdVVRgI5AcvCYMIKGG8OymdeXILDmnYREuztxBswzzv5Rl4L2+oo/NrrO+8swbWDgENz5btN3AtuzgBGnp6DVKw/T9QSwcIQGnCLhwTAADtGQEAUEsDBBQACAgIAAVOJV0AAAAAAAAAAAAAAAAWAAAATUVUQS1JTkYvY29udGFpbmVyLnhtbFWOMQ7CMAxF954i8oqawsaQlI0TwAGsxAVLqRMlaUVvTxAMxZut//2eubzmoFbKhaNYOOkjKBIXPcvDwv127c+gSkXxGKKQhY0KXMbOuCgVWSiPnWpjcox14kDlu//d1LSE0CesTwssaam6QUHN5Bn7uqX2FlMK7LA2i2EVrzO5mD1m0vNS2LX84dMZfrRhhzPDzuUNUEsHCJcsKRiVAAAA0AAAAFBLAQIUABQACAgIAAVOJV1AacIuHBMAAO0ZAQAJAAAAAAAAAAAAAAAAAAAAAABpbnB1dC54bWxQSwECFAAUAAgICAAFTiVdlywpGJUAAADQAAAAFgAAAAAAAAAAAAAAAABTEwAATUVUQS1JTkYvY29udGFpbmVyLnhtbFBLBQYAAAAAAgACAHsAAAAsFAAAAAA=",
+  "expectedNotes": [
+    {
+      "midi": 64,
+      "start": 0.652174,
+      "duration": 3.913044,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 67,
+      "start": 0.652174,
+      "duration": 3.913044,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 76,
+      "start": 1.304348,
+      "duration": 2.608696,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 79,
+      "start": 1.304348,
+      "duration": 2.608696,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 65,
+      "start": 4.565217,
+      "duration": 3.913043,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 68,
+      "start": 4.565217,
+      "duration": 3.913043,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 72,
+      "start": 4.565217,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 2,
+      "staff": 1
+    },
+    {
+      "midi": 76,
+      "start": 4.565217,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 2,
+      "staff": 1
+    },
+    {
+      "midi": 71,
+      "start": 5.217391,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 2,
+      "staff": 1
+    },
+    {
+      "midi": 74,
+      "start": 5.217391,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 2,
+      "staff": 1
+    },
+    {
+      "midi": 72,
+      "start": 5.869565,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 2,
+      "staff": 1
+    },
+    {
+      "midi": 76,
+      "start": 5.869565,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 2,
+      "staff": 1
+    },
+    {
+      "midi": 71,
+      "start": 6.521739,
+      "duration": 3.26087,
+      "hand": "R",
+      "finger": null,
+      "voice": 2,
+      "staff": 1
+    },
+    {
+      "midi": 74,
+      "start": 6.521739,
+      "duration": 3.26087,
+      "hand": "R",
+      "finger": null,
+      "voice": 2,
+      "staff": 1
+    },
+    {
+      "midi": 64,
+      "start": 9.130435,
+      "duration": 3.913044,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 67,
+      "start": 9.130435,
+      "duration": 2.608696,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 69,
+      "start": 9.782609,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 2,
+      "staff": 1
+    },
+    {
+      "midi": 72,
+      "start": 9.782609,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 2,
+      "staff": 1
+    },
+    {
+      "midi": 71,
+      "start": 10.434783,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 2,
+      "staff": 1
+    },
+    {
+      "midi": 74,
+      "start": 10.434783,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 2,
+      "staff": 1
+    },
+    {
+      "midi": 69,
+      "start": 11.086957,
+      "duration": 3.913043,
+      "hand": "R",
+      "finger": null,
+      "voice": 2,
+      "staff": 1
+    },
+    {
+      "midi": 72,
+      "start": 11.086957,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 67,
+      "start": 11.73913,
+      "duration": 1.304348,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 76,
+      "start": 11.73913,
+      "duration": 1.304348,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 72,
+      "start": 13.043478,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 62,
+      "start": 15,
+      "duration": 5.869565,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 65,
+      "start": 15,
+      "duration": 3.913043,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 69,
+      "start": 15,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 72,
+      "start": 15,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 67,
+      "start": 15.652174,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 71,
+      "start": 15.652174,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 69,
+      "start": 16.304348,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 72,
+      "start": 16.304348,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 67,
+      "start": 16.956522,
+      "duration": 3.913043,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 71,
+      "start": 16.956522,
+      "duration": 4.347826,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 65,
+      "start": 18.913043,
+      "duration": 1.956522,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 60,
+      "start": 20.869565,
+      "duration": 3.913043,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 62,
+      "start": 20.869565,
+      "duration": 3.913043,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 69,
+      "start": 21.304348,
+      "duration": 0.434783,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 71,
+      "start": 21.73913,
+      "duration": 0.434783,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 69,
+      "start": 22.173913,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 74,
+      "start": 22.826087,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 69,
+      "start": 23.478261,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 59,
+      "start": 24.130435,
+      "duration": 1.956522,
+      "hand": "L",
+      "finger": null,
+      "voice": 6,
+      "staff": 2
+    },
+    {
+      "midi": 62,
+      "start": 24.130435,
+      "duration": 1.956522,
+      "hand": "L",
+      "finger": null,
+      "voice": 6,
+      "staff": 2
+    },
+    {
+      "midi": 67,
+      "start": 24.130435,
+      "duration": 0.978261,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 69,
+      "start": 25.108696,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 67,
+      "start": 25.76087,
+      "duration": 1.304348,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 57,
+      "start": 26.413043,
+      "duration": 3.913043,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 60,
+      "start": 26.413043,
+      "duration": 3.913043,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 62,
+      "start": 26.413043,
+      "duration": 3.913043,
+      "hand": "R",
+      "finger": null,
+      "voice": 2,
+      "staff": 1
+    },
+    {
+      "midi": 65,
+      "start": 27.065217,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 67,
+      "start": 27.717391,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 65,
+      "start": 28.369565,
+      "duration": 1.956522,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 55,
+      "start": 30.326087,
+      "duration": 3.913043,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 57,
+      "start": 30.326087,
+      "duration": 3.913043,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 60,
+      "start": 30.326087,
+      "duration": 2.608696,
+      "hand": "R",
+      "finger": null,
+      "voice": 2,
+      "staff": 1
+    },
+    {
+      "midi": 64,
+      "start": 30.326087,
+      "duration": 0.978261,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 64,
+      "start": 31.304348,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 65,
+      "start": 31.956522,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 64,
+      "start": 32.608696,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 69,
+      "start": 33.26087,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 64,
+      "start": 33.913043,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 52,
+      "start": 34.565217,
+      "duration": 3.913043,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 55,
+      "start": 34.565217,
+      "duration": 3.913043,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 57,
+      "start": 34.565217,
+      "duration": 3.913043,
+      "hand": "R",
+      "finger": null,
+      "voice": 2,
+      "staff": 1
+    },
+    {
+      "midi": 62,
+      "start": 34.565217,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 3,
+      "staff": 1
+    },
+    {
+      "midi": 60,
+      "start": 35.217391,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 3,
+      "staff": 1
+    },
+    {
+      "midi": 62,
+      "start": 35.869565,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 3,
+      "staff": 1
+    },
+    {
+      "midi": 60,
+      "start": 36.521739,
+      "duration": 1.956522,
+      "hand": "R",
+      "finger": null,
+      "voice": 3,
+      "staff": 1
+    },
+    {
+      "midi": 48,
+      "start": 38.478261,
+      "duration": 1.956522,
+      "hand": "L",
+      "finger": null,
+      "voice": 6,
+      "staff": 2
+    },
+    {
+      "midi": 52,
+      "start": 39.130435,
+      "duration": 2.608696,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 55,
+      "start": 40.434783,
+      "duration": 1.304348,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 67,
+      "start": 40.434783,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 6,
+      "staff": 1
+    },
+    {
+      "midi": 53,
+      "start": 41.73913,
+      "duration": 5.869565,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 57,
+      "start": 41.73913,
+      "duration": 5.869565,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 72,
+      "start": 41.73913,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 76,
+      "start": 41.73913,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 69,
+      "start": 42.391304,
+      "duration": 5.217391,
+      "hand": "R",
+      "finger": null,
+      "voice": 2,
+      "staff": 1
+    },
+    {
+      "midi": 74,
+      "start": 42.391304,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 76,
+      "start": 43.043478,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 74,
+      "start": 43.695652,
+      "duration": 3.913043,
+      "hand": "R",
+      "finger": null,
+      "voice": 3,
+      "staff": 1
+    },
+    {
+      "midi": 52,
+      "start": 47.608696,
+      "duration": 3.913043,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 55,
+      "start": 47.608696,
+      "duration": 3.913043,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 74,
+      "start": 47.608696,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 72,
+      "start": 48.26087,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 74,
+      "start": 48.913043,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 72,
+      "start": 49.565217,
+      "duration": 1.956522,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 79,
+      "start": 49.565217,
+      "duration": 1.956522,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 53,
+      "start": 51.521739,
+      "duration": 3.913043,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 57,
+      "start": 51.521739,
+      "duration": 5.869565,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 72,
+      "start": 51.521739,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 2,
+      "staff": 1
+    },
+    {
+      "midi": 76,
+      "start": 51.521739,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 2,
+      "staff": 1
+    },
+    {
+      "midi": 69,
+      "start": 52.173913,
+      "duration": 5.217391,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 74,
+      "start": 52.173913,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 2,
+      "staff": 1
+    },
+    {
+      "midi": 76,
+      "start": 52.826087,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 2,
+      "staff": 1
+    },
+    {
+      "midi": 74,
+      "start": 53.478261,
+      "duration": 1.956522,
+      "hand": "R",
+      "finger": null,
+      "voice": 2,
+      "staff": 1
+    },
+    {
+      "midi": 53,
+      "start": 55.434783,
+      "duration": 1.956522,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 72,
+      "start": 55.434783,
+      "duration": 1.956522,
+      "hand": "R",
+      "finger": null,
+      "voice": 3,
+      "staff": 1
+    },
+    {
+      "midi": 52,
+      "start": 57.391304,
+      "duration": 3.913043,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 55,
+      "start": 57.391304,
+      "duration": 3.913043,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 60,
+      "start": 58.043478,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 62,
+      "start": 58.695652,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 60,
+      "start": 59.347826,
+      "duration": 1.956522,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 64,
+      "start": 59.347826,
+      "duration": 1.956522,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 69,
+      "start": 59.347826,
+      "duration": 1.956522,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 50,
+      "start": 61.304348,
+      "duration": 3.913043,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 53,
+      "start": 61.304348,
+      "duration": 5.869565,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 65,
+      "start": 61.956522,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 67,
+      "start": 62.608696,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 65,
+      "start": 63.26087,
+      "duration": 1.956522,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 69,
+      "start": 63.26087,
+      "duration": 1.956522,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 72,
+      "start": 63.26087,
+      "duration": 1.956522,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 50,
+      "start": 65.217391,
+      "duration": 1.956522,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 65,
+      "start": 65.217391,
+      "duration": 1.956522,
+      "hand": "R",
+      "finger": null,
+      "voice": 2,
+      "staff": 1
+    },
+    {
+      "midi": 69,
+      "start": 65.217391,
+      "duration": 1.956522,
+      "hand": "R",
+      "finger": null,
+      "voice": 2,
+      "staff": 1
+    },
+    {
+      "midi": 43,
+      "start": 67.173913,
+      "duration": 3.913043,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 50,
+      "start": 67.173913,
+      "duration": 3.913043,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 53,
+      "start": 67.173913,
+      "duration": 3.913043,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 69,
+      "start": 67.826087,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 71,
+      "start": 68.478261,
+      "duration": 0.652174,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 67,
+      "start": 69.130435,
+      "duration": 1.956522,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 71,
+      "start": 69.130435,
+      "duration": 1.956522,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 76,
+      "start": 69.130435,
+      "duration": 1.956522,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 36,
+      "start": 71.086957,
+      "duration": 1.304348,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 76,
+      "start": 71.086957,
+      "duration": 5.869565,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 79,
+      "start": 71.086957,
+      "duration": 5.869565,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 43,
+      "start": 72.391304,
+      "duration": 0.652174,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 48,
+      "start": 73.043478,
+      "duration": 1.956522,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 55,
+      "start": 75,
+      "duration": 1.956522,
+      "hand": "L",
+      "finger": null,
+      "voice": 6,
+      "staff": 2
+    },
+    {
+      "midi": 60,
+      "start": 76.956522,
+      "duration": 3.913043,
+      "hand": "L",
+      "finger": null,
+      "voice": 5,
+      "staff": 2
+    },
+    {
+      "midi": 76,
+      "start": 76.956522,
+      "duration": 3.913043,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    },
+    {
+      "midi": 79,
+      "start": 76.956522,
+      "duration": 3.913043,
+      "hand": "R",
+      "finger": null,
+      "voice": 1,
+      "staff": 1
+    }
+  ],
+  "expectedOverfullMeasures": [
+    "1",
+    "2",
+    "3",
+    "4",
+    "5",
+    "7",
+    "10",
+    "12",
+    "14",
+    "16"
+  ]
+}

--- a/omr-service/deploy/README.md
+++ b/omr-service/deploy/README.md
@@ -47,7 +47,7 @@ git -C /opt/clairkeys worktree add --detach /opt/clairkeys-deploy origin/main
 
 # 2. Build, tagged both by commit and as :current, which the unit references.
 cd /opt/clairkeys-deploy/omr-service
-podman build -f Dockerfile.audiveris \
+podman build --format docker -f Dockerfile.audiveris \
   -t "clairkeys-omr:$(git -C /opt/clairkeys rev-parse --short origin/main)" \
   -t clairkeys-omr:current .
 
@@ -81,7 +81,7 @@ git -C /opt/clairkeys-deploy fetch origin main
 test -z "$(git -C /opt/clairkeys-deploy status --porcelain)"
 git -C /opt/clairkeys-deploy checkout --detach <commit>
 cd /opt/clairkeys-deploy/omr-service
-podman build -f Dockerfile.audiveris \
+podman build --format docker -f Dockerfile.audiveris \
   -t "clairkeys-omr:<commit>" -t clairkeys-omr:current .
 expected_image=$(podman image inspect --format '{{.Id}}' "clairkeys-omr:<commit>")
 install -m 0644 deploy/clairkeys-omr.service /etc/systemd/system/clairkeys-omr.service
@@ -97,6 +97,11 @@ service and a running container; compare the container image ID with the ID
 printed by `podman image inspect` to prove that the new image is running rather
 than an older container. If restart fails, stop and inspect the journal before
 retrying instead of relying on `Restart=always` to hide a transient failure:
+
+Keep `--format docker`: podman 4.4.1's default OCI format warns that it ignores
+the Dockerfile's `HEALTHCHECK`. Confirm the built image retains that check and
+still run the external HTTP probes below; image metadata alone is not evidence
+that the provider network or the shared-secret boundary works.
 
 ```bash
 journalctl -u clairkeys-omr --since "5 minutes ago" --no-pager

--- a/omr-service/deploy/README.md
+++ b/omr-service/deploy/README.md
@@ -92,16 +92,16 @@ actual_image=$(podman inspect --format '{{.Image}}' clairkeys-omr-prod)
 test "$actual_image" = "$expected_image"
 ```
 
+Keep `--format docker`: podman 4.4.1's default OCI format warns that it ignores
+the Dockerfile's `HEALTHCHECK`. Confirm the built image retains that check and
+still run the external HTTP probes below; image metadata alone is not evidence
+that the provider network or the shared-secret boundary works.
+
 The `restart` command must exit 0. The final two checks must show an active
 service and a running container; compare the container image ID with the ID
 printed by `podman image inspect` to prove that the new image is running rather
 than an older container. If restart fails, stop and inspect the journal before
 retrying instead of relying on `Restart=always` to hide a transient failure:
-
-Keep `--format docker`: podman 4.4.1's default OCI format warns that it ignores
-the Dockerfile's `HEALTHCHECK`. Confirm the built image retains that check and
-still run the external HTTP probes below; image metadata alone is not evidence
-that the provider network or the shared-secret boundary works.
 
 ```bash
 journalctl -u clairkeys-omr --since "5 minutes ago" --no-pager

--- a/omr-service/omr/converter.py
+++ b/omr-service/omr/converter.py
@@ -12,6 +12,8 @@ import xml.etree.ElementTree as ET
 from datetime import datetime
 import zipfile
 
+from omr.musicxml_timing import QuarterClock, ScoreTimeline, scan_score
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_TIMING_REFERENCE_BPM = 60.0
@@ -79,7 +81,10 @@ class MusicXMLToClairKeysConverter:
             metadata = self._extract_metadata(root, title, composer)
             logger.info(f"Extracted metadata: {metadata}")
 
-            score_tempo = self._extract_tempo(root)
+            timeline = scan_score(root, self._find_tempo)
+            if timeline.warnings:
+                metadata['timingWarnings'] = timeline.warnings
+            score_tempo = timeline.opening_tempo
             resolved_tempo = tempo if tempo is not None else score_tempo
             if tempo is not None:
                 tempo_source = "user"
@@ -101,6 +106,7 @@ class MusicXMLToClairKeysConverter:
                 root,
                 timing_reference_bpm,
                 use_score_tempo_changes=tempo is None,
+                timeline=timeline,
             )
             logger.info(f"Extracted {len(notes)} notes")
             
@@ -193,121 +199,46 @@ class MusicXMLToClairKeysConverter:
         root: ET.Element,
         initial_tempo: float,
         use_score_tempo_changes: bool = True,
+        timeline: Optional[ScoreTimeline] = None,
     ) -> List[Dict[str, Any]]:
-        """Extract notes from MusicXML into canonical timed notes.
-
-        Timing is accumulated in *seconds*, not divisions, because tempo can
-        change between measures and each change re-scales tick->second. Within a
-        measure a cursor tracks the seconds offset so `<backup>`/`<forward>` and
-        `<chord>` place notes at the right onset; `<tie>` merges durations instead
-        of emitting a second note. Hand comes from `<staff>` (1->R, 2->L), falling
-        back to the part index only when no staff is given.
-        """
+        """Interpret musical positions first, then integrate a shared tempo map."""
+        timeline = timeline or scan_score(root, self._find_tempo)
+        clock = QuarterClock(initial_tempo, timeline.tempos if use_score_tempo_changes else {})
         notes: List[Dict[str, Any]] = []
-        parts = root.findall('.//part')
-        # Tempo is a score-wide property in MusicXML: a <sound tempo> / <per-minute>
-        # in one part (conventionally the first) governs playback for every part at
-        # that measure position. Build one measure-indexed timeline from all parts so
-        # a tempo change declared in one part re-scales the others' timing too.
-        tempo_timeline = self._build_tempo_timeline(
-            parts,
-            initial_tempo,
-            use_score_tempo_changes=use_score_tempo_changes,
-        )
-
-        for part_idx, part in enumerate(parts):
-            divisions = 1
-            measure_start_sec = 0.0
-            # Tie state must persist across measure boundaries — a note tied into the
-            # next measure has to merge with the note that opened the tie — so
-            # open_ties lives at part scope, not per measure.
-            open_ties: Dict[Any, Dict[str, Any]] = {}  # (midi, voice) -> tie-open note
-
-            for measure_idx, measure in enumerate(part.findall('measure')):
-                attributes = measure.find('attributes')
-                if attributes is not None:
-                    div_elem = attributes.find('divisions')
-                    if div_elem is not None and div_elem.text:
-                        try:
-                            divisions = int(div_elem.text)
-                        except ValueError:
-                            pass
-                if divisions <= 0:
-                    divisions = 1
-
-                tempo = tempo_timeline[measure_idx] if measure_idx < len(tempo_timeline) else initial_tempo
-                sec_per_tick = (60.0 / tempo) / divisions if tempo > 0 else 0.0
-
-                cursor_sec = 0.0        # seconds offset from measure_start_sec
-                measure_max_sec = 0.0   # furthest point reached (measure length)
-                last_onset_sec = 0.0    # onset of the last non-chord note (chords share it)
-
-                for elem in list(measure):
-                    tag = elem.tag
-                    if tag == 'backup':
-                        cursor_sec = max(0.0, cursor_sec - self._duration_ticks(elem) * sec_per_tick)
-                        continue
-                    if tag == 'forward':
-                        cursor_sec += self._duration_ticks(elem) * sec_per_tick
-                        measure_max_sec = max(measure_max_sec, cursor_sec)
-                        continue
-                    if tag != 'note':
-                        continue
-
-                    dur_sec = self._duration_ticks(elem) * sec_per_tick
-                    is_chord = elem.find('chord') is not None
-                    onset_sec = last_onset_sec if is_chord else cursor_sec
-                    end_sec = onset_sec + dur_sec
-
-                    # Rests and unpitched/unparseable notes advance time but emit nothing.
+        for part_idx, measures in enumerate(timeline.parts):
+            open_ties: Dict[Any, Dict[str, Any]] = {}
+            for measure_idx, measure in enumerate(measures):
+                for elem, onset, duration in measure.notes:
                     parsed = None if elem.find('rest') is not None else self._parse_pitch(elem)
-                    if parsed is not None:
-                        midi_num, voice, staff = parsed
-                        tie_start, tie_stop = self._tie_flags(elem)
-                        key = (midi_num, voice)
-                        if tie_stop and key in open_ties:
-                            started = open_ties[key]
-                            started['duration'] = round(started['duration'] + dur_sec, 6)
-                            if not tie_start:
-                                del open_ties[key]
-                        else:
-                            note: Dict[str, Any] = {
-                                "midi": midi_num,
-                                "start": round(measure_start_sec + onset_sec, 6),
-                                "duration": round(dur_sec, 6),
-                                "hand": self._hand_for(staff, part_idx),
-                                "finger": self._fingering(elem),
-                            }
-                            if voice is not None:
-                                note["voice"] = voice
-                            if staff is not None:
-                                note["staff"] = staff
-                            notes.append(note)
-                            if tie_start:
-                                open_ties[key] = note
-
-                    if not is_chord:
-                        cursor_sec = end_sec
-                        last_onset_sec = onset_sec
-                    measure_max_sec = max(measure_max_sec, end_sec)
-
-                measure_start_sec += measure_max_sec
-
+                    if parsed is None:
+                        continue
+                    midi_num, voice, staff = parsed
+                    start_quarter = timeline.starts[part_idx][measure_idx] + onset
+                    dur_sec = clock.duration(start_quarter, start_quarter + duration)
+                    tie_start, tie_stop = self._tie_flags(elem)
+                    key = (midi_num, voice)
+                    if tie_stop and key in open_ties:
+                        started = open_ties[key]
+                        started['duration'] = round(started['duration'] + dur_sec, 6)
+                        if not tie_start:
+                            del open_ties[key]
+                    else:
+                        note: Dict[str, Any] = {
+                            "midi": midi_num,
+                            "start": round(clock.at(start_quarter), 6),
+                            "duration": round(dur_sec, 6),
+                            "hand": self._hand_for(staff, part_idx),
+                            "finger": self._fingering(elem),
+                        }
+                        if voice is not None:
+                            note["voice"] = voice
+                        if staff is not None:
+                            note["staff"] = staff
+                        notes.append(note)
+                        if tie_start:
+                            open_ties[key] = note
         notes.sort(key=lambda n: (n['start'], n['midi']))
         return notes
-
-    def _duration_ticks(self, elem: ET.Element) -> int:
-        """Read a `<duration>` child as an integer tick count (0 if absent)."""
-        dur_elem = elem.find('duration')
-        if dur_elem is not None and dur_elem.text:
-            try:
-                return int(dur_elem.text)
-            except ValueError:
-                try:
-                    return int(float(dur_elem.text))
-                except ValueError:
-                    return 0
-        return 0
 
     def _parse_pitch(self, note_elem: ET.Element) -> Optional[tuple]:
         """Return (midi, voice, staff) for a pitched note, or None if unpitched."""
@@ -383,11 +314,11 @@ class MusicXMLToClairKeysConverter:
         must first be converted. Keep `sound` first because it is the playback
         value and needs no beat-unit conversion.
         """
-        sound = measure.find('.//sound[@tempo]')
+        sound = measure if measure.tag == 'sound' else measure.find('.//sound[@tempo]')
         if sound is not None:
             try:
                 tempo = float(sound.get('tempo'))
-                if tempo > 0:
+                if math.isfinite(tempo) and tempo > 0:
                     return tempo
             except (TypeError, ValueError):
                 pass
@@ -397,37 +328,6 @@ class MusicXMLToClairKeysConverter:
             if tempo is not None:
                 return tempo
         return None
-
-    def _build_tempo_timeline(
-        self,
-        parts: List[ET.Element],
-        initial_tempo: float,
-        use_score_tempo_changes: bool = True,
-    ) -> List[float]:
-        """Build a measure-indexed tempo (BPM) timeline shared across all parts.
-
-        For each measure position, the first tempo declared by any part (scanning
-        parts in document order) wins and carries forward until the next change.
-        This mirrors MusicXML's convention that a tempo direction in one part is a
-        global playback change, so parts that carry no tempo of their own still get
-        re-scaled at a measure where another part changed tempo. A user-supplied
-        tempo disables score changes because the explicit user value has contract
-        precedence over every score tempo.
-        """
-        max_measures = max((len(part.findall('measure')) for part in parts), default=0)
-        timeline: List[float] = []
-        current = initial_tempo
-        for i in range(max_measures):
-            if use_score_tempo_changes:
-                for part in parts:
-                    measures = part.findall('measure')
-                    if i < len(measures):
-                        measure_tempo = self._find_tempo(measures[i])
-                        if measure_tempo is not None and measure_tempo > 0:
-                            current = measure_tempo
-                            break
-            timeline.append(current)
-        return timeline
 
     def _note_to_midi(self, step: str, octave: int, alter: int = 0) -> Optional[int]:
         """Convert note name to MIDI number"""
@@ -493,25 +393,9 @@ class MusicXMLToClairKeysConverter:
         return per_minute_value * multiplier * dot_multiplier
 
     def _extract_tempo(self, root: ET.Element) -> Optional[float]:
-        """Extract the tempo the score declares *at its opening*, or None.
+        """Only a tempo effective at quarter zero describes the opening."""
+        return scan_score(root, self._find_tempo).opening_tempo
 
-        Only the first measure of each part is consulted. Scanning the whole
-        score for "a tempo" reads a mark that appears at bar 12 as though it
-        described bar 1: the opening bars get re-timed by a number the score
-        never applied to them, and `tempoSource` claims `score` for a piece
-        whose beginning is in fact unmarked. Later marks are not lost — they
-        still take effect from their own measure through
-        `_build_tempo_timeline`, which is where a mid-piece change belongs.
-        """
-        for part in root.findall('.//part'):
-            measures = part.findall('measure')
-            if not measures:
-                continue
-            tempo = self._find_tempo(measures[0])
-            if tempo is not None:
-                return tempo
-        return None
-    
     def _extract_key_signature(self, root: ET.Element) -> str:
         """Extract key signature from MusicXML"""
         key_elem = root.find('.//key')

--- a/omr-service/omr/musicxml_timing.py
+++ b/omr-service/omr/musicxml_timing.py
@@ -1,0 +1,169 @@
+"""Read musical positions before mapping them to the audio time domain."""
+
+from bisect import bisect_right
+from dataclasses import dataclass, field
+from fractions import Fraction
+import math
+from typing import Callable, Optional
+import xml.etree.ElementTree as ET
+
+
+def fraction(text: Optional[str], default: Fraction = Fraction(0)) -> Fraction:
+    try:
+        return Fraction(text) if text is not None else default
+    except (ValueError, ZeroDivisionError):
+        return default
+
+
+def meter_length(time: ET.Element) -> Optional[Fraction]:
+    if time.find('senza-misura') is not None:
+        return None
+    beats = time.findall('beats')
+    units = time.findall('beat-type')
+    if not beats or len(beats) != len(units):
+        return None
+    total = Fraction(0)
+    for count, unit in zip(beats, units):
+        numerator = sum((fraction(n) for n in (count.text or '').split('+')), Fraction(0))
+        denominator = fraction(unit.text)
+        if numerator <= 0 or denominator <= 0:
+            return None
+        total += numerator * 4 / denominator
+    return total
+
+
+@dataclass
+class Measure:
+    notes: list = field(default_factory=list)  # (XML note, local quarter onset, duration)
+    tempos: list = field(default_factory=list)  # (local quarter position, BPM)
+    length: Fraction = Fraction(0)
+    non_controlling: bool = False
+
+
+@dataclass
+class ScoreTimeline:
+    parts: list
+    starts: list
+    tempos: dict
+    warnings: list
+
+    @property
+    def opening_tempo(self) -> Optional[float]:
+        return self.tempos.get(Fraction(0))
+
+
+def scan_score(root: ET.Element, read_tempo: Callable) -> ScoreTimeline:
+    parts = []
+    warnings = []
+    for part_index, part in enumerate(root.findall('.//part')):
+        divisions = Fraction(1)
+        expected = None
+        measures = []
+        for index, element in enumerate(part.findall('measure')):
+            measure = Measure(non_controlling=element.get('non-controlling') == 'yes')
+            cursor = last_onset = Fraction(0)
+            check_meter = element.get('implicit') != 'yes' and element.get('non-controlling') != 'yes'
+            for child in element:
+                if child.tag == 'attributes':
+                    changed = fraction(child.findtext('divisions'), divisions)
+                    divisions = changed if changed > 0 else Fraction(1)
+                    times = child.findall('time')
+                    if times:
+                        lengths = [meter_length(time) for time in times]
+                        expected = lengths[0] if all(value == lengths[0] for value in lengths) else None
+                        if cursor != 0:
+                            check_meter = False
+                    continue
+                if child.tag in ('direction', 'sound'):
+                    bpm = read_tempo(child)
+                    if bpm is not None and math.isfinite(bpm) and bpm > 0:
+                        sound = child if child.tag == 'sound' else child.find('sound')
+                        offset = sound.find('offset') if sound is not None else None
+                        if offset is None and child.tag == 'direction':
+                            direction_offset = child.find('offset')
+                            if direction_offset is not None and direction_offset.get('sound') == 'yes':
+                                offset = direction_offset
+                        position = cursor + (fraction(offset.text) / divisions if offset is not None else 0)
+                        measure.tempos.append((max(Fraction(0), position), bpm))
+                    continue
+                duration = max(Fraction(0), fraction(child.findtext('duration')) / divisions)
+                if child.tag == 'backup':
+                    cursor = max(Fraction(0), cursor - duration)
+                elif child.tag == 'forward':
+                    cursor += duration
+                    measure.length = max(measure.length, cursor)
+                elif child.tag == 'note':
+                    chord = child.find('chord') is not None
+                    onset = last_onset if chord else cursor
+                    measure.notes.append((child, onset, duration))
+                    if not chord:
+                        last_onset = onset
+                        cursor = onset + duration
+                    measure.length = max(measure.length, onset + duration)
+            location = {'part': part.get('id', str(part_index + 1)), 'measure': element.get('number', str(index + 1))}
+            if check_meter and expected is not None and measure.length > expected:
+                warnings.append({'code': 'measure-overflow', **location,
+                                 'expectedQuarters': float(expected), 'actualQuarters': float(measure.length)})
+            navigation = element.find('.//repeat') is not None or element.find('.//ending') is not None
+            navigation = navigation or any(
+                any(sound.get(key) is not None for key in ('dacapo', 'dalsegno', 'tocoda', 'fine'))
+                for sound in element.findall('.//sound'))
+            if navigation:
+                warnings.append({'code': 'unexpanded-navigation', **location})
+            measures.append(measure)
+        parts.append(measures)
+
+    independent = [any(measure.non_controlling for measure in part) for part in parts]
+    shared_starts = []
+    position = Fraction(0)
+    for index in range(max((len(part) for part in parts), default=0)):
+        shared_starts.append(position)
+        # A short/omitted voice must not move its next bar ahead of other parts.
+        # Actual content sets the boundary; never repair OCR by stretching notes.
+        position += max((part[index].length for part_index, part in enumerate(parts)
+                         if not independent[part_index] and index < len(part)), default=Fraction(0))
+    starts = []
+    for part_index, part in enumerate(parts):
+        if not independent[part_index]:
+            starts.append(shared_starts)
+            continue
+        local_starts = []
+        position = Fraction(0)
+        for measure in part:
+            local_starts.append(position)
+            position += measure.length
+        starts.append(local_starts)
+    tempos = {}
+    owners = {}
+    for part_index, part in enumerate(parts):
+        for index, measure in enumerate(part):
+            for offset, bpm in measure.tempos:
+                position = starts[part_index][index] + offset
+                if position not in owners or owners[position] == part_index:
+                    tempos[position] = bpm
+                    owners[position] = part_index
+    return ScoreTimeline(parts, starts, tempos, warnings)
+
+
+class QuarterClock:
+    """Piecewise tempo integral, with logarithmic timestamp lookup."""
+
+    def __init__(self, initial_bpm: float, tempos: dict):
+        marks = {Fraction(0): initial_bpm, **tempos}
+        self.positions = sorted(marks)
+        self.bpms = [marks[position] for position in self.positions]
+        self.seconds = [0.0]
+        for index in range(1, len(self.positions)):
+            elapsed = float(self.positions[index] - self.positions[index - 1]) * 60 / self.bpms[index - 1]
+            self.seconds.append(self.seconds[-1] + elapsed)
+
+    def at(self, position: Fraction) -> float:
+        index = bisect_right(self.positions, position) - 1
+        return self.seconds[index] + float(position - self.positions[index]) * 60 / self.bpms[index]
+
+    def duration(self, start: Fraction, end: Fraction) -> float:
+        first = bisect_right(self.positions, start) - 1
+        last = bisect_right(self.positions, end) - 1
+        if first == last:
+            return float(end - start) * 60 / self.bpms[first]
+        return self.at(end) - self.at(start)

--- a/src/components/animation/FallingNotesPlayer.tsx
+++ b/src/components/animation/FallingNotesPlayer.tsx
@@ -12,6 +12,7 @@ import FallingNotes from './FallingNotes'
 import SimplePianoKeyboard from '../piano/SimplePianoKeyboard'
 import { CompactPlaybackBar, PlaybackControls, TempoDisplay } from '@/components/playback'
 import { getActiveNotes } from '@/utils/visualUtils'
+import ScoreTimingNotice from '@/components/playback/ScoreTimingNotice'
 
 /**
  * Standing in for a rotation the device will not perform. The box is laid out
@@ -192,6 +193,7 @@ export default function FallingNotesPlayer({
       ].filter(Boolean).join(' ')}
       style={orientation.rotate ? rotatedRootStyle : undefined}
     >
+      {!isPlaying && <ScoreTimingNotice metadata={animationData.metadata} />}
       <TempoDisplay
         tempo={animationData.tempo}
         tempoSource={animationData.tempoSource}

--- a/src/components/playback/ScoreTimingNotice.tsx
+++ b/src/components/playback/ScoreTimingNotice.tsx
@@ -1,0 +1,28 @@
+import type { CanonicalAnimationMetadata } from '@/types/animationContract'
+
+/** Optional converter diagnostics are untrusted metadata, not a score repair. */
+export default function ScoreTimingNotice({ metadata }: { metadata?: CanonicalAnimationMetadata }) {
+  const warnings = Array.isArray(metadata?.timingWarnings) ? metadata.timingWarnings : []
+  const measures = new Set<string>()
+  let navigation = false
+  for (const warning of warnings) {
+    if (!warning || typeof warning !== 'object') continue
+    if (warning.code === 'unexpanded-navigation') navigation = true
+    if (warning.code === 'measure-overflow' && typeof warning.measure === 'string'
+      && typeof warning.expectedQuarters === 'number' && Number.isFinite(warning.expectedQuarters)
+      && typeof warning.actualQuarters === 'number' && Number.isFinite(warning.actualQuarters)
+      && warning.expectedQuarters > 0 && warning.actualQuarters > warning.expectedQuarters) {
+      measures.add(warning.measure)
+    }
+  }
+  if (measures.size === 0 && !navigation) return null
+  return <div role="status" className="mb-4 rounded-xl border border-state-warning/40 bg-surface-muted p-3 text-sm text-ink">
+    <p className="font-medium">리듬 확인이 필요합니다</p>
+    {measures.size > 0 && <p className="mt-1 text-xs">
+      인식한 박자와 음표 길이가 맞지 않는 곳이 {measures.size}개 마디 있습니다.
+      {' '}확인할 곳: {[...measures].slice(0, 6).map(measure => `${measure.slice(0, 24)}마디`).join(', ')}{measures.size > 6 ? ' 외' : ''}.
+    </p>}
+    {navigation && <p className="mt-1 text-xs">도돌이표 등의 지시가 반복 재생 순서에 반영되지 않았습니다.</p>}
+    <p className="mt-1 text-xs">원본 악보와 비교한 뒤 연습해 주세요. 이 안내는 인식 오류를 자동으로 고친 결과가 아닙니다.</p>
+  </div>
+}

--- a/src/components/playback/__tests__/ScoreTimingNotice.test.tsx
+++ b/src/components/playback/__tests__/ScoreTimingNotice.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react'
+import ScoreTimingNotice from '../ScoreTimingNotice'
+
+it('shows recognized rhythm contradictions and unsupported navigation without claiming a correction', () => {
+  render(<ScoreTimingNotice metadata={{ timingWarnings: [
+    { code: 'measure-overflow', part: 'P1', measure: '3', expectedQuarters: 3, actualQuarters: 4.5 },
+    { code: 'measure-overflow', part: 'P2', measure: '3', expectedQuarters: 3, actualQuarters: 4.5 },
+    { code: 'unexpanded-navigation', part: 'P1', measure: '9' },
+  ] }} />)
+  expect(screen.getByRole('status')).toHaveTextContent('리듬 확인이 필요합니다')
+  expect(screen.getByRole('status')).toHaveTextContent('1개 마디')
+  expect(screen.getByRole('status')).toHaveTextContent('3마디')
+  expect(screen.getByRole('status')).toHaveTextContent('반복 재생 순서에 반영되지 않았습니다')
+})
+
+it('ignores absent or malformed optional metadata', () => {
+  const { container, rerender } = render(<ScoreTimingNotice />)
+  expect(container).toBeEmptyDOMElement()
+  rerender(<ScoreTimingNotice metadata={{ timingWarnings: [null, 4, { code: 'measure-overflow', measure: {}, expectedQuarters: 3, actualQuarters: 'bad' }] }} />)
+  expect(container).toBeEmptyDOMElement()
+})

--- a/src/utils/__tests__/musicxmlTiming.test.ts
+++ b/src/utils/__tests__/musicxmlTiming.test.ts
@@ -1,0 +1,106 @@
+/** @jest-environment node */
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { createHash } from 'node:crypto'
+import { normalizeAnimationData } from '../animationContract'
+
+function convert(parts: string, tempo?: number) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'clairkeys-timing-'))
+  const input = path.join(dir, 'score.musicxml')
+  fs.writeFileSync(input, `<score-partwise>${parts}</score-partwise>`)
+  try {
+    return JSON.parse(execFileSync(process.env.PYTHON_BIN || 'python3', [
+      '-m', 'omr.cli', input, ...(tempo === undefined ? [] : ['--tempo', String(tempo)]),
+    ], { cwd: path.join(process.cwd(), 'omr-service'), encoding: 'utf8', timeout: 30000 }))
+  } finally { fs.rmSync(dir, { recursive: true, force: true }) }
+}
+const note = (step: string, duration: number) => `<note><pitch><step>${step}</step><octave>4</octave></pitch><duration>${duration}</duration></note>`
+const attributes = '<attributes><divisions>1</divisions><time><beats>4</beats><beat-type>4</beat-type></time></attributes>'
+const mark = (bpm: number) => `<direction><sound tempo="${bpm}"/></direction>`
+
+it('applies an in-measure tempo only after its actual position', () => {
+  const data = convert(`<part id="P1"><measure number="1">${attributes}${mark(60)}${note('C',4)}</measure><measure number="2">${note('D',1)}${mark(120)}${note('E',1)}</measure></part>`)
+  expect(data.notes).toMatchObject([{ start: 0, duration: 4 }, { start: 4, duration: 1 }, { start: 5, duration: 0.5 }])
+})
+
+it('integrates a held note across a tempo change located with a playback offset', () => {
+  const data = convert(`<part id="P1"><measure number="1">${attributes}${mark(60)}${note('C',4)}<direction><offset sound="yes">-2</offset><sound tempo="120"/></direction></measure></part>`)
+  expect(data.notes[0].duration).toBe(3)
+})
+
+it('gives sound offset priority and does not let a later first mark describe the opening', () => {
+  const data = convert(`<part id="P1"><measure number="1">${attributes}<direction><offset sound="yes">3</offset><sound tempo="120"><offset>1</offset></sound></direction>${note('C',2)}</measure></part>`)
+  expect(data).toMatchObject({ tempo: null, tempoSource: 'unknown', timingReferenceBpm: 60, scoreTempo: null })
+  expect(data.notes[0].duration).toBe(1.5)
+})
+
+it('ignores a direction offset without sound=yes for playback', () => {
+  const data = convert(`<part id="P1"><measure number="1">${attributes}${mark(60)}${note('C',1)}<direction><offset>1</offset><sound tempo="120"/></direction>${note('D',1)}</measure></part>`)
+  expect(data.notes).toMatchObject([{ duration: 1 }, { start: 1, duration: 0.5 }])
+})
+
+it('uses the same in-measure tempo map and measure boundary in every part', () => {
+  const data = convert(`<part id="P1"><measure number="1">${attributes}${note('C',4)}</measure><measure number="2">${note('D',1)}</measure></part><part id="P2"><measure number="1">${attributes}${mark(60)}${note('E',2)}${mark(120)}</measure><measure number="2">${note('F',1)}</measure></part>`)
+  expect(data.notes.find((n: { midi: number }) => n.midi === 60)).toMatchObject({ start: 0, duration: 3 })
+  expect(data.notes.find((n: { midi: number }) => n.midi === 62)).toMatchObject({ start: 3, duration: 0.5 })
+  expect(data.notes.find((n: { midi: number }) => n.midi === 65)).toMatchObject({ start: 3, duration: 0.5 })
+})
+
+it('keeps an explicit user override constant through all score tempo marks', () => {
+  const data = convert(`<part id="P1"><measure number="1">${attributes}${mark(60)}${note('C',1)}${mark(120)}${note('D',1)}</measure></part>`, 90)
+  expect(data).toMatchObject({ tempo: 90, tempoSource: 'user', scoreTempo: 60 })
+  expect(data.notes[0].duration).toBeCloseTo(2/3, 6)
+  expect(data.notes[1].duration).toBeCloseTo(2/3, 6)
+})
+
+it('does not truncate fractional divisions or note durations', () => {
+  const data = convert(`<part id="P1"><measure number="1"><attributes><divisions>2.5</divisions></attributes>${mark(60)}${note('C',1.25)}</measure></part>`)
+  expect(data.notes[0].duration).toBe(0.5)
+})
+
+it('diagnoses overfull measures without correcting their notes or rejecting pickups', () => {
+  const data = convert(`<part id="P1"><measure number="0" implicit="yes">${attributes}${note('C',1)}</measure><measure number="1">${note('D',5)}</measure></part>`)
+  expect(data.metadata.timingWarnings).toEqual([{ code: 'measure-overflow', part: 'P1', measure: '1', expectedQuarters: 4, actualQuarters: 5 }])
+  expect(data.notes).toMatchObject([{ duration: 1 }, { start: 1, duration: 5 }])
+})
+
+it('names unsupported repeat navigation rather than silently implying an expanded performance', () => {
+  const data = convert(`<part id="P1"><measure number="1">${attributes}${note('C',4)}<barline><repeat direction="backward" times="2"/></barline></measure></part>`)
+  expect(data.metadata.timingWarnings).toContainEqual({ code: 'unexpanded-navigation', part: 'P1', measure: '1' })
+})
+
+it('flags the real recognized score without rewriting any of its 133 note events', () => {
+  const fixture = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'fixtures/musicxml-timing/clair-de-lune-recognition.json'), 'utf8'))
+  const archive = Buffer.from(fixture.mxlBase64, 'base64')
+  expect(createHash('sha256').update(archive).digest('hex')).toBe(fixture.mxlSha256)
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'clairkeys-recognition-'))
+  const input = path.join(dir, 'score.mxl')
+  fs.writeFileSync(input, archive)
+  try {
+    const data = JSON.parse(execFileSync(process.env.PYTHON_BIN || 'python3', ['-m', 'omr.cli', input, '--tempo', '46'], {
+      cwd: path.join(process.cwd(), 'omr-service'), encoding: 'utf8', timeout: 30000,
+    }))
+    expect(data.notes).toEqual(fixture.expectedNotes)
+    expect(data.metadata.timingWarnings.map((warning: { measure: string }) => warning.measure)).toEqual(fixture.expectedOverfullMeasures)
+    expect(normalizeAnimationData(data).metadata?.timingWarnings).toEqual(data.metadata.timingWarnings)
+  } finally { fs.rmSync(dir, { recursive: true, force: true }) }
+})
+
+it('resolves simultaneous part tempo conflicts deterministically and lets later directions in that part win', () => {
+  const data = convert(`<part id="P1"><measure>${attributes}${mark(60)}${mark(90)}${note('C',3)}</measure></part><part id="P2"><measure>${attributes}${mark(120)}${note('D',3)}</measure></part>`)
+  expect(data.tempo).toBe(90)
+  expect(data.notes.map((n: { duration: number }) => n.duration)).toEqual([2, 2])
+})
+
+it('does not diagnose free meter or explicitly non-controlling measures as overfull', () => {
+  const data = convert(`<part id="P1"><measure non-controlling="yes">${attributes}${note('C',5)}</measure><measure><attributes><time><senza-misura/></time></attributes>${note('D',8)}</measure></part>`)
+  expect(data.metadata.timingWarnings).toBeUndefined()
+})
+
+it('preserves independent bar boundaries explicitly marked non-controlling', () => {
+  const data = convert(`<part id="P1"><measure>${attributes}${note('C',3)}</measure><measure>${note('D',3)}</measure></part><part id="P2"><measure non-controlling="yes">${attributes}${note('E',4)}</measure><measure non-controlling="yes">${note('F',4)}</measure></part>`)
+  expect(data.notes.find((n: { midi: number }) => n.midi === 62).start).toBe(3)
+  expect(data.notes.find((n: { midi: number }) => n.midi === 65).start).toBe(4)
+})


### PR DESCRIPTION
The converter applied one tempo to an entire measure, so a tempo change after its first note also retimed the earlier note. Parse divisions, note/chord/rest and backup/forward positions as rational quarter beats, then integrate a shared piecewise tempo map. This handles in-measure changes, notes held across changes, playback offsets, late first markings, fractional divisions and common part boundaries while preserving explicitly non-controlling part timelines. Explicit user tempo still overrides score changes.

The same scan records optional `metadata.timingWarnings` for overfull ordinary measures and unexpanded repeat/jump navigation. The player explains these before practice. The retained real #134 MXL produces the same 133 note dictionaries and ten specific overfull-measure warnings; this exposes recognized inconsistencies and does not invent missing notes, change 6/8 into 9/8, expand repeats. The musical recognition problem in issue #134 remains unresolved. Existing canonical v1.1 readers preserve this optional metadata.

Validation: 8/9 initial regressions failed before implementation. Self-review added a failing non-controlling-part regression, then preserved that exception. Existing converter corpus and tempo provenance tests pass alongside the new timing tests. Independent typecheck/lint, Python compilation and build passed (bundled build type/lint skip; checked separately). Built Chromium at 390x844 verified the real ten-measure diagnostic and its non-correction explanation without overflow; score/session APIs mocked. Final whole-suite result is recorded in the PR validation log. VM deployment and image/health/converter smoke verification follow only after merge.

Risk: converting time domains affects all score timing, so the real corpus, offset precedence, user override and independent part boundaries are pinned. Quarter-position scanning replaces the old per-measure tempo implementation; key-signature handling and tie identity are unchanged. Rollback is a revert plus restoration of the previous OMR image; original documents remain readable. Phase and rationale: `AUDIT-musicxml-timing.md`, D-048.
