### PR TITLE
fix(omr): preserve supported key metadata without false defaults

### DIFF
--- a/docs/recovery/DECISIONS.md
+++ b/docs/recovery/DECISIONS.md
@@ -1915,6 +1915,8 @@
      major/minor로 해석하고, 그 외 값(빈 값/none/다른 선법 포함)은 이 작은 계약으로 표시하지 않는다.
   4. key/fifths 없음, 빈 값·비정수·범위 밖 값, 표현 불가능한 조표는 Optional[str]의 None으로 반환하고
      JSON keySignature 필드를 생략한다. false C나 JSON null을 새로 쓰지 않고, 음표 변환은 계속한다.
+     숫자는 ASCII 정수 표기로 제한한다. 부호와 선행 0을 분리해 작은 범위 여부를 먼저 확인하므로
+     매우 긴 숫자도 Python 정수 변환 제한 예외를 만들지 않는다. 긴 선행 0 뒤의 유효한 값은 보존한다.
   5. notes, duration, tempo provenance, timing reference, warnings, source finger 및 기존 저장 문서는
      변경하지 않는다. 현재 UI/normalizer의 optional 문자열 호환을 회귀 검사한다.
 - Rejected: 모든 플랫을 C로 유지 | 확인된 사실과 다르다.

--- a/docs/recovery/DECISIONS.md
+++ b/docs/recovery/DECISIONS.md
@@ -1898,3 +1898,30 @@
 - Tested: Same-PDF isolated automatic retry selected 9/8 in 28.604s; exported overflow bars 10→1. Runtime numeral module repeated the 3,048-label probe without non-9 proposals. Failure/budget/cancellation tests pass.
 - Not-tested: Full-score musical correctness, handwritten/unseen digit fonts and end-to-end genuine 6/8 PDF corpus. First-bar dot/tie defects and fresh baseline's late-positioned opening tempo remain unresolved; do not close #134 or mark its phase DONE for this partial repair.
 - Related: #134; validation/2026-09-06-recognition-reference-checkpoint.md
+
+## D-050: 읽을 수 없는 조표를 C로 꾸미지 않고 기존 optional 문자열 계약을 사용한다
+
+- Date: 2026-09-06
+- Status: Accepted when OMR-Q1 merges
+- Context: 실제 Always XML의 fifths=-1이 JSON C가 되고, 잘못된 fifths 문자열은 전체 변환을 중단한다.
+  Sol/Luna 독립 검토는 기존 canonical keySignature가 optional string이고 재생 음높이는 이 메타데이터를
+  사용하지 않음을 확인했다. 사용자 요청은 세 곡 검증 후 우선순위별 수정이며, 원본 인식 개선은 별도다.
+- Decision:
+  1. 기존과 같이 문서 순서의 첫 key 선언만 읽는다. key-change/파트별 조성 분석을 새로 주장하지 않는다.
+  2. 정수 fifths -7..7과 major/minor만 간결한 ASCII 이름으로 변환한다. 음수는 플랫을 포함한다.
+     major: Cb,Gb,Db,Ab,Eb,Bb,F,C,G,D,A,E,B,F#,C#.
+     minor: Abm,Ebm,Bbm,Fm,Cm,Gm,Dm,Am,Em,Bm,F#m,C#m,G#m,D#m,A#m.
+  3. mode가 없을 때만 기존 major-name 관례를 유지한다. 명시된 mode는 공백/대소문자를 정규화한 뒤
+     major/minor로 해석하고, 그 외 값(빈 값/none/다른 선법 포함)은 이 작은 계약으로 표시하지 않는다.
+  4. key/fifths 없음, 빈 값·비정수·범위 밖 값, 표현 불가능한 조표는 Optional[str]의 None으로 반환하고
+     JSON keySignature 필드를 생략한다. false C나 JSON null을 새로 쓰지 않고, 음표 변환은 계속한다.
+  5. notes, duration, tempo provenance, timing reference, warnings, source finger 및 기존 저장 문서는
+     변경하지 않는다. 현재 UI/normalizer의 optional 문자열 호환을 회귀 검사한다.
+- Rejected: 모든 플랫을 C로 유지 | 확인된 사실과 다르다.
+- Rejected: 조표가 잘못됐다는 이유로 유효한 음표 변환도 중단 | 메타데이터 결함을 전체 실패로 확대한다.
+- Rejected: 이번에 새 key 객체/스키마 버전을 도입 | 기존 optional 문자열 계약이 이 범위를 표현한다.
+- Constraint: 기존 absence/unknown 처리와 첫 선언 범위는 명시한다. Satie/Always/Love의 인식 정확도나
+  반복/손 배정 문제를 이 메타데이터 수정으로 해결했다고 표현하지 않는다.
+- Confidence: high
+- Scope-risk: moderate
+- Related: OMR-Q1; validation/2026-09-06-multimodel-review-checkpoint.md

