### PR TITLE
Recover omitted whole notes with a guarded native-template retry

### DIFF
--- a/docs/recovery/DECISIONS.md
+++ b/docs/recovery/DECISIONS.md
@@ -1927,3 +1927,22 @@
 - Confidence: high
 - Scope-risk: moderate
 - Related: OMR-Q1; validation/2026-09-06-multimodel-review-checkpoint.md
+
+## D-051: 음악적 누락 복구를 먼저 하고 자동 페이지 선별은 보류한다
+
+- Date: 2026-09-06
+- Status: User-directed work order; runtime correction policy not yet chosen
+- Context: 사용자는 앞선4번(온음표·마디·음가·붙임줄·템포·손 배정)을 최우선으로 하고, 조건부400dpi를
+  그다음으로 요청했다. 검증은 매 단계 병행한다. 비악보 페이지가 파싱 오류를 내는 것은 허용되며,
+  자동으로 페이지를 버리는 편의 기능은 필수 선행조건이 아니라는 방향을 승인했다.
+- Decision:
+  1. OMR-Q3의 Love Affair 온음표/마디 누락부터 검출 전·후·export 경계를 확인하고 실제 이벤트를 복구한다.
+  2. OMR-Q2의 자동 페이지 선별/제거 제안은 보류한다. 오선 탐지 실패를 비악보로 단정하거나 페이지를
+     조용히 제외하지 않는다. 필요한 오류는 확인된 실패 페이지/단계로 설명한다.
+  3. 조건부400dpi 재시도는 핵심 누락 복구 다음 순서이며, 특정 복구에 필요하면 통제 실험으로 증명한다.
+     모든 입력을 무조건 확대하지 않는다. 기존 JVM 동시성/시간/메모리 경계 유지.
+  4. 회귀는 각 수정 직후 세 곡으로 병행한다. 경고/메타데이터 개선만으로 음악적 인식 완료를 주장하지 않는다.
+- Constraint: D-048의 임의 마디 길이 보정 금지, D-045의 근거 없는 운지 지표 튜닝 금지 유지.
+- Confidence: high
+- Scope-risk: moderate
+- Related: OMR-Q3; user-approved order4→2 with3 concurrent and1 deferred

--- a/docs/recovery/DECISIONS.md
+++ b/docs/recovery/DECISIONS.md
@@ -1946,3 +1946,34 @@
 - Confidence: high
 - Scope-risk: moderate
 - Related: OMR-Q3; user-approved order4→2 with3 concurrent and1 deferred
+
+## D-052: 빈 마지막 마디가 있는 4/4 피아노만 대체 템플릿으로 재인식하고 엄격히 검증한다
+
+- Date: 2026-09-06
+- Status: Candidate implementation decision; acceptance requires regression and PR review
+- Context: 같은 Love solo/300dpi에서 Bravura HEADS는 온음표0개, Leland HEADS/PAGE는8개다.
+  기존439개 raw pitched 이벤트는 마디별 pitch/staff/onset/duration이 모두 보존되고, 마지막31이
+  복원된다. 별도21 누락은 wedge timeOffset NPE다. Satie raw 이벤트는 동일하지만 Always의
+  비온음표 이벤트5개가 바뀌므로 전역 폰트 교체는 허용하지 않는다. Bravura stemLessBoost0.38은
+  온음표3개만 남아 동일 복구를 달성하지 못했다. 숫자 증가만으로 정확도를 판단하지 않는다.
+- Decision:
+  1. 초기 인식은 기존 Bravura 설정 그대로 둔다. 단일 part/두 표준 오선 피아노, 균일4/4,
+     현재 검증된1~2페이지, pinned5.11.0 완료 그래프에서 온음표가 없고 마지막 stack이 빈
+     CAUTIONARY인 경우에만 원본 PDF 전체를 Leland로 한 번 더 처리한다. 페이지 선택/삭제 없음.
+  2. 동일 semaphore와 원래 deadline 안에서 순차 실행하고 결과는 별도 하위 임시 폴더에 둔다.
+     실패/시간 초과/모호한 XML/지원 밖 구조는 원본 결과를 보존한다. 설정은 JVM CLI 한정이다.
+  3. 후보는 기존 모든 마디와 pitched/rest raw 이벤트의 staff/onset/duration/pitch를 보존해야 한다.
+     기존 조표·박자·템포와 기존 타이도 보존한다. 추가 pitched 이벤트는 실제 재인식된 온음표만
+     허용하며, onset0/duration4이고 이미지 glyph가 있는 WHOLE_NOTE 그래프와 개수가 맞아야 한다.
+  4. 새 마디는 기존 마지막 번호 다음의 마지막 한 마디만 허용한다. 양쪽 staff에 온음표가 있고
+     길이가4여야 한다. 새 타이는 새 온음표와 시간/음높이가 이어지는 경계의 짝만 허용한다.
+     그 외 음가/음높이/템포/기존 타이 변경이나 새 비온음표는 거절한다. XML을 직접 보정하지 않는다.
+  5. 단일 사례의 분류기 결과가 전체 악보 정확도를 보증하지 않음을 기록한다. 실제 Love의8개
+     원본 온음표 참조 및 음가/오선, Satie/Always의 비회귀/재시도 생략, malformed/false candidate,
+     timeout/cancellation/deadline/concurrency를 회귀 검증한다. wedge21/템포/RH타이 문제는 별도다.
+- Rejected: 전역 Leland 교체 | Always의 다른 이벤트도 달라져 변화 범위를 보증할 수 없다.
+- Rejected: stemLessBoost 또는 거리 임계치 전역 완화 | 복구가 불완전하고 오탐 위험을 늘린다.
+- Rejected: 비어 보이는 마디에 음표/시간을 삽입 | 실제 이미지 인식을 우회하고 D-048에 위배된다.
+- Confidence: medium
+- Scope-risk: moderate
+- Related: D-051; OMR-Q3; local-test-data/results/whole-note-integrity

--- a/docs/recovery/DECISIONS.md
+++ b/docs/recovery/DECISIONS.md
@@ -1962,11 +1962,11 @@
      CAUTIONARY인 경우에만 원본 PDF 전체를 Leland로 한 번 더 처리한다. 페이지 선택/삭제 없음.
   2. 동일 semaphore와 원래 deadline 안에서 순차 실행하고 결과는 별도 하위 임시 폴더에 둔다.
      실패/시간 초과/모호한 XML/지원 밖 구조는 원본 결과를 보존한다. 설정은 JVM CLI 한정이다.
-  3. 후보는 기존 모든 마디와 pitched/rest raw 이벤트의 staff/onset/duration/pitch를 보존해야 한다.
+  3. 후보는 기존 모든 마디와 pitched/rest raw 이벤트의 staff/voice/onset/duration/pitch를 보존해야 한다.
      기존 조표·박자·템포와 기존 타이도 보존한다. 추가 pitched 이벤트는 실제 재인식된 온음표만
      허용하며, onset0/duration4이고 이미지 glyph가 있는 WHOLE_NOTE 그래프와 개수가 맞아야 한다.
   4. 새 마디는 기존 마지막 번호 다음의 마지막 한 마디만 허용한다. 양쪽 staff에 온음표가 있고
-     길이가4여야 한다. 새 타이는 새 온음표와 시간/음높이가 이어지는 경계의 짝만 허용한다.
+     길이가4여야 한다. 새 타이는 새 온음표와 시간/음높이/성부가 이어지는 경계의 짝만 허용한다.
      그 외 음가/음높이/템포/기존 타이 변경이나 새 비온음표는 거절한다. XML을 직접 보정하지 않는다.
   5. 단일 사례의 분류기 결과가 전체 악보 정확도를 보증하지 않음을 기록한다. 실제 Love의8개
      원본 온음표 참조 및 음가/오선, Satie/Always의 비회귀/재시도 생략, malformed/false candidate,