--- a/docs/recovery/phases/OMR-Q1-key-metadata.md
+++ b/docs/recovery/phases/OMR-Q1-key-metadata.md
@@ -1,0 +1,39 @@
+# OMR-Q1 — Preserve traditional key-signature metadata truthfully
+
+Status: `IN_PROGRESS`
+Depends on: Satie/Always/Love validation, Sol/Luna contract review, D-050
+
+## Objective
+
+Fix the demonstrated XML fifths=-1 → JSON C defect without changing any recognized note, rhythm,
+tempo or fingering. Prevent malformed key metadata from aborting otherwise valid conversion.
+
+## Prioritized work context
+
+The highest-impact remaining problem is PDF→MusicXML losing notes, bars, dots/ties and printed tempo.
+Love's extra text page also exposes input/page failure handling. Those need source-aware experiments,
+not blind padding, page dropping or filename rules. This small confirmed converter fix is the first
+independent deliverable while the larger recognition design is reviewed; it is not a substitute for it.
+
+## Work stages
+
+1. Add failing raw-CLI regression tests for flats, explicit minor and unsupported/malformed/missing keys.
+2. Implement D-050's optional-string, bounded first-key extraction contract.
+3. Check canonical normalization and untouched notes/tempo/timing; keep golden metadata fixtures truthful.
+4. Replay retained Always XML: keyF while all647 notes and other non-generated fields remain equal.
+   Satie D and Love E remain unchanged with exact notes.
+5. Independent review, focused/full tests, typecheck/lint/build, ready PR and CI. Merge and production
+   rollout follow their explicit approval boundaries; no stored-score rewrite.
+
+## Completion criteria
+
+- All -7..7 major/minor mappings verified; absent mode uses the existing major-name convention.
+- Missing/invalid/unrepresentable key is omitted, not invented as C and not a conversion failure.
+- A normalizer/CLI regression gate exercises the raw metadata, not only note-comparison helpers.
+- Existing valid note, tempo, timing and source-finger data are unchanged.
+- No claim that this fixes missing printed tempo, omitted bars, repeats or physical hand assignment.
+
+## Scope exclusions
+
+Key-change maps, polymodal/transposing parts, non-traditional key-step/key-alter signatures, namespace
+expansion, runtime recognition profile changes, PDF retention and inferred fingering cost changes.

--- a/fixtures/key-signatures/explicit-minor.musicxml
+++ b/fixtures/key-signatures/explicit-minor.musicxml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list><score-part id="P1"><part-name>Piano</part-name></score-part></part-list>
+  <part id="P1"><measure number="1"><attributes>
+    <divisions>1</divisions><key><fifths>-3</fifths><mode> MiNoR </mode></key>
+    <time><beats>1</beats><beat-type>4</beat-type></time>
+  </attributes><direction><sound tempo="72"/></direction>
+  <note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration><voice>1</voice><staff>1</staff></note>
+  </measure></part>
+</score-partwise>

--- a/fixtures/key-signatures/flat-major.musicxml
+++ b/fixtures/key-signatures/flat-major.musicxml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list><score-part id="P1"><part-name>Piano</part-name></score-part></part-list>
+  <part id="P1"><measure number="1"><attributes>
+    <divisions>1</divisions><key><fifths>-1</fifths></key>
+    <time><beats>1</beats><beat-type>4</beat-type></time>
+  </attributes><direction><sound tempo="72"/></direction>
+  <note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration><voice>1</voice><staff>1</staff></note>
+  </measure></part>
+</score-partwise>

--- a/fixtures/key-signatures/invalid-fifths.musicxml
+++ b/fixtures/key-signatures/invalid-fifths.musicxml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list><score-part id="P1"><part-name>Piano</part-name></score-part></part-list>
+  <part id="P1"><measure number="1"><attributes>
+    <divisions>1</divisions><key><fifths>invalid</fifths></key>
+    <time><beats>1</beats><beat-type>4</beat-type></time>
+  </attributes><direction><sound tempo="72"/></direction>
+  <note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration><voice>1</voice><staff>1</staff></note>
+  </measure></part>
+</score-partwise>