--- a/docs/recovery/phases/OMR-Q3-whole-note-integrity.md
+++ b/docs/recovery/phases/OMR-Q3-whole-note-integrity.md
@@ -1,0 +1,42 @@
+# OMR-Q3 — Repair musical-event loss before page-selection convenience
+
+Status: `IN_PROGRESS`
+Depends on: source references and retained graphs; no dependency on OMR-Q2
+
+## Objective
+
+Repair omitted whole notes/measures and then missing note values/ties/tempo at the recognition boundary.
+The user explicitly reordered work: musical integrity first, conditional400dpi second, regression at
+every change; automatic page selection is deferred and is not a prerequisite.
+
+## Evidence and first target
+
+Love Affair solo has31 printed measures; retained output has29, missing21/31. First3 raw-reference bars
+match41/41, but no whole-note types are exported. Whole-note symbols are also absent from the completed
+saved graph at both solo300 and the independent TruongCa400 experiment. Completed-graph absence alone
+does not distinguish failed detection from later removal.
+
+## Work stages
+
+1. Independently fix the source whole-note reference for sampled bars/voices and preserve an explicit
+   regression fixture before implementation. Do not treat the411-note output as gold.
+2. Capture the HEADS-stage graph with the unchanged engine/source and compare to final graph/XML.
+   Inspect pinned5.11.0 detection/filter/export code to locate the loss. No filename patches or invented notes.
+3. Record a specific correction decision before implementing a bounded fix. Keep musical duration and
+   physical key-release guidance separate; do not pad bars to hide missing recognition.
+4. Verify the actual source events and normal Satie/Always/Love controls after each behavior change.
+   Use conditional400dpi only if needed and independently shown beneficial, within existing budget/concurrency.
+5. Review-ready PR, CI/review and explicit target merge/rollout approvals. Broader unresolved items stay open.
+
+## Completion criteria
+
+- Sampled missing whole notes/measures actually survive to MusicXML/canonical with correct pitch/time.
+- No new whole-note/voice/tie corruption on controls; no warning-count-only success claim.
+- No automatic deletion/skipping of uncertain/non-music pages. An unparseable page may fail clearly.
+- No silently accepted corrupted result, artificial duration stretching or ungrounded fingering retuning.
+- Source PDFs remain user-local/Git-excluded; VM analysis copies cleaned after work units.
+
+## Out of scope
+
+Automatic page-filter implementation, complete-score certification without a human reference, new
+commercial runtime OMR/LLM provider, stored-score rewriting, or unrelated key metadata changes.

--- a/docs/recovery/phases/OMR-Q3-whole-note-integrity.md
+++ b/docs/recovery/phases/OMR-Q3-whole-note-integrity.md
@@ -22,8 +22,10 @@ does not distinguish failed detection from later removal.
    regression fixture before implementation. Do not treat the411-note output as gold.
 2. Capture the HEADS-stage graph with the unchanged engine/source and compare to final graph/XML.
    Inspect pinned5.11.0 detection/filter/export code to locate the loss. No filename patches or invented notes.
-3. Record a specific correction decision before implementing a bounded fix. Keep musical duration and
-   physical key-release guidance separate; do not pad bars to hide missing recognition.
+3. Implement D-052's bounded whole-note template retry regression-first. Keep initial Bravura and
+   abstain outside the validated4/4/piano/terminal-cautionary scope. Preserve original musical events;
+   accept only image-recognized whole additions and the recovered terminal measure. The independent
+   measure21 wedge exporter exception remains a separate correction. Never pad bars or invent notes.
 4. Verify the actual source events and normal Satie/Always/Love controls after each behavior change.
    Use conditional400dpi only if needed and independently shown beneficial, within existing budget/concurrency.
 5. Review-ready PR, CI/review and explicit target merge/rollout approvals. Broader unresolved items stay open.

--- a/omr-service/omr/audiveris.py
+++ b/omr-service/omr/audiveris.py
@@ -14,6 +14,10 @@ from time import monotonic
 from omr.converter import MusicXMLToClairKeysConverter
 from omr.meter_retry import accept_meter_retry, prepare_meter_retry, retry_is_eligible
 from omr.time_numeral import classify_time_numeral