--- a/fixtures/key-signatures/missing-key.musicxml
+++ b/fixtures/key-signatures/missing-key.musicxml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list><score-part id="P1"><part-name>Piano</part-name></score-part></part-list>
+  <part id="P1"><measure number="1"><attributes>
+    <divisions>1</divisions>
+    <time><beats>1</beats><beat-type>4</beat-type></time>
+  </attributes><direction><sound tempo="72"/></direction>
+  <note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration><voice>1</voice><staff>1</staff></note>
+  </measure></part>
+</score-partwise>

--- a/fixtures/key-signatures/out-of-range.musicxml
+++ b/fixtures/key-signatures/out-of-range.musicxml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list><score-part id="P1"><part-name>Piano</part-name></score-part></part-list>
+  <part id="P1"><measure number="1"><attributes>
+    <divisions>1</divisions><key><fifths>8</fifths></key>
+    <time><beats>1</beats><beat-type>4</beat-type></time>
+  </attributes><direction><sound tempo="72"/></direction>
+  <note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration><voice>1</voice><staff>1</staff></note>
+  </measure></part>
+</score-partwise>

--- a/fixtures/key-signatures/unsupported-mode.musicxml
+++ b/fixtures/key-signatures/unsupported-mode.musicxml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list><score-part id="P1"><part-name>Piano</part-name></score-part></part-list>
+  <part id="P1"><measure number="1"><attributes>
+    <divisions>1</divisions><key><fifths>-1</fifths><mode>dorian</mode></key>
+    <time><beats>1</beats><beat-type>4</beat-type></time>
+  </attributes><direction><sound tempo="72"/></direction>
+  <note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration><voice>1</voice><staff>1</staff></note>
+  </measure></part>
+</score-partwise>

--- a/omr-service/omr/converter.py
+++ b/omr-service/omr/converter.py
@@ -6,6 +6,7 @@ Converts MusicXML files to ClairKeys animation data format
 import json
 import logging
 import math
+import re
 from pathlib import Path, PurePosixPath
 from typing import Dict, List, Optional, Any
 import xml.etree.ElementTree as ET
@@ -29,6 +30,17 @@ _QUARTER_NOTE_MULTIPLIERS = {
     "32nd": 0.125,
     "64th": 0.0625,
     "128th": 0.03125,
+}
+
+_TRADITIONAL_KEY_NAMES = {
+    "major": (
+        "Cb", "Gb", "Db", "Ab", "Eb", "Bb", "F", "C",
+        "G", "D", "A", "E", "B", "F#", "C#",
+    ),
+    "minor": (
+        "Abm", "Ebm", "Bbm", "Fm", "Cm", "Gm", "Dm", "Am",
+        "Em", "Bm", "F#m", "C#m", "G#m", "D#m", "A#m",
+    ),
 }
 
 class MusicXMLToClairKeysConverter:
@@ -125,10 +137,12 @@ class MusicXMLToClairKeysConverter:
                 "tempoSource": tempo_source,
                 "timingReferenceBpm": timing_reference_bpm,
                 "scoreTempo": score_tempo,
-                "keySignature": self._extract_key_signature(root),
                 "timeSignature": self._extract_time_signature(root),
                 "generated_at": datetime.utcnow().isoformat()
             }
+            key_signature = self._extract_key_signature(root)
+            if key_signature is not None:
+                animation_data["keySignature"] = key_signature
             
             logger.info(f"Successfully converted to ClairKeys format")
             return animation_data
@@ -396,19 +410,37 @@ class MusicXMLToClairKeysConverter:
         """Only a tempo effective at quarter zero describes the opening."""
         return scan_score(root, self._find_tempo).opening_tempo
 
-    def _extract_key_signature(self, root: ET.Element) -> str:
-        """Extract key signature from MusicXML"""
+    def _extract_key_signature(self, root: ET.Element) -> Optional[str]:
+        """Decode the first key declaration without guessing unreadable metadata."""
         key_elem = root.find('.//key')
-        if key_elem is not None:
-            fifths_elem = key_elem.find('fifths')
-            if fifths_elem is not None:
-                fifths = int(fifths_elem.text)
-                # Convert circle of fifths to key name (simplified)
-                keys = ['C', 'G', 'D', 'A', 'E', 'B', 'F#', 'C#']
-                if 0 <= fifths < len(keys):
-                    return keys[fifths]
-        
-        return "C"  # Default to C major
+        if key_elem is None:
+            return None
+
+        fifths_elem = key_elem.find('fifths')
+        if fifths_elem is None or fifths_elem.text is None:
+            return None
+        fifths_text = fifths_elem.text.strip()
+        if re.fullmatch(r"[+-]?[0-9]+", fifths_text) is None:
+            return None
+        digits = fifths_text[1:] if fifths_text[0] in "+-" else fifths_text
+        digits = digits.lstrip("0") or "0"
+        # Bound the textual magnitude before int(): huge invalid values must
+        # not hit Python's digit limit or consume arbitrary bigint work.
+        if len(digits) != 1 or digits > "7":
+            return None
+        fifths = int(digits) * (-1 if fifths_text.startswith("-") else 1)
+
+        mode_elem = key_elem.find('mode')
+        if mode_elem is None:
+            mode = "major"
+        elif mode_elem.text is None:
+            return None
+        else:
+            mode = mode_elem.text.strip().lower()
+            if mode not in _TRADITIONAL_KEY_NAMES:
+                return None
+
+        return _TRADITIONAL_KEY_NAMES[mode][fifths + 7]
     
     def _extract_time_signature(self, root: ET.Element) -> str:
         """Extract time signature from MusicXML"""