+from omr.whole_note_retry import (
+    accept_whole_note_retry,
+    retry_is_eligible as whole_note_retry_is_eligible,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -155,7 +159,12 @@ class AudiverisProcessor:
             musicxml_path = output_files[0]
             
             logger.info(f"Successfully generated MusicXML: {musicxml_path}")
-            return await self._maybe_retry_meter(musicxml_path, pdf_path, output_dir, deadline)
+            meter_result = await self._maybe_retry_meter(
+                musicxml_path, pdf_path, output_dir, deadline
+            )
+            return await self._maybe_retry_whole_notes(
+                meter_result, pdf_path, output_dir, deadline
+            )
             
         except Exception as e:
             logger.error(f"Error in Audiveris processing: {str(e)}")
@@ -217,6 +226,76 @@ class AudiverisProcessor:
             # Diagnostics only; PDF/image checkpoints stay inside the existing
             # request temp tree and are removed by the service's normal cleanup.
             logger.warning('Meter retry unavailable (%s); retaining first result', type(error).__name__)
+            return original
+
+    async def _maybe_retry_whole_notes(
+        self, original: Path, pdf_path: Path, output_dir: Path, deadline: float
+    ) -> Path:
+        """Retry one guarded 4/4 piano with Leland inside the first deadline.
+
+        This method is called while ``process_pdf`` still owns the conversion
+        semaphore.  The original PDF and first XML/OMR stay untouched, and an
+        unsupported or rejected candidate simply returns the first result.
+        """
+        source = output_dir / f'{pdf_path.stem}.omr'
+        if monotonic() >= deadline:
+            return original
+        try:
+            converter = MusicXMLToClairKeysConverter()
+            before = converter._parse_musicxml(original).getroot()
+            if not whole_note_retry_is_eligible(before, source):
+                return original
+            retry_dir = Path(tempfile.mkdtemp(prefix='whole-note-retry-', dir=output_dir))
+            remaining = deadline - monotonic()
+            if remaining <= 0:
+                return original
+            logger.info('Retrying guarded whole-note recognition with the Leland music template')
+            process = await asyncio.create_subprocess_exec(
+                str(self.audiveris_executable), '-batch', '-export',
+                '-constant',
+                'org.audiveris.omr.ui.symbol.MusicFont.defaultMusicFamily=Leland',
+                '-output', str(retry_dir), '--', str(pdf_path),
+                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+                cwd=retry_dir,
+            )
+            remaining = deadline - monotonic()
+            if remaining <= 0:
+                await self._kill_and_wait(process)
+                return original
+            await self._communicate_with_timeout(process, remaining)
+            if process.returncode != 0:
+                logger.warning(
+                    'Whole-note retry exited %s; retaining first recognition result',
+                    process.returncode,
+                )
+                return original
+            outputs = sorted(retry_dir.glob('*.mxl'))
+            if not outputs:
+                outputs = sorted(retry_dir.glob('*.xml'))
+            graphs = sorted(retry_dir.glob('*.omr'))
+            if len(outputs) != 1 or len(graphs) != 1:
+                return original
+            candidate = converter._parse_musicxml(outputs[0]).getroot()
+            if monotonic() >= deadline:
+                return original
+            if not accept_whole_note_retry(before, candidate, graphs[0]):
+                logger.warning(
+                    'Whole-note retry failed event/metadata/graph guards; retaining first result'
+                )
+                return original
+            if monotonic() >= deadline:
+                return original
+            logger.info(
+                'Selected graph-backed whole-note recovery; other recognition defects may persist'
+            )
+            return outputs[0]
+        except asyncio.CancelledError:
+            raise
+        except Exception as error:
+            logger.warning(
+                'Whole-note retry unavailable (%s); retaining first result',
+                type(error).__name__,
+            )
             return original
     
     async def validate_audiveris_installation(self) -> bool:

--- a/omr-service/omr/whole_note_retry.py
+++ b/omr-service/omr/whole_note_retry.py
@@ -1,0 +1,417 @@
+"""Guarded Audiveris 5.11.0 Leland retry for missing whole notes (D-052).
+
+The retry is an alternative recognition result, never an XML repair.  These
+helpers deliberately abstain when the score or saved graph is outside the one
+validated two-staff 4/4 piano shape.
+"""
+
+from collections import Counter
+from dataclasses import dataclass
+from fractions import Fraction
+from pathlib import Path
+import re
+import xml.etree.ElementTree as ET
+import zipfile
+
+
+_MAX_ARCHIVE_ENTRIES = 64
+_MAX_ARCHIVE_BYTES = 100_000_000
+_MAX_XML_BYTES = 20_000_000
+_MAX_MEASURES = 1_000
+_MAX_MEASURE_CHILDREN = 10_000
+_PAGE_STEPS = frozenset({'HEADS', 'RHYTHMS', 'PAGE'})
+_PITCH_STEPS = frozenset({'C', 'D', 'E', 'F', 'G', 'A', 'B'})
+
+
+@dataclass(frozen=True)
+class _Event:
+    measure: int
+    kind: str
+    pitch: tuple[str, int, int] | None
+    staff: int
+    onset: Fraction
+    duration: Fraction
+    note_type: str
+
+
+@dataclass
+class _Score:
+    measures: list[int]
+    events: Counter
+    lengths: dict[int, Fraction]
+    metadata: tuple
+    ties: dict[str, Counter]
+    tie_details: dict[str, Counter]
+
+
+def _integer(text, *, minimum=None, maximum=None):
+    if text is None or not text or len(text) > 12 or not text.isascii():
+        raise ValueError('invalid integer')
+    if text[0] in '+-':
+        digits = text[1:]
+    else:
+        digits = text
+    if not digits or not digits.isdecimal():
+        raise ValueError('invalid integer')
+    value = int(text)
+    if minimum is not None and value < minimum:
+        raise ValueError('integer below bound')
+    if maximum is not None and value > maximum:
+        raise ValueError('integer above bound')
+    return value
+
+
+def _fraction(text, *, positive=False):
+    # Native MusicXML uses small fixed-point values. Never let a short exponent
+    # lexeme allocate an unbounded integer inside Fraction before we can abstain.
+    if (text is None or not re.fullmatch(
+            r'[+-]?[0-9]{1,12}(?:/[0-9]{1,12}|\.[0-9]{1,12})?', text)):
+        raise ValueError('invalid rational')
+    try:
+        value = Fraction(text)
+    except ZeroDivisionError:
+        raise ValueError('zero rational denominator') from None
+    if positive and value <= 0:
+        raise ValueError('non-positive rational')
+    return value
+
+
+def _signature(element):
+    return (
+        element.tag,
+        tuple(sorted(element.attrib.items())),
+        (element.text or '').strip(),
+        tuple(_signature(child) for child in element),
+    )
+
+
+def _uniform_four_four(root):
+    if root.tag != 'score-partwise' or len(root.findall('part')) != 1:
+        return False
+    measures = root.findall('part/measure')
+    if not measures or measures[0].find('attributes/time') is None:
+        return False
+    times = root.findall('.//attributes/time')
+    if not times:
+        return False
+    return all(
+        time.find('senza-misura') is None
+        and len(time.findall('beats')) == 1
+        and len(time.findall('beat-type')) == 1
+        and time.findtext('beats') == '4'
+        and time.findtext('beat-type') == '4'
+        for time in times
+    )
+
+
+def _pitch(note):
+    pitch = note.find('pitch')
+    if pitch is None:
+        return None
+    step = pitch.findtext('step')
+    if step not in _PITCH_STEPS:
+        raise ValueError('invalid pitch step')
+    octave = _integer(pitch.findtext('octave'), minimum=-1, maximum=9)
+    alter = _integer(pitch.findtext('alter', '0'), minimum=-2, maximum=2)
+    return step, alter, octave
+
+
+def _scan_score(root):
+    if root.tag != 'score-partwise':
+        raise ValueError('unsupported root')
+    parts = root.findall('part')
+    if len(parts) != 1:
+        raise ValueError('unsupported part count')
+    part_measures = parts[0].findall('measure')
+    if not part_measures or len(part_measures) > _MAX_MEASURES:
+        raise ValueError('unsupported measure count')
+    measures = []
+    events = Counter()
+    lengths = {}
+    metadata = [('part-id', parts[0].get('id'))]
+    ties = {'tie': Counter(), 'tied': Counter()}
+    tie_details = {'tie': Counter(), 'tied': Counter()}
+    divisions = Fraction(1)
+    for measure in part_measures:
+        if len(measure) > _MAX_MEASURE_CHILDREN:
+            raise ValueError('oversized measure')
+        number = _integer(measure.get('number'), minimum=1, maximum=100_000)
+        if measures and number <= measures[-1]:
+            raise ValueError('measure numbers must increase uniquely')
+        measures.append(number)
+        cursor = end = previous_onset = Fraction(0)
+        for item in measure:
+            if item.tag == 'attributes':
+                value = item.findtext('divisions')
+                if value is not None:
+                    divisions = _fraction(value, positive=True)
+                for child in item:
+                    if child.tag in ('key', 'time', 'staves', 'clef', 'transpose', 'staff-details'):
+                        metadata.append((number, child.tag, _signature(child)))
+            elif item.tag == 'sound' and item.get('tempo') is not None:
+                metadata.append((number, 'sound-tempo', cursor, divisions, _signature(item)))
+            elif item.tag == 'direction':
+                if (item.find('.//metronome') is not None
+                        or item.find('.//sound[@tempo]') is not None):
+                    # Keep cursor and all offset/sound attributes, not just BPM.
+                    # A conservative rejection of equivalent formatting is safe.
+                    metadata.append((number, 'tempo-direction', cursor, divisions, _signature(item)))
+            elif item.tag in ('backup', 'forward'):
+                duration = _fraction(item.findtext('duration'), positive=True) / divisions
+                cursor += -duration if item.tag == 'backup' else duration
+                if cursor < 0:
+                    raise ValueError('negative measure cursor')
+                end = max(end, cursor)
+            elif item.tag == 'note':
+                if item.find('grace') is not None or item.find('unpitched') is not None:
+                    raise ValueError('unsupported note kind')
+                duration = _fraction(item.findtext('duration'), positive=True) / divisions
+                chord = item.find('chord') is not None
+                onset = previous_onset if chord else cursor
+                staff = _integer(item.findtext('staff', '1'), minimum=1, maximum=2)
+                pitch = _pitch(item)
+                rest = item.find('rest') is not None
+                if (pitch is None) == (not rest):
+                    raise ValueError('note must be pitched or rest')
+                event = _Event(
+                    number, 'pitch' if pitch is not None else 'rest', pitch, staff,
+                    onset, duration, (item.findtext('type') or '').strip(),
+                )
+                events[event] += 1
+                for marker in item.findall('tie'):
+                    ties['tie'][(event, marker.get('type'))] += 1
+                    tie_details['tie'][(event, _signature(marker))] += 1
+                for marker in item.findall('notations/tied'):
+                    ties['tied'][(event, marker.get('type'))] += 1
+                    tie_details['tied'][(event, _signature(marker))] += 1
+                end = max(end, onset + duration)
+                if not chord:
+                    previous_onset = onset
+                    cursor += duration
+        lengths[number] = end
+    return _Score(measures, events, lengths, tuple(metadata), ties, tie_details)
+
+
+def _archive_xml(archive, info):
+    data = archive.read(info)
+    if b'<!DOCTYPE' in data.upper() or b'<!ENTITY' in data.upper():
+        raise ValueError('declarations are not supported in graph XML')
+    return ET.fromstring(data)
+
+
+def _safe_graph(path):
+    with zipfile.ZipFile(path) as archive:
+        infos = archive.infolist()
+        names = [info.filename for info in infos]
+        if (len(infos) > _MAX_ARCHIVE_ENTRIES
+                or len(names) != len(set(names))
+                or sum(info.file_size for info in infos) > _MAX_ARCHIVE_BYTES
+                or any(info.flag_bits & 1 for info in infos)):
+            raise ValueError('unsafe graph archive')
+        if 'book.xml' not in names:
+            raise ValueError('missing book metadata')
+        book_info = archive.getinfo('book.xml')
+        if book_info.file_size > _MAX_XML_BYTES:
+            raise ValueError('oversized book metadata')
+        book = _archive_xml(archive, book_info)
+        book_sheets = book.findall('sheet')
+        if book.get('software-version') != '5.11.0' or not 1 <= len(book_sheets) <= 2:
+            raise ValueError('unsupported graph version or page count')
+        logical_parts = book.findall('score/logical-part')
+        if len(logical_parts) != 1 or logical_parts[0].get('staff-count') != '2':
+            raise ValueError('unsupported logical part')
+        sheets = []
+        for index, book_sheet in enumerate(book_sheets, 1):
+            if book_sheet.get('number') != str(index):
+                raise ValueError('ambiguous sheet numbering')
+            steps = (book_sheet.findtext('steps') or '').split()
+            if not _PAGE_STEPS.issubset(steps):
+                raise ValueError('incomplete graph')
+            pages = book_sheet.findall('page')
+            if len(pages) != 1:
+                raise ValueError('unsupported internal page count')
+            book_systems = pages[0].findall('system')
+            if not book_systems:
+                raise ValueError('sheet has no systems')
+            for system in book_systems:
+                parts = system.findall('part')
+                if len(parts) != 1:
+                    raise ValueError('unsupported system parts')
+                configurations = parts[0].findall('staff-configuration')
+                if (len(configurations) != 2
+                        or any(item.get('line-count') != '5' for item in configurations)):
+                    raise ValueError('unsupported staff configuration')
+            name = f'sheet#{index}/sheet#{index}.xml'
+            if name not in names or archive.getinfo(name).file_size > _MAX_XML_BYTES:
+                raise ValueError('missing or oversized sheet graph')
+            sheet = _archive_xml(archive, archive.getinfo(name))
+            graph_pages = sheet.findall('page')
+            if len(graph_pages) != 1:
+                raise ValueError('unsupported sheet graph pages')
+            graph_systems = graph_pages[0].findall('system')
+            if len(graph_systems) != len(book_systems):
+                raise ValueError('book and sheet systems disagree')
+            for system in graph_systems:
+                parts = system.findall('part')
+                if len(parts) != 1:
+                    raise ValueError('unsupported graph system parts')
+                staves = parts[0].findall('staff')
+                if (len(staves) != 2
+                        or any(len(staff.findall('lines/line')) != 5 for staff in staves)):
+                    raise ValueError('unsupported graph staves')
+            sheets.append(sheet)
+        return sheets
+
+
+def _has_foreground(table):
+    width = _integer(table.get('width'), minimum=1, maximum=1024)
+    height = _integer(table.get('height'), minimum=1, maximum=1024)
+    orientation = table.get('orientation')
+    if orientation not in ('VERTICAL', 'HORIZONTAL'):
+        return False
+    vertical = orientation == 'VERTICAL'
+    runs = table.findall('runs')
+    if len(runs) != (width if vertical else height):
+        return False
+    limit, foreground = (height if vertical else width), 0
+    for sequence in runs:
+        text = sequence.text or ''
+        if len(text) > 32768:
+            return False
+        values = text.split()
+        if len(values) > 2 * limit + 1:
+            return False
+        position = 0
+        for index, value in enumerate(values):
+            length = _integer(value, minimum=0, maximum=limit)
+            position += length
+            if position > limit:
+                return False
+            if index % 2 == 0:
+                foreground += length
+    return foreground > 0
+
+
+def _whole_glyph_count(sheets):
+    count = 0
+    for sheet in sheets:
+        glyphs = {}
+        for glyph in sheet.iter('glyph'):
+            glyphs.setdefault(glyph.get('id'), []).append(glyph)
+        used = set()
+        for head in sheet.iter('head'):
+            if head.get('shape') != 'WHOLE_NOTE':
+                continue
+            glyph_id = head.get('glyph')
+            matches = glyphs.get(glyph_id, [])
+            if (not glyph_id or glyph_id in used or len(matches) != 1
+                    or matches[0].find('run-table') is None
+                    or not _has_foreground(matches[0].find('run-table'))):
+                raise ValueError('whole note lacks unique image glyph')
+            used.add(glyph_id)
+            count += 1
+    return count
+
+
+def _has_final_empty_cautionary(sheets):
+    last_sheet = sheets[-1]
+    systems = last_sheet.findall('page/system')
+    if not systems:
+        return False
+    system = systems[-1]
+    stacks = system.findall('stack')
+    parts = system.findall('part')
+    if not stacks or len(parts) != 1:
+        return False
+    stack = stacks[-1]
+    measures = parts[0].findall('measure')
+    if (stack.get('special') != 'CAUTIONARY' or stack.get('duration') != '0'
+            or list(stack) or not measures):
+        return False
+    final_measure = measures[-1]
+    return final_measure.get('id', '').endswith('C') and all(
+        child.tag in ('left-barline', 'right-barline') for child in final_measure
+    )
+
+
+def retry_is_eligible(root, source_graph: Path):
+    """Return whether the first result has the exact guarded retry shape."""
+    try:
+        if not _uniform_four_four(root):
+            return False
+        score = _scan_score(root)
+        if any(event.kind == 'pitch' and event.note_type == 'whole' for event in score.events):
+            return False
+        sheets = _safe_graph(source_graph)
+        return _whole_glyph_count(sheets) == 0 and _has_final_empty_cautionary(sheets)
+    except (ET.ParseError, OSError, ValueError, ZeroDivisionError, RecursionError,
+            zipfile.BadZipFile, KeyError):
+        return False
+
+
+def _validate_new_ties(original, candidate, additions):
+    differences = {}
+    for kind in ('tie', 'tied'):
+        if original.tie_details[kind] - candidate.tie_details[kind]:
+            return False
+        if original.ties[kind] - candidate.ties[kind]:
+            return False
+        differences[kind] = candidate.ties[kind] - original.ties[kind]
+    if not differences['tie'] and not differences['tied']:
+        return True
+    if differences['tie'] != differences['tied'] or sum(differences['tie'].values()) != 2:
+        return False
+    markers = list(differences['tie'].elements())
+    starts = [event for event, marker_type in markers if marker_type == 'start']
+    stops = [event for event, marker_type in markers if marker_type == 'stop']
+    if len(starts) != 1 or len(stops) != 1:
+        return False
+    start, stop = starts[0], stops[0]
+    return (
+        start.kind == stop.kind == 'pitch'
+        and start.pitch == stop.pitch
+        and start.staff == stop.staff
+        and stop.measure == start.measure + 1
+        and start.onset + start.duration == candidate.lengths[start.measure]
+        and stop.onset == 0
+        and (additions[start] or additions[stop])
+    )
+
+
+def accept_whole_note_retry(original_root, candidate_root, candidate_graph: Path):
+    """Accept only an append-only, graph-backed whole-note recovery."""
+    try:
+        if not _uniform_four_four(original_root) or not _uniform_four_four(candidate_root):
+            return False
+        original = _scan_score(original_root)
+        candidate = _scan_score(candidate_root)
+        if candidate.measures != original.measures + [original.measures[-1] + 1]:
+            return False
+        if candidate.metadata != original.metadata:
+            return False
+        if any(candidate.lengths[number] != original.lengths[number]
+               for number in original.measures):
+            return False
+        if original.events - candidate.events:
+            return False
+        additions = candidate.events - original.events
+        if not additions:
+            return False
+        for event, count in additions.items():
+            if (count < 1 or event.kind != 'pitch' or event.onset != 0
+                    or event.duration != 4 or event.note_type != 'whole'):
+                return False
+        new_measure = candidate.measures[-1]
+        final_events = Counter({event: count for event, count in additions.items()
+                                if event.measure == new_measure})
+        if (not final_events or candidate.lengths[new_measure] != 4
+                or {event.staff for event in final_events} != {1, 2}
+                or any(event.measure == new_measure for event in original.events)):
+            return False
+        if not _validate_new_ties(original, candidate, additions):
+            return False
+        sheets = _safe_graph(candidate_graph)
+        return _whole_glyph_count(sheets) == sum(additions.values())
+    except (ET.ParseError, OSError, ValueError, ZeroDivisionError, RecursionError,
+            zipfile.BadZipFile, KeyError):
+        return False

--- a/omr-service/omr/whole_note_retry.py
+++ b/omr-service/omr/whole_note_retry.py
@@ -32,6 +32,7 @@ class _Event:
     onset: Fraction
     duration: Fraction
     note_type: str
+    voice: str | None
 
 
 @dataclass
@@ -173,9 +174,13 @@ def _scan_score(root):
                 rest = item.find('rest') is not None
                 if (pitch is None) == (not rest):
                     raise ValueError('note must be pitched or rest')
+                voice = item.findtext('voice')
+                if (len(item.findall('voice')) > 1 or (voice is not None and (
+                        len(voice) > 12 or not voice.isascii() or not voice.strip().isdecimal()))):
+                    raise ValueError('unsupported voice identity')
                 event = _Event(
                     number, 'pitch' if pitch is not None else 'rest', pitch, staff,
-                    onset, duration, (item.findtext('type') or '').strip(),
+                    onset, duration, (item.findtext('type') or '').strip(), voice,
                 )
                 events[event] += 1
                 for marker in item.findall('tie'):
@@ -371,6 +376,7 @@ def _validate_new_ties(original, candidate, additions):
         start.kind == stop.kind == 'pitch'
         and start.pitch == stop.pitch
         and start.staff == stop.staff
+        and start.voice == stop.voice
         and stop.measure == start.measure + 1
         and start.onset + start.duration == candidate.lengths[start.measure]
         and stop.onset == 0

--- a/omr-service/tests/test_whole_note_retry.py
+++ b/omr-service/tests/test_whole_note_retry.py
@@ -1,0 +1,373 @@
+import tempfile
+import unittest
+from unittest.mock import patch
+from fractions import Fraction
+from pathlib import Path
+import xml.etree.ElementTree as ET
+import zipfile
+
+from omr.recognition_evaluation import read_musicxml
+from omr.whole_note_retry import accept_whole_note_retry, retry_is_eligible, _fraction
+
+
+def score(meter='4', include_final=False):
+    root = ET.Element('score-partwise')
+    part_list = ET.SubElement(root, 'part-list')
+    score_part = ET.SubElement(part_list, 'score-part', id='P1')
+    ET.SubElement(score_part, 'part-name').text = 'Piano'
+    part = ET.SubElement(root, 'part', id='P1')
+    numbers = [str(number) for number in range(1, 21)] + [str(number) for number in range(22, 31)]
+    if include_final:
+        numbers.append('31')
+    for number in numbers:
+        measure = ET.SubElement(part, 'measure', number=number)
+        if number == '1':
+            attributes = ET.SubElement(measure, 'attributes')
+            ET.SubElement(attributes, 'divisions').text = '4'
+            key = ET.SubElement(attributes, 'key')
+            ET.SubElement(key, 'fifths').text = '4'
+            time = ET.SubElement(attributes, 'time')
+            ET.SubElement(time, 'beats').text = meter
+            ET.SubElement(time, 'beat-type').text = '8' if meter == '6' else '4'
+            ET.SubElement(attributes, 'staves').text = '2'
+            ET.SubElement(measure, 'sound', tempo='60')
+        if number == '31':
+            for index, (step, alter, octave, staff) in enumerate(
+                    [('F', '1', '4', '1'), ('G', '1', '4', '1'), ('G', '1', '3', '2')]):
+                if index == 2:
+                    backup = ET.SubElement(measure, 'backup')
+                    ET.SubElement(backup, 'duration').text = '16'
+                note = ET.SubElement(measure, 'note')
+                if index == 1:
+                    ET.SubElement(note, 'chord')
+                pitch = ET.SubElement(note, 'pitch')
+                ET.SubElement(pitch, 'step').text = step
+                ET.SubElement(pitch, 'alter').text = alter
+                ET.SubElement(pitch, 'octave').text = octave
+                ET.SubElement(note, 'duration').text = '16'
+                ET.SubElement(note, 'type').text = 'whole'
+                ET.SubElement(note, 'staff').text = staff
+            continue
+        note = ET.SubElement(measure, 'note')
+        if number == '30':
+            measure.remove(note)
+            forward = ET.SubElement(measure, 'forward')
+            ET.SubElement(forward, 'duration').text = '8'
+            note = ET.SubElement(measure, 'note')
+            pitch = ET.SubElement(note, 'pitch')
+            ET.SubElement(pitch, 'step').text = 'G'
+            ET.SubElement(pitch, 'alter').text = '1'
+            ET.SubElement(pitch, 'octave').text = '3'
+            ET.SubElement(note, 'duration').text = '8'
+            ET.SubElement(note, 'type').text = 'half'
+            ET.SubElement(note, 'staff').text = '2'
+        else:
+            ET.SubElement(note, 'rest')
+            ET.SubElement(note, 'duration').text = '16'
+            ET.SubElement(note, 'type').text = 'whole'
+            ET.SubElement(note, 'staff').text = '1'
+    return root
+
+
+def add_whole(measure, step, alter, octave, staff):
+    note = ET.SubElement(measure, 'note')
+    pitch = ET.SubElement(note, 'pitch')
+    ET.SubElement(pitch, 'step').text = step
+    ET.SubElement(pitch, 'alter').text = str(alter)
+    ET.SubElement(pitch, 'octave').text = str(octave)
+    ET.SubElement(note, 'duration').text = '16'
+    ET.SubElement(note, 'type').text = 'whole'
+    ET.SubElement(note, 'staff').text = str(staff)
+    return note
+
+
+def valid_candidate():
+    root = score(include_final=True)
+    part = root.find('part')
+    additions = {
+        '6': [('D', 1, 4, 1), ('G', 1, 4, 1)],
+        '18': [('B', 0, 1, 2)],
+        '22': [('D', 1, 4, 1), ('G', 1, 4, 1)],
+    }
+    for number, pitches in additions.items():
+        measure = next(item for item in part.findall('measure') if item.get('number') == number)
+        inserted = []
+        for index, pitch in enumerate(pitches):
+            note = add_whole(measure, *pitch)
+            if index:
+                note.insert(0, ET.Element('chord'))
+            inserted.append(note)
+        for note in inserted:
+            measure.remove(note)
+        for index, note in enumerate(inserted):
+            measure.insert(index, note)
+        backup = ET.Element('backup')
+        ET.SubElement(backup, 'duration').text = '16'
+        measure.insert(len(inserted), backup)
+    old_note = next(item for item in part.findall("measure[@number='30']/note")
+                    if item.findtext('pitch/step') == 'G')
+    ET.SubElement(old_note, 'tie', type='start')
+    notations = ET.SubElement(old_note, 'notations')
+    ET.SubElement(notations, 'tied', type='start')
+    final_bass = part.find("measure[@number='31']/note[staff='2']")
+    ET.SubElement(final_bass, 'tie', type='stop')
+    notations = ET.SubElement(final_bass, 'notations')
+    ET.SubElement(notations, 'tied', type='stop')
+    return root
+
+
+def graph_book(sheet_count=2, version='5.11.0'):
+    root = ET.Element('book', {'software-version': version})
+    for number in range(1, sheet_count + 1):
+        sheet = ET.SubElement(root, 'sheet', number=str(number))
+        ET.SubElement(sheet, 'steps').text = (
+            'LOAD BINARY SCALE GRID HEADERS STEM_SEEDS BEAMS LEDGERS HEADS STEMS '
+            'REDUCTION CUE_BEAMS TEXTS MEASURES CHORDS CURVES SYMBOLS LINKS RHYTHMS PAGE')
+        page = ET.SubElement(sheet, 'page', id='1')
+        system = ET.SubElement(page, 'system')
+        part = ET.SubElement(system, 'part', {'logical-id': '1'})
+        ET.SubElement(part, 'staff-configuration', {'line-count': '5'})
+        ET.SubElement(part, 'staff-configuration', {'line-count': '5'})
+    score_node = ET.SubElement(root, 'score')
+    ET.SubElement(score_node, 'logical-part', id='1', **{'staff-count': '2'})
+    return root
+
+
+def sheet(cautionary=False, whole_count=0):
+    root = ET.Element('sheet')
+    page = ET.SubElement(root, 'page', id='1')
+    system = ET.SubElement(page, 'system', id='1')
+    stack = ET.SubElement(system, 'stack', id='30', duration='0' if cautionary else '1')
+    if cautionary:
+        stack.set('special', 'CAUTIONARY')
+    part = ET.SubElement(system, 'part', id='1')
+    for staff_id in ('1', '2'):
+        staff = ET.SubElement(part, 'staff', id=staff_id)
+        lines = ET.SubElement(staff, 'lines')
+        for _ in range(5):
+            ET.SubElement(lines, 'line')
+    measure = ET.SubElement(part, 'measure', id='30C' if cautionary else '30')
+    ET.SubElement(measure, 'right-barline')
+    sig = ET.SubElement(system, 'sig')
+    for index in range(whole_count):
+        glyph_id = f'g{index}'
+        ET.SubElement(sig, 'head', id=f'h{index}', shape='WHOLE_NOTE', glyph=glyph_id,
+                      staff='1' if index != whole_count - 1 else '2')
+        glyph = ET.SubElement(root, 'glyph', id=glyph_id)
+        table = ET.SubElement(glyph, 'run-table', orientation='VERTICAL', width='2', height='2')
+        ET.SubElement(table, 'runs').text = '2'
+        ET.SubElement(table, 'runs').text = '2'
+    return root
+
+
+def archive(directory, name, *, cautionary=False, whole_count=0, version='5.11.0',
+            sheet_count=2):
+    target = Path(directory) / name
+    with zipfile.ZipFile(target, 'w', zipfile.ZIP_DEFLATED) as output:
+        output.writestr('book.xml', ET.tostring(graph_book(sheet_count, version)))
+        for number in range(1, sheet_count + 1):
+            output.writestr(f'sheet#{number}/sheet#{number}.xml', ET.tostring(
+                sheet(cautionary=cautionary and number == sheet_count,
+                      whole_count=whole_count if number == sheet_count else 0)))
+            output.writestr(f'sheet#{number}/BINARY.png', b'image')
+    return target
+
+
+class WholeNoteRetryTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.original_graph = archive(self.temporary.name, 'original.omr', cautionary=True)
+        self.candidate_graph = archive(self.temporary.name, 'candidate.omr', whole_count=8)
+
+    def test_love_shape_is_eligible_and_exact_additions_are_accepted(self):
+        original = score()
+        candidate = valid_candidate()
+        self.assertTrue(retry_is_eligible(original, self.original_graph))
+        self.assertTrue(accept_whole_note_retry(original, candidate, self.candidate_graph))
+        self.assertEqual(
+            [measure.get('number') for measure in original.findall('part/measure')],
+            [str(number) for number in range(1, 21)] + [str(number) for number in range(22, 31)],
+        )
+
+    def test_actual_retained_love_pair_is_accepted(self):
+        root = Path(__file__).resolve().parents[2]
+        original_mxl = root / 'local-test-data/results/love-affair-2026-09-06/diagnostic-solo/solo.mxl'
+        original_omr = original_mxl.with_suffix('.omr')
+        candidate_mxl = root / 'local-test-data/results/whole-note-integrity/page-leland-300/solo.mxl'
+        candidate_omr = candidate_mxl.with_suffix('.omr')
+        if not all(path.is_file() for path in (original_mxl, original_omr, candidate_mxl, candidate_omr)):
+            self.skipTest('retained local Love diagnostics are not present')
+        original, candidate = read_musicxml(original_mxl), read_musicxml(candidate_mxl)
+        self.assertTrue(retry_is_eligible(original, original_omr))
+        self.assertTrue(accept_whole_note_retry(original, candidate, candidate_omr))
+
+    def test_actual_satie_and_always_controls_abstain(self):
+        root = Path(__file__).resolve().parents[2] / 'local-test-data/results'
+        cases = [
+            (
+                root / 'satie-2026-09-06/original-diagnostic.mxl',
+                root / 'whole-note-integrity/satie-leland-300/satie-gymnopedie-1.mxl',
+                root / 'whole-note-integrity/satie-leland-300/satie-gymnopedie-1.omr',
+            ),
+            (
+                root / 'always-with-me-2026-09-06/diagnostic.mxl',
+                root / 'whole-note-integrity/always-leland-300/Always_With_Me_2pages_300dpi.mxl',
+                root / 'whole-note-integrity/always-leland-300/Always_With_Me_2pages_300dpi.omr',
+            ),
+        ]
+        for original_path, candidate_path, candidate_graph in cases:
+            if not all(path.is_file() for path in (original_path, candidate_path, candidate_graph)):
+                self.skipTest('retained local control diagnostics are not present')
+            original, candidate = read_musicxml(original_path), read_musicxml(candidate_path)
+            with self.subTest(score=original_path.parent.name):
+                self.assertFalse(retry_is_eligible(
+                    original, Path(self.temporary.name) / 'must-not-open.omr'))
+                self.assertFalse(accept_whole_note_retry(original, candidate, candidate_graph))
+
+    def test_non_four_four_scores_abstain_without_opening_graph(self):
+        missing = Path(self.temporary.name) / 'missing.omr'
+        for meter in ('3', '6'):
+            with self.subTest(meter=meter):
+                self.assertFalse(retry_is_eligible(score(meter), missing))
+
+    def test_unsupported_or_malformed_graphs_abstain(self):
+        variants = [
+            archive(self.temporary.name, 'wrong-version.omr', cautionary=True, version='5.12.0'),
+            archive(self.temporary.name, 'three-pages.omr', cautionary=True, sheet_count=3),
+            archive(self.temporary.name, 'has-whole.omr', cautionary=True, whole_count=1),
+        ]
+        for graph in variants:
+            with self.subTest(graph=graph.name):
+                self.assertFalse(retry_is_eligible(score(), graph))
+        malformed = Path(self.temporary.name) / 'malformed.omr'
+        malformed.write_bytes(b'not a zip')
+        self.assertFalse(retry_is_eligible(score(), malformed))
+        crowded = Path(self.temporary.name) / 'crowded.omr'
+        with zipfile.ZipFile(crowded, 'w') as output:
+            output.writestr('book.xml', ET.tostring(graph_book()))
+            for index in range(64):
+                output.writestr(f'extra-{index}', b'x')
+        self.assertFalse(retry_is_eligible(score(), crowded))
+        declared = Path(self.temporary.name) / 'declared.omr'
+        with zipfile.ZipFile(declared, 'w') as output:
+            output.writestr('book.xml', b'<!DOCTYPE book><book software-version="5.11.0"/>')
+        self.assertFalse(retry_is_eligible(score(), declared))
+
+    def test_candidate_must_preserve_events_measures_and_metadata(self):
+        changes = []
+        changes.append(lambda root: root.find("part/measure[@number='2']/note/duration").__setattr__('text', '8'))
+        changes.append(lambda root: root.find("part/measure[@number='1']/attributes/key/fifths").__setattr__('text', '3'))
+        changes.append(lambda root: root.find("part/measure[@number='1']/sound").set('tempo', '61'))
+        changes.append(lambda root: root.find('part').insert(20, ET.Element('measure', number='21')))
+        changes.append(lambda root: ET.SubElement(
+            root.find("part/measure[@number='2']"), 'forward').append(
+                ET.fromstring('<duration>4</duration>')))
+        for change in changes:
+            candidate = valid_candidate()
+            change(candidate)
+            with self.subTest(change=change):
+                self.assertFalse(accept_whole_note_retry(score(), candidate, self.candidate_graph))
+
+    def test_only_whole_onset_zero_duration_four_additions_are_allowed(self):
+        for variant in ('type', 'duration', 'onset'):
+            candidate = valid_candidate()
+            added = candidate.find("part/measure[@number='6']/note[pitch]")
+            if variant == 'type':
+                added.find('type').text = 'half'
+            elif variant == 'duration':
+                added.find('duration').text = '8'
+            else:
+                candidate.find("part/measure[@number='6']").insert(1, ET.fromstring('<forward><duration>4</duration></forward>'))
+            with self.subTest(variant=variant):
+                self.assertFalse(accept_whole_note_retry(score(), candidate, self.candidate_graph))
+
+    def test_new_ties_must_be_one_contiguous_pair_touching_an_added_whole(self):
+        candidate = valid_candidate()
+        candidate.find("part/measure[@number='31']/note[staff='2']/tie").set('type', 'start')
+        self.assertFalse(accept_whole_note_retry(score(), candidate, self.candidate_graph))
+
+    def test_tempo_cannot_move_within_a_preserved_measure(self):
+        candidate = valid_candidate()
+        measure = candidate.find("part/measure[@number='1']")
+        sound = measure.find('sound')
+        measure.remove(sound)
+        measure.append(sound)
+        self.assertFalse(accept_whole_note_retry(score(), candidate, self.candidate_graph))
+
+    def test_first_measure_must_declare_the_guarded_meter(self):
+        original = score()
+        attributes = original.find('part/measure/attributes')
+        time = attributes.find('time')
+        attributes.remove(time)
+        later = ET.SubElement(original.find("part/measure[@number='2']"), 'attributes')
+        later.append(time)
+        self.assertFalse(retry_is_eligible(original, self.original_graph))
+
+    def test_structural_staff_metadata_cannot_disappear(self):
+        candidate = valid_candidate()
+        attributes = candidate.find('part/measure/attributes')
+        attributes.remove(attributes.find('staves'))
+        self.assertFalse(accept_whole_note_retry(score(), candidate, self.candidate_graph))
+
+    def test_tempo_sound_and_direction_offsets_must_be_preserved(self):
+        for offset_xml in ('<sound tempo="60"><offset>1</offset></sound>',
+                           '<direction><direction-type><metronome><beat-unit>quarter</beat-unit>'
+                           '<per-minute>60</per-minute></metronome></direction-type>'
+                           '<offset sound="yes">1</offset></direction>'):
+            original, candidate = score(), valid_candidate()
+            original.find("part/measure[@number='1']").append(ET.fromstring(offset_xml))
+            changed = ET.fromstring(offset_xml)
+            changed.find('offset').text = '2'
+            candidate.find("part/measure[@number='1']").append(changed)
+            with self.subTest(offset_xml=offset_xml):
+                self.assertFalse(accept_whole_note_retry(original, candidate, self.candidate_graph))
+
+    def test_rational_lexemes_are_bounded_before_fraction_construction(self):
+        for value in ('1e3', '1/0', '9' * 65):
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                _fraction(value)
+        # The deliberately huge exponent must never reach the real allocator,
+        # even if the lexical guard regresses in a future implementation.
+        with patch('omr.whole_note_retry.Fraction', side_effect=AssertionError('allocator reached')):
+            with self.assertRaises(ValueError):
+                _fraction('1E999999999')
+
+    def test_blank_or_malformed_glyph_run_tables_are_rejected(self):
+        for variant in ('blank', 'dimension', 'orientation', 'sequence-count', 'overflow'):
+            graph = sheet(whole_count=8)
+            table = graph.find('.//glyph/run-table')
+            if variant == 'blank':
+                for run in table:
+                    run.text = '0 2'
+            elif variant == 'dimension':
+                table.set('width', '0')
+            elif variant == 'orientation':
+                table.set('orientation', 'UNKNOWN')
+            elif variant == 'sequence-count':
+                table.remove(table[0])
+            else:
+                table[0].text = '3'
+            path = Path(self.temporary.name) / (variant + '.omr')
+            with zipfile.ZipFile(path, 'w') as output:
+                output.writestr('book.xml', ET.tostring(graph_book()))
+                output.writestr('sheet#1/sheet#1.xml', ET.tostring(sheet()))
+                output.writestr('sheet#2/sheet#2.xml', ET.tostring(graph))
+            with self.subTest(variant=variant):
+                self.assertFalse(accept_whole_note_retry(score(), valid_candidate(), path))
+
+    def test_graph_wholes_must_have_unique_image_glyphs_and_match_additions(self):
+        too_few = archive(self.temporary.name, 'too-few.omr', whole_count=7)
+        self.assertFalse(accept_whole_note_retry(score(), valid_candidate(), too_few))
+        graph = sheet(whole_count=8)
+        graph.find('.//head').set('glyph', 'missing')
+        broken = Path(self.temporary.name) / 'broken.omr'
+        with zipfile.ZipFile(broken, 'w') as output:
+            output.writestr('book.xml', ET.tostring(graph_book()))
+            output.writestr('sheet#1/sheet#1.xml', ET.tostring(sheet()))
+            output.writestr('sheet#2/sheet#2.xml', ET.tostring(graph))
+        self.assertFalse(accept_whole_note_retry(score(), valid_candidate(), broken))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/omr-service/tests/test_whole_note_retry.py
+++ b/omr-service/tests/test_whole_note_retry.py
@@ -287,6 +287,18 @@ class WholeNoteRetryTests(unittest.TestCase):
         candidate.find("part/measure[@number='31']/note[staff='2']/tie").set('type', 'start')
         self.assertFalse(accept_whole_note_retry(score(), candidate, self.candidate_graph))
 
+    def test_existing_voice_cannot_change_even_with_identical_pitch_and_tie_markers(self):
+        candidate = valid_candidate()
+        note = candidate.find("part/measure[@number='30']/note[staff='2']")
+        ET.SubElement(note, 'voice').text = '99'
+        self.assertFalse(accept_whole_note_retry(score(), candidate, self.candidate_graph))
+
+    def test_new_tie_pair_must_share_the_converter_voice_identity(self):
+        candidate = valid_candidate()
+        note = candidate.find("part/measure[@number='31']/note[staff='2']")
+        ET.SubElement(note, 'voice').text = '99'
+        self.assertFalse(accept_whole_note_retry(score(), candidate, self.candidate_graph))
+
     def test_tempo_cannot_move_within_a_preserved_measure(self):
         candidate = valid_candidate()
         measure = candidate.find("part/measure[@number='1']")

--- a/omr-service/tests/test_whole_note_retry_runtime.py
+++ b/omr-service/tests/test_whole_note_retry_runtime.py
@@ -1,0 +1,117 @@
+import asyncio
+import tempfile
+from time import monotonic
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+import xml.etree.ElementTree as ET
+
+from omr.audiveris import AudiverisProcessor
+from test_audiveris_runtime import HangingProcess, SuccessfulProcess
+from test_whole_note_retry import archive, score, valid_candidate
+
+
+class WholeNoteRetryRuntimeTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.directory = Path(self.temporary.name)
+        self.pdf = self.directory / 'input.pdf'
+        self.pdf.write_bytes(b'%PDF original all pages')
+        self.original = self.directory / 'input.xml'
+        self.original.write_bytes(ET.tostring(score()))
+        source = archive(self.directory, 'source.omr', cautionary=True)
+        source.replace(self.directory / 'input.omr')
+        self.processor = AudiverisProcessor()
+
+    async def candidate_process(self, *command, **kwargs):
+        output = Path(command[command.index('-output') + 1])
+        (output / 'input.xml').write_bytes(ET.tostring(valid_candidate()))
+        archive(output, 'input.omr', whole_count=8)
+        return SuccessfulProcess()
+
+    def run_retry(self, deadline=None):
+        return asyncio.run(self.processor._maybe_retry_whole_notes(
+            self.original, self.pdf, self.directory,
+            deadline if deadline is not None else monotonic() + 5))
+
+    def test_success_uses_only_leland_constant_original_pdf_and_separate_directory(self):
+        original_xml = self.original.read_bytes()
+        original_graph = (self.directory / 'input.omr').read_bytes()
+        with patch('omr.audiveris.asyncio.create_subprocess_exec', side_effect=self.candidate_process) as create:
+            result = self.run_retry()
+        command = create.call_args.args
+        self.assertNotEqual(result, self.original)
+        self.assertEqual(self.original.read_bytes(), original_xml)
+        self.assertEqual((self.directory / 'input.omr').read_bytes(), original_graph)
+        self.assertIn('org.audiveris.omr.ui.symbol.MusicFont.defaultMusicFamily=Leland', command)
+        self.assertNotIn('-transcribe', command)
+        self.assertEqual(command[-1], str(self.pdf))
+        self.assertNotEqual(result.parent, self.directory)
+
+    def test_three_four_and_six_eight_never_spawn_retry(self):
+        for meter in ('3', '6'):
+            self.original.write_bytes(ET.tostring(score(meter)))
+            with self.subTest(meter=meter), patch(
+                    'omr.audiveris.asyncio.create_subprocess_exec') as create:
+                self.assertEqual(self.run_retry(), self.original)
+                create.assert_not_called()
+
+    def test_actual_satie_and_always_return_the_identical_path(self):
+        root = Path(__file__).resolve().parents[2] / 'local-test-data/results'
+        controls = [
+            root / 'satie-2026-09-06/original-diagnostic.mxl',
+            root / 'always-with-me-2026-09-06/diagnostic.mxl',
+        ]
+        if not all(path.is_file() for path in controls):
+            self.skipTest('retained local control diagnostics are not present')
+        with patch('omr.audiveris.asyncio.create_subprocess_exec') as create:
+            for original in controls:
+                with self.subTest(score=original.parent.name):
+                    result = asyncio.run(self.processor._maybe_retry_whole_notes(
+                        original, Path('control.pdf'), original.parent, monotonic() + 5))
+                    self.assertIs(result, original)
+            create.assert_not_called()
+
+    def test_exhausted_budget_does_not_start_retry(self):
+        with patch('omr.audiveris.asyncio.create_subprocess_exec') as create:
+            self.assertEqual(self.run_retry(monotonic() - 1), self.original)
+            create.assert_not_called()
+
+    def test_rejected_candidate_preserves_original_result(self):
+        async def altered(*command, **kwargs):
+            output = Path(command[command.index('-output') + 1])
+            candidate = valid_candidate()
+            candidate.find("part/measure[@number='2']/note/duration").text = '8'
+            (output / 'input.xml').write_bytes(ET.tostring(candidate))
+            archive(output, 'input.omr', whole_count=8)
+            return SuccessfulProcess()
+        with patch('omr.audiveris.asyncio.create_subprocess_exec', side_effect=altered):
+            self.assertEqual(self.run_retry(), self.original)
+
+    def test_timed_out_retry_is_killed_and_original_survives(self):
+        process = HangingProcess()
+        with patch('omr.audiveris.asyncio.create_subprocess_exec', new=AsyncMock(return_value=process)):
+            self.assertEqual(self.run_retry(monotonic() + .02), self.original)
+        self.assertTrue(process.killed)
+        self.assertTrue(process.waited)
+
+    def test_cancelled_retry_is_killed_and_propagates(self):
+        process = HangingProcess()
+
+        async def run():
+            task = asyncio.create_task(self.processor._maybe_retry_whole_notes(
+                self.original, self.pdf, self.directory, monotonic() + 5))
+            await process.communicate_started.wait()
+            task.cancel()
+            with self.assertRaises(asyncio.CancelledError):
+                await task
+
+        with patch('omr.audiveris.asyncio.create_subprocess_exec', new=AsyncMock(return_value=process)):
+            asyncio.run(run())
+        self.assertTrue(process.killed)
+        self.assertTrue(process.waited)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/utils/__tests__/omrRuntimeContract.test.ts
+++ b/src/utils/__tests__/omrRuntimeContract.test.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from 'child_process'
+import { existsSync } from 'fs'
 import path from 'path'
 
 const OMR_DIR = path.join(process.cwd(), 'omr-service')
@@ -11,7 +12,11 @@ describe('OMR processor and recognition evaluation contracts', () => {
     'test_meter_retry.py',
     'test_meter_retry_runtime.py',
     'test_time_numeral.py',
+    'test_whole_note_retry.py',
+    'test_whole_note_retry_runtime.py',
   ])('passes %s', (suite) => {
+    // unittest discovery exits successfully even when a named suite is absent.
+    expect(existsSync(path.join(OMR_DIR, 'tests', suite))).toBe(true)
     expect(() =>
       execFileSync(
         PYTHON,


### PR DESCRIPTION
## Purpose

Recover source-recognized whole notes and an omitted terminal measure without changing existing musical events or globally replacing the OMR font.

## Recovery phase

- Phase: OMR-Q3, bounded whole-note/terminal-bar recovery slice (the broader phase remains incomplete).
- Phase document: [OMR-Q3](https://github.com/landfill/ClairKeys/blob/codex/omr-whole-note-integrity/docs/recovery/phases/OMR-Q3-whole-note-integrity.md)

## Scope

- Included: guarded pinned5.11.0 Leland retry for 1–2-page, one-part/two-standard-staff, uniform4/4 scores with no whole heads and an empty terminal cautionary stack; strict old-event, voice, bar-length, metadata and tie preservation; foreground-glyph evidence; original-result fallback.
- Explicitly excluded: page filtering, DPI override, global font change, XML note insertion, stored-score migration, production rollout, wedge21 export repair, numeric tempo/RH-tie/fermata recovery and full-score certification.

## Key decisions

- D-051: musical loss first; automatic page selection deferred.
- D-052: initial Bravura result remains unchanged. Retry the full original PDF once with Leland, sequentially under the same slot/deadline, and accept only image-recognized whole additions plus one final bar. Error/rejection/timeout preserves the original; cancellation kills/waits and propagates.
- ef714c7 additionally preserves voices because the converter keys sounding ties by MIDI/voice.
- Global Leland rejected: unrelated Always events changed in controlled experiments.

## Validation

[Implementation/native record](https://github.com/landfill/ClairKeys/blob/main/docs/recovery/validation/2026-09-06-whole-note-retry-implementation.md) · [Experiment/model record](https://github.com/landfill/ClairKeys/blob/main/docs/recovery/validation/2026-09-06-whole-note-template-checkpoint.md)

| Check | Result | Evidence record |
|---|---|---|
| Focused tests | 24 Python PASS, including retained Love pair and two voice regressions | Implementation record, ef714c7 follow-up |
| Type check | PASS, separate `npx tsc --noEmit`; hosted latest-head check PASS | Implementation record / PR Checks |
| Lint | PASS, separate `npm run lint` | Implementation record / both hosted workflows |
| Unit tests | 974 Jest / 102 suites and 107 local Python PASS; same image dependencies 104 passed/3 private-source skips | Implementation record |
| Build | PASS; does not substitute for separate type/lint checks | Implementation record / hosted Build Check |
| Manual/E2E | Exact7ddf7cd native Love 87.042s, 8 whole events/31 recovered; 3 native controls unchanged; both latest-head hosted E2E paths PASS | Implementation record / hosted checks |

The ef714c7 follow-up changes only acceptance strictness, not native JVM commands. The retained native Love pair still passes with every old voice-tagged event preserved. Private-source tests skipped in the isolated dependency container pass locally and are separately covered by actual native wrapper runs.

## Baseline difference

- Fixed failures: eight source-confirmed whole events at Love6/18/22/31 now survive; terminal31 restored; existing439 raw pitched events preserved, candidate447/418 canonical. New guards reject bar-length drift, moved tempo, changed voices/tie identity and malformed/blank glyph data.
- Remaining known failures: Love21 wedge-export NPE, lengths11/19/20, numeric tempo, final RH ties and fermata remain; see [implementation record](https://github.com/landfill/ClairKeys/blob/main/docs/recovery/validation/2026-09-06-whole-note-retry-implementation.md). Satie/Always baseline inaccuracies remain; see [experiment checkpoint](https://github.com/landfill/ClairKeys/blob/main/docs/recovery/validation/2026-09-06-whole-note-template-checkpoint.md).
- Evidence records: source PDFs/checkpoints remain Git-excluded; shared factual validation and model provenance are in docs/recovery.
- New failures: none in the final test suites or control outputs. Rejected global-font experiments are not production policy.

## Risks and rollback

- Risks: narrow classifier fallback, not full-score certification. Graph whole glyphs are counted globally, not generally aligned to XML events. Only the validated4/4 terminal-cautionary case retries. No browser audio/geometry or expert fingering claim.
- Rollback: revert this PR or keep the current production image to disable the alternate pass. No stored-score rewrite; merge and rollout require explicit approval.
- Review coverage: Sol implementation, Opus source reference, AGY acceptance review, Luna independent reviews and coordinator adversarial corrections. CodeRabbit reviewed c32bde7 with no actionable code comments; ef714c7 incremental review is quota-limited, not passed. Luna independently reviewed that exact follow-up, passed24 focused tests and found no actionable issue. Coverage and advisory dispositions are recorded in docs/recovery/reviews/PR-144.md.

## Review checklist

- [x] The PR contains one phase or one bounded objective.
- [x] The PR was created review-ready and is not a draft.
- [x] Existing user-owned changes are excluded.
- [x] Handoff and validation records are current.
- [x] Canonical handoff, validation, and review evidence are stored inside the project.
- [x] No type, lint, or test failure is hidden by configuration.
- [x] Every actionable review comment is tracked in `docs/recovery/reviews/`.
- [x] Merge is deferred until the user explicitly approves this PR.