--- a/omr-service/tests/test_key_signature.py
+++ b/omr-service/tests/test_key_signature.py
@@ -1,0 +1,130 @@
+import asyncio
+import tempfile
+import unittest
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from omr.converter import MusicXMLToClairKeysConverter
+
+
+MAJOR_KEYS = [
+    "Cb", "Gb", "Db", "Ab", "Eb", "Bb", "F", "C",
+    "G", "D", "A", "E", "B", "F#", "C#",
+]
+MINOR_KEYS = [
+    "Abm", "Ebm", "Bbm", "Fm", "Cm", "Gm", "Dm", "Am",
+    "Em", "Bm", "F#m", "C#m", "G#m", "D#m", "A#m",
+]
+
+
+def key_root(fifths=None, mode=None, include_key=True):
+    key = ""
+    if include_key:
+        fifths_xml = "" if fifths is None else f"<fifths>{fifths}</fifths>"
+        mode_xml = "" if mode is None else f"<mode>{mode}</mode>"
+        key = f"<key>{fifths_xml}{mode_xml}</key>"
+    return ET.fromstring(
+        f"<score-partwise><part><measure><attributes>{key}</attributes>"
+        "</measure></part></score-partwise>"
+    )
+
+
+class KeySignatureExtractionTest(unittest.TestCase):
+    def setUp(self):
+        self.converter = MusicXMLToClairKeysConverter()
+
+    def test_maps_all_traditional_major_and_minor_fifths(self):
+        for fifths, expected in zip(range(-7, 8), MAJOR_KEYS):
+            with self.subTest(fifths=fifths, mode="major"):
+                self.assertEqual(
+                    self.converter._extract_key_signature(key_root(fifths, "  MaJoR ")),
+                    expected,
+                )
+        for fifths, expected in zip(range(-7, 8), MINOR_KEYS):
+            with self.subTest(fifths=fifths, mode="minor"):
+                self.assertEqual(
+                    self.converter._extract_key_signature(key_root(fifths, "  MiNoR ")),
+                    expected,
+                )
+
+    def test_absent_mode_uses_major_name_but_explicit_unsupported_mode_is_omitted(self):
+        self.assertEqual(self.converter._extract_key_signature(key_root(-1)), "F")
+        for mode in ("", "none", "dorian"):
+            with self.subTest(mode=mode):
+                self.assertIsNone(
+                    self.converter._extract_key_signature(key_root(-1, mode))
+                )
+
+    def test_missing_invalid_and_out_of_range_fifths_are_omitted(self):
+        cases = (
+            key_root(include_key=False),
+            key_root(),
+            key_root(""),
+            key_root("not-an-integer"),
+            key_root("1.0"),
+            key_root("1_0"),
+            key_root(-8),
+            key_root(8),
+        )
+        for root in cases:
+            with self.subTest(xml=ET.tostring(root, encoding="unicode")):
+                self.assertIsNone(self.converter._extract_key_signature(root))
+
+    def test_first_key_declaration_remains_the_bounded_source(self):
+        root = ET.fromstring(
+            "<score-partwise><part><measure><attributes>"
+            "<key><fifths>-1</fifths></key>"
+            "<key><fifths>2</fifths></key>"
+            "</attributes></measure></part></score-partwise>"
+        )
+        self.assertEqual(self.converter._extract_key_signature(root), "F")
+
+    def test_numeric_lexemes_are_ascii_and_bounded_before_integer_conversion(self):
+        for name, text, expected in (
+            ("huge-out-of-range", "9" * 5000, None),
+            ("huge-leading-zero", "0" * 5000 + "7", "C#"),
+            ("huge-negative-leading-zero", "-" + "0" * 5000 + "7", "Cb"),
+            ("explicit-plus", "+0002", "D"),
+            ("negative-zero", "-000", "C"),
+            ("unicode-digit", "\u0661", None),
+        ):
+            with self.subTest(case=name):
+                self.assertEqual(self.converter._extract_key_signature(key_root(text)), expected)
+
+    def test_invalid_key_does_not_abort_conversion_or_emit_null(self):
+        xml = """<?xml version="1.0"?>
+<score-partwise version="3.1">
+  <part-list><score-part id="P1"><part-name>Piano</part-name></score-part></part-list>
+  <part id="P1"><measure number="1"><attributes>
+    <divisions>1</divisions><key><fifths>invalid</fifths></key>
+    <time><beats>1</beats><beat-type>4</beat-type></time>
+  </attributes><direction><sound tempo="72"/></direction>
+  <note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration>
+    <voice>1</voice><staff>1</staff></note></measure></part>
+</score-partwise>"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "invalid.musicxml"
+            for value in ("invalid", "9" * 5000):
+                path.write_text(xml.replace("<fifths>invalid</fifths>", f"<fifths>{value}</fifths>"), encoding="utf-8")
+                result = asyncio.run(self.converter.convert(path))
+                self.assertNotIn("keySignature", result)
+                self.assertEqual(result["tempo"], 72)
+
+        self.assertNotIn("keySignature", result)
+        self.assertEqual(result["tempo"], 72)
+        self.assertEqual(
+            result["notes"],
+            [{
+                "midi": 60,
+                "start": 0.0,
+                "duration": 0.833333,
+                "hand": "R",
+                "finger": None,
+                "voice": 1,
+                "staff": 1,
+            }],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/utils/__tests__/animationContract.test.ts
+++ b/src/utils/__tests__/animationContract.test.ts
@@ -138,6 +138,14 @@ describe('normalizeAnimationData — converter.py shape (fields under metadata)'
     expect(out.version).toBe(ANIMATION_CONTRACT_VERSION) // no version in Shape C → filled
     expect(out.notes[0]).toMatchObject({ midi: 67, hand: 'R', finger: 3 })
   })
+
+  it('preserves optional flat/minor names and keeps absent key metadata absent', () => {
+    const note = { midi: 60, start: 0, duration: 1 }
+
+    expect(normalizeAnimationData({ keySignature: 'F', notes: [note] }).keySignature).toBe('F')
+    expect(normalizeAnimationData({ keySignature: 'Cm', notes: [note] }).keySignature).toBe('Cm')
+    expect(normalizeAnimationData({ notes: [note] })).not.toHaveProperty('keySignature')
+  })
 })
 
 describe('normalizeAnimationData — hard errors (no silent fallback)', () => {

--- a/src/utils/__tests__/converterKeySignatureContract.test.ts
+++ b/src/utils/__tests__/converterKeySignatureContract.test.ts
@@ -1,0 +1,64 @@
+import { execFileSync } from 'child_process'
+import fs from 'fs'
+import path from 'path'
+import { normalizeAnimationData } from '../animationContract'
+
+const REPO_ROOT = process.cwd()
+const OMR_DIR = path.join(REPO_ROOT, 'omr-service')
+const FIXTURES_DIR = path.join(REPO_ROOT, 'fixtures', 'key-signatures')
+const PYTHON = process.env.PYTHON_BIN || 'python3'
+
+function runRawConverter(fixture: string): Record<string, unknown> {
+  const stdout = execFileSync(
+    PYTHON,
+    ['-m', 'omr.cli', path.join(FIXTURES_DIR, fixture)],
+    {
+      cwd: OMR_DIR,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 30_000,
+      maxBuffer: 32 * 1024 * 1024,
+    }
+  )
+  return JSON.parse(stdout) as Record<string, unknown>
+}
+
+function withoutKeyAndGeneratedAt(raw: Record<string, unknown>): Record<string, unknown> {
+  const { keySignature: _keySignature, generated_at: _generatedAt, ...rest } = raw
+  return rest
+}
+
+describe('converter key-signature raw CLI contract (D-050)', () => {
+  it('passes the complete bounded Python extraction matrix', () => {
+    expect(() => execFileSync(PYTHON, [
+      '-m', 'unittest', 'discover', '-s', 'tests', '-p', 'test_key_signature.py',
+    ], { cwd: OMR_DIR, stdio: ['ignore', 'pipe', 'pipe'], timeout: 30_000 })).not.toThrow()
+  })
+
+  it.each([
+    ['flat-major.musicxml', 'F'],
+    ['explicit-minor.musicxml', 'Cm'],
+  ])('emits the traditional name for %s', (fixture, expected) => {
+    const raw = runRawConverter(fixture)
+    expect(raw.keySignature).toBe(expected)
+    expect(normalizeAnimationData(raw).keySignature).toBe(expected)
+  })
+
+  it.each([
+    'invalid-fifths.musicxml',
+    'missing-key.musicxml',
+    'out-of-range.musicxml',
+    'unsupported-mode.musicxml',
+  ])('omits unreadable metadata without aborting for %s', (fixture) => {
+    const raw = runRawConverter(fixture)
+    expect(raw).not.toHaveProperty('keySignature')
+    expect(normalizeAnimationData(raw).keySignature).toBeUndefined()
+  })
+
+  it('changes only key metadata across the identical tiny inputs', () => {
+    const baseline = withoutKeyAndGeneratedAt(runRawConverter('flat-major.musicxml'))
+    for (const fixture of fs.readdirSync(FIXTURES_DIR).sort()) {
+      expect(withoutKeyAndGeneratedAt(runRawConverter(fixture))).toEqual(baseline)
+    }
+  })
+})


### PR DESCRIPTION
## Purpose

First bounded deliverable from the Satie / Always With Me / Love Affair validation: fix traditional key metadata without changing recognized notes or playback. This does not resolve the wider recognition issues.

## Change

- Decode first key declaration for fifths -7..7, major/minor; absent mode retains the historical major-name convention.
- Omit unknown, malformed, unsupported or out-of-range key metadata instead of inventing C or aborting conversion.
- Keep the existing optional-string canonical contract; no schema object/version change or stored-score rewrite.
- Bound ASCII numeric text before integer conversion, including pathological digit lengths and valid long leading-zero forms.
- Add a raw converter CLI gate, full Python extraction matrix in CI, and canonical normalization tests.

## Evidence and review

- Regression-first: negative/invalid/minor tests failed before implementation. Independent Luna review exposed giant-number and Unicode-digit edge cases; both were reproduced and fixed.
- Sol implemented the initial contract; Luna independently reviewed it; coordinator reviewed/fixed boundaries and reran verification. Opus reviewed broader recognition priorities separately.
- Final 102 Jest suites / 972 tests PASS; 83 Python service tests PASS; independent typecheck/lint/build PASS (build itself skips type/lint).
- Retained actual XML replay: Always 647 notes unchanged with only key C→F; Satie 239/D and Love 411/E unchanged. Every non-key, non-generated field is equal.
- Decision D-050, phase OMR-Q1 and docs/recovery/validation/2026-09-06-key-metadata-implementation.md document contract and limits.

## Risks / exclusions / rollback

Unknown keys are now absent rather than always present as C; canonical/internal consumers already support absence, but raw external consumers should not assume the field exists. Only first declaration and traditional major/minor fifths are covered; no mode inference, key-change map, namespace expansion or transposing-part analysis.

No improvement to missing notes/bars, dots/ties, printed tempo recognition, repeats or hand assignment is claimed. Production remains unchanged. Rollback is reverting this converter-only PR or retaining the current production image; no data migration is needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - MusicXML의 조표 정보를 전통적인 이름으로 변환해 결과에 표시합니다.
  - 장조·단조 조표를 지원하며, 유효한 조표가 없으면 해당 필드를 생략합니다.

- **버그 수정**
  - 잘못되었거나 지원되지 않는 조표 정보가 있어도 음표 변환이 중단되지 않습니다.
  - 조표가 문서 순서에 따라 일관되게 처리됩니다.

- **문서**
  - 조표 메타데이터 보존 및 복구 절차를 문서화했습니다.

- **테스트**
  - 유효·누락·범위 초과·잘못된 조표 입력에 대한 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->