### PR TITLE
Recover wedge-dropped measures from source-backed native symbols

### DIFF
--- a/docs/recovery/DECISIONS.md
+++ b/docs/recovery/DECISIONS.md
@@ -2045,3 +2045,70 @@
   근거일 뿐 분류기 결과가 아니며, 그것만으로 그래프에 inter를 넣지 않는다.
 - Related: D-048; D-049; D-051; D-052; OMR-Q3-wedge-export-integrity;
   local-test-data/results/wedge-integrity
+
+## D-054: 실제 null-time wedge로 마디가 빠진 선택 결과만 source-backed 후보 재인식을 허용한다
+
+- Date: 2026-09-06
+- Status: Implemented and native-validated candidate; PR/CI review and delivery approval remain
+- Context: 순서가 보존된 native checkpoint에서 대상 8분쉼표는 SYMBOLS가 만든 뒤 LINKS가 지웠다.
+  그 rest/rest-chord만 엔진의 기존 `frozen` 보호로 보존하면 마디21은 13개 이벤트를 모두 export하지만
+  인쇄 참조 동시 일치는 9/13이다. 나머지4개는 LEDGERS가 source ink에 있는 첫 ledger를 만들지 못해
+  HEADS가 한 칸 높은 저등급 머리를 만들고, 남은 ink tail이 false augmentation dot으로 연결되는 별도
+  연쇄다. 같은 연쇄가 이미 export되는 마디20에도 있다. `minLedgerLengthLow` 실험은 target ledger를
+  복구하지 못했고 다른 ledger만 늘렸으며, Satie에는 rhythm-failure 안의 purged-rest 후보가4개라서
+  rhythm failure나 rest profile만으로 동작시키는 정책은 너무 넓다.
+- Decision:
+  1. 이미 선택된 5.11.0 결과의 MusicXML에서 실제 번호 공백이 있고, 같은 namespaced
+     `(sheet, system, stack)`의 graph measure에 voice가 주장하지 않은 chord를 endpoint로 둔 wedge가
+     있을 때만 후보 경로를 시작한다. 여러 movement, 모호한 번호 매핑, 중복 ID, 여러 원인 stack,
+     지원 밖 part/staff/page 구조는 원본을 그대로 반환한다. 단순 rhythm warning이나 마디 공백만으로
+     시작하지 않는다.
+  2. 후보는 기존 semaphore와 최초 deadline 안의 별도 임시 디렉터리에서 같은 source PDF와 선택 결과의
+     music-font 조건으로만 만든다. normal pipeline, meter retry, whole-note retry의 명령과 결과는 바꾸지
+     않는다. 실패·timeout·취소 외 모든 모호성은 원본 선택 결과로 복귀하고, 취소는 전파한다.
+  3. Native trace에서 target38x7 Section/filament는 stock construction 범위 안에서 생성되고 lookup의
+     Min/MaxThickness·Length·Convexity·Straight·Pitch check를 모두 통과했다. 제거 지점은
+     `LedgersPostAnalysis`: delta21.5는 sheet2 허용[19..24] 안이지만 exact height7은 통계 상한6보다
+     1px 커서 `HEIGHT`로 제거된다. 따라서 factory/suite cap 완화는 채택하지 않는다. 별도 recovery
+     executable은 stock factory와 suite를 그대로 쓰고, 선택 결과와 BINARY에서 동적으로 계산한
+     namespaced rectangle 안에서 delta가 정상이며 유일한 discard 사유가 upper `HEIGHT`이고
+     `floor(height) == maxHeight + 1`인 ledger만 post-analysis 제거에서 보존한다. region이 없으면 원래
+     post-analysis와 동일하다. head·pitch·dot·note·voice·timing node와 전역 threshold는 바꾸지 않는다.
+  4. SYMBOLS가 실제로 만든 뒤 선택 graph에서 사라진 rest 중 target stack 안에서 기하학적으로 유일하고,
+     같은 sheet에서 엔진이 받아들인 동일 shape의 크기·staff pitch profile에 드는 항목만 그 rest-chord와
+     함께 사본에서 `frozen=true`로 보존한다. inter, note, time, voice, pitch, dot를 직접 만들거나 고치지
+     않는다.
+  5. native 후보가 추가로 바꿀 수 있는 기존 마디는 target과 같은 source-backed ledger-defect signature를
+     독립적으로 만족하는 stack뿐이다. signature는 BINARY의 theoretical ledger ordinate를 가로지르는
+     foreground run, 같은 staff의 accepted-ledger normalized geometry, 저등급/abnormal head와 연결된
+     augmentation, baseline의 ledger 부재, 같은 sheet·ledger index의 accepted-ledger normalized geometry,
+     후보가 만든 image-glyph-backed ledger와 native head 이동,
+     false dot의 native 소멸을 모두 요구한다. 마디 번호·좌표·제목·고정 개수로 선택하지 않는다.
+  6. 후보 채택은 모든 기존 마디 보존, 범위 밖 마디의 pitched/rest event·voice·tie·direction·tempo·meter
+     동일성, slur endpoint pairing 동일성, 범위 안의 note-count 보존과 meter 거리 개선, 누락 마디의
+     기존 graph head만 export됨, source-backed ledger/rest 변화 밖의 graph inter count·shape·pitch·staff,
+     primitive curve/median, relation 종류와 endpoint, assigned/free live-glyph ink 동일성, D-052 whole-note
+     구조 보존을 요구한다. stock 반복에서도 달라지는 미참조 glyph cache와 MusicXML layout 좌표·source
+     path·encoding date, subpixel bounds/context-grade 및 관계의 재계산된 거리/grade는 musical equality로
+     쓰지 않는다. slur 번호 재생성은 endpoint pairing이 같을 때만 동등하다. 하나라도 증명하지 못하면
+     원본을 반환한다.
+     Source-confirmed 기존 defect stack의 direction cursor는 payload·staff·explicit offset이 같고 old/new
+     양쪽에서 동일 staff·pitch·순번의 native chord onset에 결합될 때만 함께 이동할 수 있다. Love20에서
+     이 규칙으로 확인된 hairpin2.5→3.5와 pedal release3.0 이외의 임의 direction retiming은 허용하지 않는다.
+  7. Love의 phase 완료는 인쇄 참조 13개 전부의 MIDI/staff/onset/duration 동시 일치와 기존 전 마디 및
+     Satie/good-Satie/Always의 비회귀를 native 실행으로 확인한 뒤에만 주장한다. 코드·fixture 통과나
+     9/13 rest-only 결과만으로 완료하지 않는다.
+- Rejected: 모든 purged rest 또는 rhythm-failure stack을 보존 | Satie에서 같은 폭의 후보4개가 발생한다.
+- Rejected: ledger 길이나 두께 상수를 normal pipeline 또는 candidate factory/suite에 적용 | target construction은
+  이미 성공하며 실제 제거는 post-analysis의 1px height quantization 경계다.
+- Rejected: native ledger를 포함해 선택 graph XML에 inter를 복사하거나 note, timing, voice, pitch,
+  false dot를 직접 덮어쓰기 | engine lifecycle과 source recognition을 우회한다.
+- Constraint: 선택 결과 원본, source PDF, normal controls와 기존 retry 결과는 그대로 보존한다. production,
+  merge, rollout은 별도 명시적 승인 없이는 바꾸지 않는다.
+- Confidence: medium
+- Scope-risk: moderate
+- Reversibility: clean
+- Directive: 실제 native 13/13과 control preservation 전에는 thickness 후보를 일반 교정으로 표현하거나
+  phase completion을 낮추지 않는다. stack ID는 sheet/system namespace 없이 비교하지 않는다.
+- Related: D-048; D-052; D-053; OMR-Q3-wedge-export-integrity;
+  validation/2026-09-06-wedge-native-resume.md

--- a/docs/recovery/DECISIONS.md
+++ b/docs/recovery/DECISIONS.md
@@ -1977,3 +1977,71 @@
 - Confidence: medium
 - Scope-risk: moderate
 - Related: D-051; OMR-Q3; local-test-data/results/whole-note-integrity
+
+## D-053: 마디 21 손실은 export 단계에서 확정되지만 원인 후보는 더 앞에 있으므로, 단계별 증거부터 얻는다
+
+- Date: 2026-09-06
+- Status: Diagnostic scope only. 어떤 교정 정책도 아직 채택되지 않았고, 아래 후보들은 통제된 진단에서
+  실제 이벤트 수치를 얻은 뒤에만 결정 후보가 된다. 부분 복구를 완료 기준으로 삼지 않는다.
+- Context: Love solo 인쇄 마디 21의 13개 유음 이벤트 중 export에 도달하는 것은 0개다. 저장된 두
+  그래프(초기 Bravura, 채택된 Leland 재시도)에서 동일한 연쇄가 재현된다.
+  1. (상류 후보, 미증명) 인쇄된 트레블 8분쉼표가 최종 그래프에 없다. glyph `6164`(x 1972, y 956, 22x47)는
+     system 2의 free-glyph에 남아 있고 어떤 inter도 이를 쓰지 않는다. 같은 오선에서 엔진이 실제로
+     받아들인 8분쉼표(inter `6279`, glyph `5915`, y 956, 23x47)와 위치·크기·채움비가 거의 같다.
+     엔진이 쓰는 Bravura/Leland 폰트 템플릿 점수는 `6164`가 `rest8th` 0.5118(margin 0.157),
+     받아들여진 `5915`가 0.5175(margin 0.144)다. 대조군(받아들여진 8분쉼표 4개, 온쉼표, 검은 머리)은
+     모두 올바른 형태로 1위를 차지한다. 다만 온음표 때와 같은 한계가 그대로 적용된다 — 완성 그래프의
+     부재는 "분류된 적 없음"과 "만들어졌다가 나중에 제거됨"을 구분하지 못한다. 단계별 증거가 나오기
+     전까지 이것은 가설이며, 그래프에 inter를 넣을 근거가 되지 않는다.
+  2. 그 쉼표가 없는 한 `MeasureRhythm.createNewVoices`는 뒤따르는 트레블 8분 화음에 시간을 줄 수 없다.
+     다른 오선에 동시 화음이 없어 sibling이 없고 `mergeWithPreviousSlot`이 요구하는 `EQUAL` 관계도 없다.
+     로그가 이를 그대로 기록한다: `Measure{#6} No timeOffset for HeadChordInter#5339`,
+     `S2 MeasureStack#6 no correct rhythm`. 마디는 `abnormal`이 되고 voice 2는 빈 채로 직렬화된다.
+  3. reload 시 `Slot.afterReload`는 성부가 `BEGIN`으로 주장한 화음(및 measure-rest 화음)에만 time
+     offset을 전달하므로 그 화음들의 `getTimeOffset()`은 null로 남는다(`timeOffset`은 저장되지 않는다).
+  4. wedge `5835`가 그중 둘에 붙어 있어 `PartwiseBuilder$WedgeIterators`의 비교자가 `Collections.sort`
+     안에서 NPE를 던지고(`PartwiseBuilder.java:3722`), `processMeasure`의 catch(2228-2234)가 만들던
+     마디를 출력에서 제거한다. 결과 마디 번호는 1–20, 22–31이다.
+  sheet1에는 null-time wedge 끝점이 없어 손실은 정확히 이 한 마디다. b9d3ac6가 복구한 온음표·마디 31과는
+  무관한 별개 원인이며 그 복구는 보존해야 한다.
+- Decision (diagnostic):
+  1. 후보는 "복구된 이벤트 수"가 아니라 인쇄 참조 13개 이벤트와의 (MIDI, staff, onset, quarter
+     duration) 4항목 동시 일치 수로 평가한다. 예외가 나지 않았다거나 export가 성공했다는 사실은
+     음악적 근거가 아니다.
+  2. 진단은 원본 그래프·XML을 건드리지 않고 사본에서만 수행하며, 실행 중인 서비스와 배포 이미지는
+     바꾸지 않는다.
+  3. 비교 대상 후보:
+     (a) export 장애물만 제거 — 시간이 없는 화음에 붙은 wedge의 `chord-wedge` 관계만 사본에서 제거하고
+         `-batch -export`만 다시 실행한다. 재인식은 없다. 내보내지는 이벤트 상한이 7/13이고, 슬롯 onset이
+         0, 0.75, 1.25, 1.75, 2.25(인쇄는 0, 0.5, 1, 1.5, 2)이며 베이스 첫 머리가 한 음 높게 읽혀 있어,
+         4항목 정확 일치 예측치는 13개 중 2개다.
+     (b) 상류 후보 복구 — 단계별 증거가 확보되면 없는 8분쉼표를 사본 그래프에 되살리고 `RHYTHMS`/`PAGE`를
+         다시 실행한다(D-049가 세운 형태). 시간이 붙은 이벤트를 되찾을 수 있는 유일한 후보이고 null time
+         offset 자체가 사라지므로 export 실패도 함께 없어진다. 다만 베이스 첫 머리가 이미 한 음 높게
+         읽혀 있으므로 이 후보만으로 도달 가능한 상한은 13개 중 12개다. 폰트 템플릿 점수만으로 inter를
+         삽입하지 않는다.
+     (c) 네이티브 교정 — 격리된 빌드에서 pinned 5.11.0 소스를 고친다. 소스는 이미 저장소에 있고,
+         `gradle.properties`가 JDK 25와 Gradle 9.4.1을 요구한다(현재 로컬은 JDK 17뿐이므로 툴체인 준비가
+         선행조건이지 불가능 사유가 아니다). 최소 후보는 `WedgeIterators`
+         비교자의 null 처리(이미 `push(null)`이 정의하는 "마지막에 flush" 의미와 일치하는 상류 버그
+         수정)이고, 필요하면 `createNewVoices`의 시간 추론을 함께 본다. JVM만 있는 운영 VM은 이 선택지를
+         배제하지 않는다 — 격리된 툴체인에서 빌드·실험하고 운영은 건드리지 않으면 된다.
+  4. (b)와 (c)는 다른 마디를 바꿀 수 있으므로, 이미 export되던 모든 마디의 음높이·음가·성부·staff·타이·
+     `forward`/`backup`과 시작 템포·`sound`/`metronome` 표기의 동일성, 그리고 b9d3ac6의 온음표·마디 31
+     복구 유지를 후보 채택 조건으로 확인한다. Satie/Always/good-Satie 대조도 변하지 않아야 한다.
+  5. 어떤 후보든 남는 손실·음높이 오류·리듬 오류를 검증 기록에 그대로 적는다. 마디 21이 음악적으로
+     완전해졌다는 표현은 이벤트 단위 근거 없이는 쓰지 않는다.
+- Rejected: 빠진 마디를 XML에 직접 써넣거나 마디 5를 복사 | 실제 인식을 우회하고 D-048·D-052에 위배된다.
+- Rejected: 성부 없는 화음에 임의의 time offset/성부를 배정 | 엔진이 만들지 않은 리듬을 발명한다.
+- Rejected: 모든 wedge/dynamics를 전역으로 끄거나 상수로 억제 | 정상 악보의 인식 결과까지 바꾼다.
+- Rejected: 진단 경고만 남기고 마디는 계속 버린다 | 인쇄된 13개 이벤트를 계속 전부 잃는다.
+- Rejected: 7/13 부분 복구를 이 단계의 완료로 기록 | 원인 단계 후보를 검증하기도 전에 손실을 정상화한다.
+- Constraint: 운영 VM은 pinned 5.11.0 이미지와 JRE만 실행하며 이 작업으로 바뀌지 않는다. 네이티브 실험은
+  격리된 툴체인에서만 한다. D-040 원본 PDF 미보관, 기존 결과 파일 불변, b9d3ac6 복구 보존.
+- Confidence: medium
+- Scope-risk: narrow
+- Reversibility: clean
+- Directive: export 성공이나 예외 부재를 음악적 정확성의 근거로 쓰지 않는다. 폰트 템플릿 점수는 가설의
+  근거일 뿐 분류기 결과가 아니며, 그것만으로 그래프에 inter를 넣지 않는다.
+- Related: D-048; D-049; D-051; D-052; OMR-Q3-wedge-export-integrity;
+  local-test-data/results/wedge-integrity

--- a/docs/recovery/phases/OMR-Q3-wedge-export-integrity.md
+++ b/docs/recovery/phases/OMR-Q3-wedge-export-integrity.md
@@ -4,7 +4,7 @@ Status: `IN_PROGRESS`
 Depends on: OMR-Q3 whole-note recovery (merged as `b9d3ac6`, deployed image `d7d6344b…106c8a`)
 Scope note: this is the independent printed-measure-21 loss that
 [OMR-Q3](OMR-Q3-whole-note-integrity.md) explicitly separated from the whole-note/cautionary chain.
-Decision record: `D-053` in [DECISIONS.md](../DECISIONS.md).
+Decision records: `D-053` and `D-054` in [DECISIONS.md](../DECISIONS.md).
 
 ## Progress
 

--- a/docs/recovery/phases/OMR-Q3-wedge-export-integrity.md
+++ b/docs/recovery/phases/OMR-Q3-wedge-export-integrity.md
@@ -8,7 +8,8 @@ Decision records: `D-053` and `D-054` in [DECISIONS.md](../DECISIONS.md).
 
 ## Progress
 
-- 2026-09-06: Export-side cause chain independently reproduced from repository-resident graphs and
+- **Historical — initial diagnostic checkpoint (superseded by later Progress entries), 2026-09-06:**
+  Export-side cause chain independently reproduced from repository-resident graphs and
   logs, plus an upstream candidate for its origin (an eighth rest absent from the final graph).
   Baseline measured against AGY's reference: measure 21 scores 0 of 13, measure 22 scores 10 of 10.
   Diagnostic scripts prepared; the native run is blocked pending user approval of the VM scope. No

--- a/docs/recovery/phases/OMR-Q3-wedge-export-integrity.md
+++ b/docs/recovery/phases/OMR-Q3-wedge-export-integrity.md
@@ -28,7 +28,7 @@ Reproduced from `local-test-data/results/whole-note-integrity/wrapper-final-love
 (both the first Bravura result and the shipped Leland retry) with
 `local-test-data/results/wedge-integrity/analyze_wedge_loss.py`:
 
-0. **Upstream candidate, not proven.** The printed eighth rest that separates the treble half chord
+0. **Historical pre-native hypothesis (superseded).** The printed eighth rest that separates the treble half chord
    from the three treble eighth chords is absent from the final graph: glyph `6164` (x 1972, y 956,
    22x47) sits in system 2's free-glyph list with no inter, while the engine's own accepted eighth
    rest on the same staff (inter `6279`, glyph `5915`, y 956, 23x47) is its geometric twin.
@@ -36,7 +36,9 @@ Reproduced from `local-test-data/results/whole-note-integrity/wrapper-final-love
    `rest8th` 0.5118 (margin 0.157) versus 0.5175 (margin 0.144) for that accepted rest, with every
    accepted rest and a notehead control ranking correctly. As with the whole heads, absence in a
    completed graph cannot distinguish *never classified* from *classified and later removed*, so
-   this is a hypothesis needing stage-specific evidence — not a licence to insert an inter.
+   this was initially a hypothesis needing stage-specific evidence—not a licence to insert an
+   inter. Ordered native checkpoints later proved SYMBOLS creates it and LINKS removes it; D-054
+   now uses that engine-created inter under stricter source guards.
 1. Whatever the reason for its absence, without a rest there `MeasureRhythm.createNewVoices` cannot
    time the following eighth chords: they
    are a rookie voice at a slot with no simultaneous chord on the other staff, and
@@ -59,7 +61,11 @@ and sheet 1 has no null-time wedge end, so this accounts for exactly one lost me
 unrelated to the whole-note/cautionary chain that `b9d3ac6` fixed; measure 31 is present in the
 shipped output and must stay present.
 
-## Candidate corrections, by how much music they recover
+## Historical candidate comparison, by how much music they recover
+
+This section records the pre-implementation decision boundary. Its partial ceilings and statements
+that native evidence did not yet exist are superseded by the dated Progress entries and D-054; they
+remain here to show why export-only and rest-only repairs were rejected.
 
 Export walks `measure.getVoices()` and each voice's slot entries, so chords that no voice claims are
 never exported even when the measure survives. That splits the candidates cleanly:
@@ -90,16 +96,20 @@ the exported XML remain forbidden under D-048 and D-052.
 1. Reproduce the cause from retained evidence and record it in the repository. (done)
 2. Run the controlled diagnostics on copied graphs and report, per candidate, how many of the 13
    reference events come back and how many match on pitch, staff, onset and quarter duration
-   together. No production behavior changes during this stage.
+   together. No production behavior changes during this stage. (done)
 3. Choose a correction policy only after those numbers exist, including whether a native engine
    correction (patched build or evidence-backed symbol recovery plus step re-run) is preferable to
-   an export-only workaround.
+   an export-only workaround. (done: D-054 selects a fail-closed native candidate, subject to its
+   native acceptance evidence; export-only and rest-only partial results remain rejected)
 4. Add regression coverage before any behavior change: graph fixtures reproducing the fault, guard
    tests for the accepted candidate, and runtime tests for budget, cancellation and failure fallback.
+   (done for implementation scope; hosted CI remains in stage 7)
 5. Implement the chosen policy for the selected recognition result, inside the existing conversion
-   semaphore and the original deadline.
+   semaphore and the original deadline. (done; actual processor selection verified)
 6. Verify against the printed reference for measure 21, not against "export produced no exception".
    Re-verify the Satie/Always/Love controls and the whole-note recovery that `b9d3ac6` delivers.
+   (done for implementation: direct native candidate, actual processor selection and four
+   no-region controls pass)
 7. Review-ready PR, CI/review, then explicit merge and rollout approvals.
 
 ## Completion criteria
@@ -108,12 +118,16 @@ the exported XML remain forbidden under D-048 and D-052.
   count of exact matches (MIDI, staff, onset and quarter duration together) against the printed
   reference, alongside the count of events still missing. A partial recovery is never recorded as
   completion of this phase.
-- Every measure that already exported keeps identical note content, voices, ties and directions,
-  except for anything the accepted candidate is explicitly allowed to drop.
+- Every out-of-scope measure that already exported keeps identical note/rest content, voices, ties,
+  slur endpoint pairing and directions. An already-exported measure may change only when it
+  independently satisfies D-054's graph-and-BINARY-backed missing-ledger/false-dot signature, its
+  corrected events are exact against a separately recorded printed-source reference, and no event
+  remains missing or unexpected. The candidate may not drop content from any measure.
 - The whole-note recovery (8 whole notes, terminal measure 31) is unchanged on the same input.
 - Every residual loss and every residual pitch or rhythm error is stated in the validation record;
   no claim of a musically complete measure 21 without event-level evidence.
-- Satie/Always/good-Satie controls show no note, duration, voice or tie change.
+- Satie/Always/good-Satie controls show no note, duration, voice, tie, slur-endpoint or direction
+  change; their missing measures or rhythm warnings alone must not trigger the candidate.
 - Runtime stays inside the existing semaphore, deadline and cleanup rules; the source PDF is never
   tracked and analysis copies are removed after collection.
 

--- a/docs/recovery/phases/OMR-Q3-wedge-export-integrity.md
+++ b/docs/recovery/phases/OMR-Q3-wedge-export-integrity.md
@@ -1,0 +1,125 @@
+# OMR-Q3 (wedge) — Stop the exporter from deleting a recognized measure
+
+Status: `IN_PROGRESS`
+Depends on: OMR-Q3 whole-note recovery (merged as `b9d3ac6`, deployed image `d7d6344b…106c8a`)
+Scope note: this is the independent printed-measure-21 loss that
+[OMR-Q3](OMR-Q3-whole-note-integrity.md) explicitly separated from the whole-note/cautionary chain.
+Decision record: `D-053` in [DECISIONS.md](../DECISIONS.md).
+
+## Progress
+
+- 2026-09-06: Export-side cause chain independently reproduced from repository-resident graphs and
+  logs, plus an upstream candidate for its origin (an eighth rest absent from the final graph).
+  Baseline measured against AGY's reference: measure 21 scores 0 of 13, measure 22 scores 10 of 10.
+  Diagnostic scripts prepared; the native run is blocked pending user approval of the VM scope. No
+  production repair is implemented and no correction policy is approved.
+
+## Objective
+
+Printed measure 21 of the Love Affair solo exports as nothing at all: 0 of its 13 printed pitched
+events reach MusicXML. All 13 heads exist in the pinned Audiveris 5.11.0 graph, but the measure's
+voice/rhythm interpretation is incomplete, and a downstream export failure then deletes the whole
+measure. Recover the printed events, without inventing notes, durations, voices or bars, and without
+weakening any other measure.
+
+## Verified cause
+
+Reproduced from `local-test-data/results/whole-note-integrity/wrapper-final-love/`
+(both the first Bravura result and the shipped Leland retry) with
+`local-test-data/results/wedge-integrity/analyze_wedge_loss.py`:
+
+0. **Upstream candidate, not proven.** The printed eighth rest that separates the treble half chord
+   from the three treble eighth chords is absent from the final graph: glyph `6164` (x 1972, y 956,
+   22x47) sits in system 2's free-glyph list with no inter, while the engine's own accepted eighth
+   rest on the same staff (inter `6279`, glyph `5915`, y 956, 23x47) is its geometric twin.
+   Font-template scoring against the pinned engine's own Bravura/Leland faces puts glyph `6164` at
+   `rest8th` 0.5118 (margin 0.157) versus 0.5175 (margin 0.144) for that accepted rest, with every
+   accepted rest and a notehead control ranking correctly. As with the whole heads, absence in a
+   completed graph cannot distinguish *never classified* from *classified and later removed*, so
+   this is a hypothesis needing stage-specific evidence — not a licence to insert an inter.
+1. Whatever the reason for its absence, without a rest there `MeasureRhythm.createNewVoices` cannot
+   time the following eighth chords: they
+   are a rookie voice at a slot with no simultaneous chord on the other staff, and
+   `mergeWithPreviousSlot` needs an `EQUAL` narrow-slot relation that does not exist. The retained
+   log records exactly that: `MeasureRhythm.java:1044 | Measure{#6} No timeOffset for
+   HeadChordInter#5339{... staff:3 slot#6 dur:1/8}`, then `StackRhythm.java:224 | S2 MeasureStack#6
+   no correct rhythm`. The measure is marked `abnormal="true"` and voice 2 is serialized empty.
+2. On reload, `Slot.afterReload` forwards a time offset only to chords a voice claims with
+   status `BEGIN` (plus measure-rest chords). The three unclaimed chords therefore keep
+   `AbstractChordInter.getTimeOffset() == null`; `timeOffset` is not persisted in the book.
+3. Wedge `5835` (`DIMINUENDO`) is linked to two of those chords (`5339` LEFT, `5341` RIGHT), so
+   `PartwiseBuilder$WedgeIterators` builds `TimedWedge` events with a null `timeOffset` and its
+   comparator throws `NullPointerException` inside `Collections.sort`
+   (`PartwiseBuilder.java:3722`, reached from `processMeasure` at line 2058).
+4. `processMeasure`'s catch block (lines 2228-2234) removes the partially built measure from the
+   output, so the exported number sequence is 1–20, 22–31 and the whole measure disappears.
+
+The same structure exists in both retained graphs (Bravura first result and shipped Leland retry),
+and sheet 1 has no null-time wedge end, so this accounts for exactly one lost measure. It is
+unrelated to the whole-note/cautionary chain that `b9d3ac6` fixed; measure 31 is present in the
+shipped output and must stay present.
+
+## Candidate corrections, by how much music they recover
+
+Export walks `measure.getVoices()` and each voice's slot entries, so chords that no voice claims are
+never exported even when the measure survives. That splits the candidates cleanly:
+
+- **Removing only the export obstacle** (null-time wedge link, or an equivalent null-safe exporter)
+  recovers the voiced part only: treble voice 1 half chord and bass voice 5 — at most 7 of the 13
+  printed pitched events, and far fewer exact matches: the stack's slots sit at quarter onsets
+  0, 0.75, 1.25, 1.75, 2.25 where the printed bar has 0, 0.5, 1, 1.5, 2, and one bass head is read a
+  diatonic step high. The predicted score is 2 exact four-field matches of 13. The three unvoiced
+  treble eighth chords stay lost. This is a floor, not a completion criterion.
+- **Repairing the upstream candidate** (restoring the absent eighth rest so `RHYTHMS` can time the
+  treble voice) is the only candidate that could return the timed events and also remove the null
+  time offsets that cause the export failure. Its ceiling is 12 of 13, not 13, because one bass head
+  is independently misread. It requires stage-specific evidence for the rest, a re-run of
+  `RHYTHMS`/`PAGE` on a copied graph in the shape D-049 established, and proof that no other measure
+  is disturbed. None of that exists yet.
+
+Under the obstacle-only candidate the measure also inherits the engine's rhythm defect for that
+stack (`duration 17/16`, `excess 1/16`) and a bass head read a diatonic step high (graph pitch
+position 5, F#2, where the printed source and the engine's own bar 19 give E2). The existing D-048
+`measure-overflow` warning reports the length defect without any new metadata contract.
+
+Giving the unvoiced chords a time offset directly, copying measure 5, or writing the measure into
+the exported XML remain forbidden under D-048 and D-052.
+
+## Work stages
+
+1. Reproduce the cause from retained evidence and record it in the repository. (done)
+2. Run the controlled diagnostics on copied graphs and report, per candidate, how many of the 13
+   reference events come back and how many match on pitch, staff, onset and quarter duration
+   together. No production behavior changes during this stage.
+3. Choose a correction policy only after those numbers exist, including whether a native engine
+   correction (patched build or evidence-backed symbol recovery plus step re-run) is preferable to
+   an export-only workaround.
+4. Add regression coverage before any behavior change: graph fixtures reproducing the fault, guard
+   tests for the accepted candidate, and runtime tests for budget, cancellation and failure fallback.
+5. Implement the chosen policy for the selected recognition result, inside the existing conversion
+   semaphore and the original deadline.
+6. Verify against the printed reference for measure 21, not against "export produced no exception".
+   Re-verify the Satie/Always/Love controls and the whole-note recovery that `b9d3ac6` delivers.
+7. Review-ready PR, CI/review, then explicit merge and rollout approvals.
+
+## Completion criteria
+
+- Printed measure 21 is present in the exported MusicXML, and the recovered events are reported as a
+  count of exact matches (MIDI, staff, onset and quarter duration together) against the printed
+  reference, alongside the count of events still missing. A partial recovery is never recorded as
+  completion of this phase.
+- Every measure that already exported keeps identical note content, voices, ties and directions,
+  except for anything the accepted candidate is explicitly allowed to drop.
+- The whole-note recovery (8 whole notes, terminal measure 31) is unchanged on the same input.
+- Every residual loss and every residual pitch or rhythm error is stated in the validation record;
+  no claim of a musically complete measure 21 without event-level evidence.
+- Satie/Always/good-Satie controls show no note, duration, voice or tie change.
+- Runtime stays inside the existing semaphore, deadline and cleanup rules; the source PDF is never
+  tracked and analysis copies are removed after collection.
+
+## Out of scope
+
+Assigning voices, times or durations by hand; editing exported MusicXML directly;
+padding or copying any measure (notably measure 5, whose printed content matches measure 21);
+global wedge or dynamics suppression; changing DPI or page selection; the numeric tempo, right-hand
+final ties and remaining recognition defects.

--- a/fixtures/recognition/wedge-baseline-candidate.xml
+++ b/fixtures/recognition/wedge-baseline-candidate.xml
@@ -1,0 +1,33 @@
+<score-partwise>
+  <part id="P1">
+    <measure number="22">
+      <attributes>
+        <divisions>2</divisions>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <staves>2</staves>
+      </attributes>
+      <!-- treble: whole chord G#4, D#4 -->
+      <note>
+        <pitch><step>G</step><alter>1</alter><octave>4</octave></pitch>
+        <duration>8</duration>
+        <staff>1</staff>
+      </note>
+      <note>
+        <chord/>
+        <pitch><step>D</step><alter>1</alter><octave>4</octave></pitch>
+        <duration>8</duration>
+        <staff>1</staff>
+      </note>
+      <backup><duration>8</duration></backup>
+      <!-- bass: 8 eighth notes: E2, B2, G#3, B3, F#4, B3, G#3, B2 -->
+      <note><pitch><step>E</step><octave>2</octave></pitch><duration>1</duration><staff>2</staff></note>
+      <note><pitch><step>B</step><octave>2</octave></pitch><duration>1</duration><staff>2</staff></note>
+      <note><pitch><step>G</step><alter>1</alter><octave>3</octave></pitch><duration>1</duration><staff>2</staff></note>
+      <note><pitch><step>B</step><octave>3</octave></pitch><duration>1</duration><staff>2</staff></note>
+      <note><pitch><step>F</step><alter>1</alter><octave>4</octave></pitch><duration>1</duration><staff>2</staff></note>
+      <note><pitch><step>B</step><octave>3</octave></pitch><duration>1</duration><staff>2</staff></note>
+      <note><pitch><step>G</step><alter>1</alter><octave>3</octave></pitch><duration>1</duration><staff>2</staff></note>
+      <note><pitch><step>B</step><octave>2</octave></pitch><duration>1</duration><staff>2</staff></note>
+    </measure>
+  </part>
+</score-partwise>

--- a/fixtures/recognition/wedge-existing-ledger-reference.json
+++ b/fixtures/recognition/wedge-existing-ledger-reference.json
@@ -1,0 +1,31 @@
+{
+  "source": "Love Affair Piano Solo, printed measure 20 (independent 2026-09-06 source read)",
+  "sourcePdfSha256": "acdd4ee03f8da75493491f677519dbce4fecf0275b106caf268fa6899ea34253",
+  "timeSignature": "4/4",
+  "measures": [
+    {
+      "number": 20,
+      "quarterLength": 4,
+      "restEvents": [
+        {"staff": 1, "onset": 2, "duration": 0.5}
+      ],
+      "pitchedEvents": [
+        {"midi": 61, "staff": 1, "onset": 0, "duration": 2},
+        {"midi": 71, "staff": 1, "onset": 0, "duration": 2},
+        {"midi": 69, "staff": 1, "onset": 2.5, "duration": 0.5},
+        {"midi": 78, "staff": 1, "onset": 2.5, "duration": 0.5},
+        {"midi": 69, "staff": 1, "onset": 3, "duration": 0.5},
+        {"midi": 78, "staff": 1, "onset": 3, "duration": 0.5},
+        {"midi": 73, "staff": 1, "onset": 3.5, "duration": 0.5},
+        {"midi": 76, "staff": 1, "onset": 3.5, "duration": 0.5},
+        {"midi": 40, "staff": 2, "onset": 0, "duration": 0.5},
+        {"midi": 49, "staff": 2, "onset": 0.5, "duration": 0.5},
+        {"midi": 52, "staff": 2, "onset": 1, "duration": 0.5},
+        {"midi": 57, "staff": 2, "onset": 1.5, "duration": 0.5},
+        {"midi": 59, "staff": 2, "onset": 2, "duration": 0.5},
+        {"midi": 61, "staff": 2, "onset": 2.5, "duration": 0.5},
+        {"midi": 57, "staff": 2, "onset": 3, "duration": 1}
+      ]
+    }
+  ]
+}

--- a/fixtures/recognition/wedge-positive-control.xml
+++ b/fixtures/recognition/wedge-positive-control.xml
@@ -1,0 +1,92 @@
+<score-partwise>
+  <part id="P1">
+    <measure number="21">
+      <attributes>
+        <divisions>2</divisions>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <staves>2</staves>
+      </attributes>
+      <!-- treble: half chord (A4, E4), rest 0.5, eighth chord (F#4, A4), eighth chord (C#5, E5), eighth chord (B4, D#5) -->
+      <note>
+        <pitch><step>A</step><octave>4</octave></pitch>
+        <duration>4</duration>
+        <staff>1</staff>
+      </note>
+      <note>
+        <chord/>
+        <pitch><step>E</step><octave>4</octave></pitch>
+        <duration>4</duration>
+        <staff>1</staff>
+      </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <staff>1</staff>
+      </note>
+      <note>
+        <pitch><step>F</step><alter>1</alter><octave>4</octave></pitch>
+        <duration>1</duration>
+        <staff>1</staff>
+      </note>
+      <note>
+        <chord/>
+        <pitch><step>A</step><octave>4</octave></pitch>
+        <duration>1</duration>
+        <staff>1</staff>
+      </note>
+      <note>
+        <pitch><step>C</step><alter>1</alter><octave>5</octave></pitch>
+        <duration>1</duration>
+        <staff>1</staff>
+      </note>
+      <note>
+        <chord/>
+        <pitch><step>E</step><octave>5</octave></pitch>
+        <duration>1</duration>
+        <staff>1</staff>
+      </note>
+      <note>
+        <pitch><step>B</step><octave>4</octave></pitch>
+        <duration>1</duration>
+        <staff>1</staff>
+      </note>
+      <note>
+        <chord/>
+        <pitch><step>D</step><alter>1</alter><octave>5</octave></pitch>
+        <duration>1</duration>
+        <staff>1</staff>
+      </note>
+      <backup><duration>8</duration></backup>
+      <!-- bass: E2(0.5), C#3(0.5), F#3(0.5), A3(0.5), C#4(2.0) -->
+      <note><pitch><step>E</step><octave>2</octave></pitch><duration>1</duration><staff>2</staff></note>
+      <note><pitch><step>C</step><alter>1</alter><octave>3</octave></pitch><duration>1</duration><staff>2</staff></note>
+      <note><pitch><step>F</step><alter>1</alter><octave>3</octave></pitch><duration>1</duration><staff>2</staff></note>
+      <note><pitch><step>A</step><octave>3</octave></pitch><duration>1</duration><staff>2</staff></note>
+      <note><pitch><step>C</step><alter>1</alter><octave>4</octave></pitch><duration>4</duration><staff>2</staff></note>
+    </measure>
+    <measure number="22">
+      <!-- treble: whole chord G#4, D#4 -->
+      <note>
+        <pitch><step>G</step><alter>1</alter><octave>4</octave></pitch>
+        <duration>8</duration>
+        <staff>1</staff>
+      </note>
+      <note>
+        <chord/>
+        <pitch><step>D</step><alter>1</alter><octave>4</octave></pitch>
+        <duration>8</duration>
+        <staff>1</staff>
+      </note>
+      <backup><duration>8</duration></backup>
+      <!-- bass: 8 eighth notes: E2, B2, G#3, B3, F#4, B3, G#3, B2 -->
+      <note><pitch><step>E</step><octave>2</octave></pitch><duration>1</duration><staff>2</staff></note>
+      <note><pitch><step>B</step><octave>2</octave></pitch><duration>1</duration><staff>2</staff></note>
+      <note><pitch><step>G</step><alter>1</alter><octave>3</octave></pitch><duration>1</duration><staff>2</staff></note>
+      <note><pitch><step>B</step><octave>3</octave></pitch><duration>1</duration><staff>2</staff></note>
+      <note><pitch><step>F</step><alter>1</alter><octave>4</octave></pitch><duration>1</duration><staff>2</staff></note>
+      <note><pitch><step>B</step><octave>3</octave></pitch><duration>1</duration><staff>2</staff></note>
+      <note><pitch><step>G</step><alter>1</alter><octave>3</octave></pitch><duration>1</duration><staff>2</staff></note>
+      <note><pitch><step>B</step><octave>2</octave></pitch><duration>1</duration><staff>2</staff></note>
+    </measure>
+  </part>
+</score-partwise>

--- a/fixtures/recognition/wedge-reference.json
+++ b/fixtures/recognition/wedge-reference.json
@@ -1,0 +1,43 @@
+{
+  "sourceIssue": "OMR-Q3",
+  "sourcePdfSha256": "acdd4ee03f8da75493491f677519dbce4fecf0275b106caf268fa6899ea34253",
+  "scope": "Visually read measures 21 and 22 only; raw pitched events before tie merging. Not a full-score ground truth.",
+  "timeSignature": "4/4",
+  "measures": [
+    {
+      "number": 21,
+      "quarterLength": 4.0,
+      "pitchedEvents": [
+        { "midi": 69, "staff": 1, "onset": 0.0, "duration": 2.0 },
+        { "midi": 64, "staff": 1, "onset": 0.0, "duration": 2.0 },
+        { "midi": 66, "staff": 1, "onset": 2.5, "duration": 0.5 },
+        { "midi": 69, "staff": 1, "onset": 2.5, "duration": 0.5 },
+        { "midi": 73, "staff": 1, "onset": 3.0, "duration": 0.5 },
+        { "midi": 76, "staff": 1, "onset": 3.0, "duration": 0.5 },
+        { "midi": 71, "staff": 1, "onset": 3.5, "duration": 0.5 },
+        { "midi": 75, "staff": 1, "onset": 3.5, "duration": 0.5 },
+        { "midi": 40, "staff": 2, "onset": 0.0, "duration": 0.5 },
+        { "midi": 49, "staff": 2, "onset": 0.5, "duration": 0.5 },
+        { "midi": 54, "staff": 2, "onset": 1.0, "duration": 0.5 },
+        { "midi": 57, "staff": 2, "onset": 1.5, "duration": 0.5 },
+        { "midi": 61, "staff": 2, "onset": 2.0, "duration": 2.0 }
+      ]
+    },
+    {
+      "number": 22,
+      "quarterLength": 4.0,
+      "pitchedEvents": [
+        { "midi": 68, "staff": 1, "onset": 0.0, "duration": 4.0 },
+        { "midi": 63, "staff": 1, "onset": 0.0, "duration": 4.0 },
+        { "midi": 40, "staff": 2, "onset": 0.0, "duration": 0.5 },
+        { "midi": 47, "staff": 2, "onset": 0.5, "duration": 0.5 },
+        { "midi": 56, "staff": 2, "onset": 1.0, "duration": 0.5 },
+        { "midi": 59, "staff": 2, "onset": 1.5, "duration": 0.5 },
+        { "midi": 66, "staff": 2, "onset": 2.0, "duration": 0.5 },
+        { "midi": 59, "staff": 2, "onset": 2.5, "duration": 0.5 },
+        { "midi": 56, "staff": 2, "onset": 3.0, "duration": 0.5 },
+        { "midi": 47, "staff": 2, "onset": 3.5, "duration": 0.5 }
+      ]
+    }
+  ]
+}

--- a/fixtures/recognition/wedge-retry/book.xml
+++ b/fixtures/recognition/wedge-retry/book.xml
@@ -1,0 +1,13 @@
+<book software-version="5.11.0" software-build="fixture">
+  <sheet number="1">
+    <steps>LOAD BINARY SCALE GRID HEADERS STEM_SEEDS BEAMS LEDGERS HEADS STEMS REDUCTION CUE_BEAMS TEXTS MEASURES CHORDS CURVES SYMBOLS LINKS RHYTHMS PAGE</steps>
+    <page id="1" movement-start="true" delta-measure-id="3">
+      <last-time-rational num="4" den="4"/>
+      <system><part logical-id="1"><staff-configuration line-count="5"/><staff-configuration line-count="5"/></part></system>
+    </page>
+  </sheet>
+  <score>
+    <logical-part id="1" staff-count="2"><staff-configuration line-count="5"/><staff-configuration line-count="5"/></logical-part>
+    <page sheet-number="1" sheet-page-id="1"/>
+  </score>
+</book>

--- a/fixtures/recognition/wedge-retry/selected-sheet.xml
+++ b/fixtures/recognition/wedge-retry/selected-sheet.xml
@@ -1,0 +1,51 @@
+<sheet>
+  <page id="1">
+    <system id="1">
+      <stack id="1" left="10" right="109" duration="1"/>
+      <stack id="2" left="110" right="209" duration="5/4"><slot id="1" x-offset="20" time-offset="0"/></stack>
+      <stack id="3" left="210" right="309" duration="1"/>
+      <part id="1">
+        <staff id="1" left="10" right="309"><lines><line><point x="10" y="40"/><point x="309" y="40"/></line><line><point x="10" y="50"/><point x="309" y="50"/></line><line><point x="10" y="60"/><point x="309" y="60"/></line><line><point x="10" y="70"/><point x="309" y="70"/></line><line><point x="10" y="80"/><point x="309" y="80"/></line></lines><header><clef>clef-g</clef></header><notes>head-ok</notes></staff>
+        <staff id="2" left="10" right="309"><lines><line><point x="10" y="100"/><point x="309" y="100"/></line><line><point x="10" y="110"/><point x="309" y="110"/></line><line><point x="10" y="120"/><point x="309" y="120"/></line><line><point x="10" y="130"/><point x="309" y="130"/></line><line><point x="10" y="140"/><point x="309" y="140"/></line></lines><header><clef>clef-f</clef></header><ledgers><ledgers-entry index="1">ledger-ok</ledgers-entry></ledgers><notes>head-ledger-ok head-bad</notes></staff>
+        <measure id="1"><head-chords>chord-ledger-ok</head-chords><voice id="1"><slots><entry><key>1</key><value status="BEGIN" chord="chord-ledger-ok"/></entry></slots></voice></measure>
+        <measure id="2" abnormal="true"><head-chords>chord-target chord-target-2</head-chords><voice id="1"/><voice id="5"/></measure>
+        <measure id="3"><head-chords>chord-ok</head-chords><voice id="1"><slots><entry><key>1</key><value status="BEGIN" chord="chord-ok"/></entry></slots></voice></measure>
+      </part>
+      <free-glyphs>glyph-free</free-glyphs>
+      <sig><inters>
+        <clef shape="G_CLEF" staff="1" id="clef-g"><bounds x="10" y="35" w="10" h="50"/></clef>
+        <clef shape="F_CLEF" staff="2" id="clef-f"><bounds x="10" y="95" w="10" h="50"/></clef>
+        <head pitch="6" shape="NOTEHEAD_BLACK" glyph="glyph-head-ledger-ok" grade="0.72" staff="2" id="head-ledger-ok"><bounds x="30" y="145" w="14" h="11"/></head>
+        <ledger thickness="3" shape="LEDGER" glyph="glyph-ledger-ok" grade="0.75" staff="2" id="ledger-ok"><bounds x="26" y="149" w="20" h="3"/><median><p1 x="26" y="150"/><p2 x="46" y="150"/></median></ledger>
+        <head pitch="5" shape="NOTEHEAD_BLACK" glyph="glyph-head-bad" grade="0.27" abnormal="true" staff="2" id="head-bad"><bounds x="130" y="142" w="12" h="11"/></head>
+        <head pitch="1" shape="NOTEHEAD_BLACK" glyph="glyph-head-target-2" grade="0.70" staff="1" id="head-target-2"><bounds x="165" y="65" w="12" h="11"/></head>
+        <augmentation-dot shape="AUGMENTATION_DOT" glyph="glyph-false-dot" grade="0.63" staff="2" id="false-dot"><bounds x="140" y="149" w="4" h="3"/></augmentation-dot>
+        <head-chord grade="0.27" staff="2" id="chord-target"><bounds x="130" y="142" w="14" h="11"/></head-chord>
+        <head-chord grade="0.40" staff="1" id="chord-target-2"><bounds x="165" y="65" w="12" h="11"/></head-chord>
+        <head-chord grade="0.72" staff="2" id="chord-ledger-ok"><bounds x="30" y="145" w="14" h="11"/></head-chord>
+        <head-chord grade="0.70" staff="1" id="chord-ok"><bounds x="230" y="65" w="12" h="11"/></head-chord>
+        <wedge shape="DIMINUENDO" id="wedge-target"><bounds x="125" y="55" w="55" h="8"/></wedge>
+        <rest pitch="-0.5" shape="EIGHTH_REST" glyph="glyph-rest-ok" grade="0.70" staff="1" id="rest-ok"><bounds x="70" y="53" w="10" h="20"/></rest>
+        <rest-chord grade="0.70" staff="1" id="rest-chord-ok"><bounds x="70" y="53" w="10" h="20"/></rest-chord>
+        </inters><relations>
+          <relation source="chord-target" target="wedge-target"><chord-wedge side="LEFT"/></relation>
+          <relation source="chord-target-2" target="wedge-target"><chord-wedge side="RIGHT"/></relation>
+          <relation source="false-dot" target="head-bad"><augmentation/></relation>
+          <relation source="chord-target" target="head-bad"><containment/></relation>
+          <relation source="chord-target-2" target="head-target-2"><containment/></relation>
+          <relation source="chord-ledger-ok" target="head-ledger-ok"><containment/></relation>
+          <relation source="rest-chord-ok" target="rest-ok"><containment/></relation>
+        </relations>
+      </sig>
+    </system>
+  </page>
+  <glyph-index>
+    <glyph groups="STUMP" id="glyph-head-ledger-ok"><run-table orientation="VERTICAL" width="14" height="11"><runs>3 5 3</runs><runs>2 7 2</runs><runs>1 9 1</runs><runs>1 9 1</runs><runs>1 9 1</runs><runs>1 9 1</runs><runs>1 9 1</runs><runs>1 9 1</runs><runs>2 7 2</runs><runs>3 5 3</runs><runs>11</runs><runs>11</runs><runs>11</runs><runs>11</runs></run-table></glyph>
+    <glyph id="glyph-ledger-ok"><run-table orientation="HORIZONTAL" width="20" height="3"><runs>20</runs><runs>20</runs><runs>20</runs></run-table></glyph>
+    <glyph id="glyph-head-bad"><run-table orientation="VERTICAL" width="12" height="11"><runs>3 5 3</runs><runs>2 7 2</runs><runs>1 9 1</runs><runs>1 9 1</runs><runs>1 9 1</runs><runs>1 9 1</runs><runs>1 9 1</runs><runs>2 7 2</runs><runs>3 5 3</runs><runs>11</runs><runs>11</runs><runs>11</runs></run-table></glyph>
+    <glyph id="glyph-head-target-2"><run-table orientation="VERTICAL" width="12" height="11"><runs>3 5 3</runs><runs>2 7 2</runs><runs>1 9 1</runs><runs>1 9 1</runs><runs>1 9 1</runs><runs>1 9 1</runs><runs>1 9 1</runs><runs>2 7 2</runs><runs>3 5 3</runs><runs>11</runs><runs>11</runs><runs>11</runs></run-table></glyph>
+    <glyph id="glyph-false-dot"><run-table orientation="HORIZONTAL" width="4" height="3"><runs>4</runs><runs>4</runs><runs>4</runs></run-table></glyph>
+    <glyph id="glyph-rest-ok"><run-table orientation="VERTICAL" width="10" height="20"><runs>20</runs><runs>20</runs><runs>20</runs><runs>20</runs><runs>20</runs><runs>20</runs><runs>20</runs><runs>20</runs><runs>20</runs><runs>20</runs></run-table></glyph>
+    <glyph left="230" top="50" groups="SYMBOL" id="glyph-free"><run-table orientation="HORIZONTAL" width="10" height="3"><runs>10</runs><runs>10</runs><runs>10</runs></run-table></glyph>
+  </glyph-index>
+</sheet>

--- a/fixtures/recognition/wedge-retry/symbols-sheet.xml
+++ b/fixtures/recognition/wedge-retry/symbols-sheet.xml
@@ -1,0 +1,32 @@
+<sheet>
+  <page id="1">
+    <system id="1">
+      <stack id="1" left="10" right="109" duration="1"/>
+      <stack id="2" left="110" right="209" duration="5/4"><slot id="1" x-offset="20" time-offset="0"/></stack>
+      <stack id="3" left="210" right="309" duration="1"/>
+      <part id="1">
+        <staff id="1" left="10" right="309"><lines><line><point x="10" y="40"/><point x="309" y="40"/></line><line><point x="10" y="50"/><point x="309" y="50"/></line><line><point x="10" y="60"/><point x="309" y="60"/></line><line><point x="10" y="70"/><point x="309" y="70"/></line><line><point x="10" y="80"/><point x="309" y="80"/></line></lines></staff>
+        <staff id="2" left="10" right="309"><lines><line><point x="10" y="100"/><point x="309" y="100"/></line><line><point x="10" y="110"/><point x="309" y="110"/></line><line><point x="10" y="120"/><point x="309" y="120"/></line><line><point x="10" y="130"/><point x="309" y="130"/></line><line><point x="10" y="140"/><point x="309" y="140"/></line></lines></staff>
+        <measure id="1"/><measure id="2" abnormal="true"/><measure id="3"/>
+      </part>
+      <sig><inters>
+        <rest pitch="-0.5" shape="EIGHTH_REST" glyph="glyph-rest-ok" grade="0.70" staff="1" id="rest-ok"><bounds x="70" y="53" w="10" h="20"/></rest>
+        <rest-chord grade="0.70" staff="1" id="rest-chord-ok"><bounds x="70" y="53" w="10" h="20"/></rest-chord>
+        <rest pitch="-0.5" shape="EIGHTH_REST" glyph="glyph-rest-target" grade="0.36" staff="1" id="rest-target"><bounds x="150" y="53" w="10" h="20"/></rest>
+        <rest-chord grade="0.36" staff="1" id="rest-chord-target"><bounds x="150" y="53" w="10" h="20"/></rest-chord>
+        <rest pitch="-0.5" shape="QUARTER_REST" glyph="glyph-rest-other" grade="0.35" staff="1" id="rest-other"><bounds x="230" y="50" w="10" h="20"/></rest>
+        <rest-chord grade="0.35" staff="1" id="rest-chord-other"><bounds x="230" y="50" w="10" h="20"/></rest-chord>
+        </inters><relations>
+          <relation source="rest-chord-ok" target="rest-ok"><containment/></relation>
+          <relation source="rest-chord-target" target="rest-target"><containment/></relation>
+          <relation source="rest-chord-other" target="rest-other"><containment/></relation>
+        </relations>
+      </sig>
+    </system>
+  </page>
+  <glyph-index>
+    <glyph id="glyph-rest-ok"><run-table orientation="VERTICAL" width="10" height="20"><runs>20</runs><runs>20</runs><runs>20</runs><runs>20</runs><runs>20</runs><runs>20</runs><runs>20</runs><runs>20</runs><runs>20</runs><runs>20</runs></run-table></glyph>
+    <glyph id="glyph-rest-target"><run-table orientation="VERTICAL" width="10" height="20"><runs>20</runs><runs>20</runs><runs>20</runs><runs>20</runs><runs>20</runs><runs>20</runs><runs>20</runs><runs>20</runs><runs>20</runs><runs>20</runs></run-table></glyph>
+    <glyph id="glyph-rest-other"><run-table orientation="VERTICAL" width="10" height="20"><runs>20</runs><runs>20</runs><runs>20</runs><runs>20</runs><runs>20</runs><runs>20</runs><runs>20</runs><runs>20</runs><runs>20</runs><runs>20</runs></run-table></glyph>
+  </glyph-index>
+</sheet>

--- a/omr-service/Dockerfile.audiveris
+++ b/omr-service/Dockerfile.audiveris
@@ -6,10 +6,15 @@ ARG AUDIVERIS_SHA256=ae714594f40e54b1a4951fc3f914f08ae38fe5d07b7f2283b1a904fdb6e
 ARG TESSDATA_REPOSITORY_URL=https://raw.githubusercontent.com/tesseract-ocr/tessdata
 ARG TESSDATA_TAG=4.1.0
 ARG TESSDATA_ENG_SHA256=daa0c97d651c19fba3b25e81317cd697e9908c8208090c94c3905381c23fc047
+ARG OPENJDK_25_URL=https://download.java.net/java/GA/jdk25.0.2/b1e0dfa218384cb9959bdcb897162d4e/10/GPL/openjdk-25.0.2_linux-x64_bin.tar.gz
+ARG OPENJDK_25_SHA256=555ce0821e4fe175ea50d54518cd6fbece9663c1998de529bc6ce429534457df
+ARG AUDIVERIS_SOURCE_COMMIT=9e1e55cd2746037d059345881c53e6a6754bffbd
+ARG LEDGERS_POST_ANALYSIS_SHA256=81202a3d8b10912c132a8340d3de6d6a70782d39cd15e0972410a95212f46f3c
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV AUDIVERIS_EXECUTABLE=/opt/audiveris/bin/Audiveris
+ENV AUDIVERIS_RECOVERY_EXECUTABLE=/opt/clairkeys-audiveris-recovery/bin/Audiveris
 ENV AUDIVERIS_MAX_CONCURRENCY=1
 ENV AUDIVERIS_TIMEOUT_SECONDS=900
 ENV TESSDATA_PREFIX=/usr/share/tesseract-ocr/4.00/tessdata
@@ -40,6 +45,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-pip \
     python3-dev \
     curl \
+    patch \
     unzip \
     libxml2-dev \
     libxslt1-dev \
@@ -69,6 +75,41 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && /opt/audiveris/bin/Audiveris -version \
     && rm -f "/tmp/${AUDIVERIS_DEB}" /tmp/eng.traineddata \
     && rm -rf /var/lib/apt/lists/*
+
+# Keep the official installation byte-identical for the normal path. The
+# alternate installation differs only by a pinned LedgersPostAnalysis class
+# whose one-pixel upper-height exception requires an explicit recovery region.
+COPY audiveris-patches/0001-region-scoped-ledger-recovery.patch /tmp/ledger-recovery.patch
+RUN mkdir -p \
+      /tmp/jdk25 \
+      /tmp/audiveris-source/app/src/main/java/org/audiveris/omr/sheet/ledger \
+      /tmp/ledger-classes \
+    && curl -fsSL "${OPENJDK_25_URL}" -o /tmp/openjdk25.tar.gz \
+    && echo "${OPENJDK_25_SHA256}  /tmp/openjdk25.tar.gz" | sha256sum -c - \
+    && curl -fsSL \
+      "https://raw.githubusercontent.com/Audiveris/audiveris/${AUDIVERIS_SOURCE_COMMIT}/app/src/main/java/org/audiveris/omr/sheet/ledger/LedgersPostAnalysis.java" \
+      -o /tmp/audiveris-source/app/src/main/java/org/audiveris/omr/sheet/ledger/LedgersPostAnalysis.java \
+    && echo "${LEDGERS_POST_ANALYSIS_SHA256}  /tmp/audiveris-source/app/src/main/java/org/audiveris/omr/sheet/ledger/LedgersPostAnalysis.java" \
+      | sha256sum -c - \
+    && sed -i 's/\r$//' \
+      /tmp/audiveris-source/app/src/main/java/org/audiveris/omr/sheet/ledger/LedgersPostAnalysis.java \
+    && patch --directory=/tmp/audiveris-source -p1 --ignore-whitespace \
+      --input=/tmp/ledger-recovery.patch \
+    && tar -xzf /tmp/openjdk25.tar.gz -C /tmp/jdk25 --strip-components=1 \
+    && /tmp/jdk25/bin/javac --release 25 -proc:none -sourcepath '' \
+      -cp '/opt/audiveris/lib/app/*' -d /tmp/ledger-classes \
+      /tmp/audiveris-source/app/src/main/java/org/audiveris/omr/sheet/ledger/LedgersPostAnalysis.java \
+    && cp -a /opt/audiveris /opt/clairkeys-audiveris-recovery \
+    && /tmp/jdk25/bin/jar --update \
+      --file /opt/clairkeys-audiveris-recovery/lib/app/audiveris.jar \
+      -C /tmp/ledger-classes org/audiveris/omr/sheet/ledger \
+    && /tmp/jdk25/bin/jar --list \
+      --file /opt/clairkeys-audiveris-recovery/lib/app/audiveris.jar \
+      | grep -Fqx 'org/audiveris/omr/sheet/ledger/LedgersPostAnalysis.class' \
+    && /opt/audiveris/bin/Audiveris -version \
+    && /opt/clairkeys-audiveris-recovery/bin/Audiveris -version \
+    && rm -rf /tmp/jdk25 /tmp/audiveris-source /tmp/ledger-classes \
+      /tmp/openjdk25.tar.gz /tmp/ledger-recovery.patch
 
 # Create working directory
 WORKDIR /app

--- a/omr-service/README.md
+++ b/omr-service/README.md
@@ -155,6 +155,11 @@ this service should not expose it.
 - Audiveris maximum Java heap: 3GB
 - Native Audiveris conversions per service instance: 1
 - Audiveris conversion timeout: 15 minutes
+- The normal executable remains `/opt/audiveris/bin/Audiveris`. A duplicated,
+  source-pinned `/opt/clairkeys-audiveris-recovery/bin/Audiveris` installation
+  contains the region-scoped ledger post-analysis boundary used only after the
+  D-054 missing export/null-time-wedge trigger; unsupported or rejected candidates retain the
+  normal result. Its JDK25 compiler is build-only and is removed from the image.
 - Remaining memory is reserved for Python, native OCR libraries, and the OS
 
 The service runs on a VM with **15GiB**, so the concurrency limit of 1 is

--- a/omr-service/audiveris-patches/0001-region-scoped-ledger-recovery.patch
+++ b/omr-service/audiveris-patches/0001-region-scoped-ledger-recovery.patch
@@ -10,13 +10,14 @@ index 8df6ce1..603916c 100644
  import java.awt.geom.Line2D;
  import java.awt.geom.Point2D;
  import java.util.ArrayList;
-@@ -295,12 +296,56 @@ public class LedgersPostAnalysis
+@@ -295,12 +296,57 @@ public class LedgersPostAnalysis
                      minHeight,
                      maxHeight);
  
 -            if (!dD.isBlank() || !hH.isBlank()) {
 +            final boolean discard = !dD.isBlank() || !hH.isBlank();
 +            final boolean retainRecovery = discard
++                    && info.ledger.getGlyph() != null
 +                    && isRecovery(info)
 +                    && dD.isBlank()
 +                    && "HEIGHT".equals(hH)

--- a/omr-service/audiveris-patches/0001-region-scoped-ledger-recovery.patch
+++ b/omr-service/audiveris-patches/0001-region-scoped-ledger-recovery.patch
@@ -1,0 +1,81 @@
+diff --git a/app/src/main/java/org/audiveris/omr/sheet/ledger/LedgersPostAnalysis.java b/app/src/main/java/org/audiveris/omr/sheet/ledger/LedgersPostAnalysis.java
+index 8df6ce1..603916c 100644
+--- a/app/src/main/java/org/audiveris/omr/sheet/ledger/LedgersPostAnalysis.java
++++ b/app/src/main/java/org/audiveris/omr/sheet/ledger/LedgersPostAnalysis.java
+@@ -36,6 +36,7 @@ import org.audiveris.omr.sig.inter.LedgerInter;
+ import org.slf4j.Logger;
+ import org.slf4j.LoggerFactory;
+ 
++import java.awt.Rectangle;
+ import java.awt.geom.Line2D;
+ import java.awt.geom.Point2D;
+ import java.util.ArrayList;
+@@ -295,12 +296,56 @@ public class LedgersPostAnalysis
+                     minHeight,
+                     maxHeight);
+ 
+-            if (!dD.isBlank() || !hH.isBlank()) {
++            final boolean discard = !dD.isBlank() || !hH.isBlank();
++            final boolean retainRecovery = discard
++                    && isRecovery(info)
++                    && dD.isBlank()
++                    && "HEIGHT".equals(hH)
++                    && ((int) Math.floor(info.height) == maxHeight + 1);
++
++            if (retainRecovery) {
++                logger.info(
++                        "Retaining source-backed ledger {} at one-pixel post-analysis boundary",
++                        info.ledger);
++            } else if (discard) {
+                 discard(info.ledger);
+             }
+         }
+     }
+ 
++    private boolean isRecovery (Info info)
++    {
++        final String specification = constants.recoveryRegions.getValue().trim();
++
++        if (specification.isEmpty()) {
++            return false;
++        }
++
++        final int sheetNumber = sheet.getStub().getNumber();
++        final int systemId = info.staff.getSystem().getId();
++        final Rectangle bounds = info.ledger.getBounds();
++        for (String token : specification.split(";")) {
++            final String[] fields = token.split(",", -1);
++            if (fields.length != 6) {
++                throw new IllegalArgumentException("Invalid ledger recovery region: " + token);
++            }
++            final int tokenSheet = Integer.parseInt(fields[0]);
++            final int tokenSystem = Integer.parseInt(fields[1]);
++            final int x = Integer.parseInt(fields[2]);
++            final int y = Integer.parseInt(fields[3]);
++            final int width = Integer.parseInt(fields[4]);
++            final int height = Integer.parseInt(fields[5]);
++            if (x < 0 || y < 0 || width <= 0 || height <= 0) {
++                throw new IllegalArgumentException("Invalid ledger recovery region: " + token);
++            }
++            if (tokenSheet == sheetNumber && tokenSystem == systemId
++                    && new Rectangle(x, y, width, height).intersects(bounds)) {
++                return true;
++            }
++        }
++        return false;
++    }
++
+     //---------//
+     // process //
+     //---------//
+@@ -335,6 +380,10 @@ public class LedgersPostAnalysis
+     private static class Constants
+             extends ConstantSet
+     {
++        private final Constant.String recoveryRegions = new Constant.String(
++                "",
++                "Candidate-only ledger recovery rectangles: sheet,system,x,y,width,height;...");
++
+         private final Scale.Fraction maxIsolatedLedgerWidth = new Scale.Fraction(
+                 3,
+                 "Reasonable maximum width for an isolated ledger");

--- a/omr-service/omr/audiveris.py
+++ b/omr-service/omr/audiveris.py
@@ -18,6 +18,12 @@ from omr.whole_note_retry import (
     accept_whole_note_retry,
     retry_is_eligible as whole_note_retry_is_eligible,
 )
+from omr.wedge_retry import (
+    accept_wedge_retry,
+    detect_wedge_export_loss,
+    prepare_wedge_retry,
+    recovery_region_constant,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -29,12 +35,19 @@ class AudiverisProcessor:
         audiveris_executable: Optional[Path] = None,
         max_concurrent_conversions: Optional[int] = None,
         process_timeout_seconds: Optional[float] = None,
+        audiveris_recovery_executable: Optional[Path] = None,
     ):
         configured_executable = os.getenv(
             "AUDIVERIS_EXECUTABLE", "/opt/audiveris/bin/Audiveris"
         )
         self.audiveris_executable = Path(
             audiveris_executable or configured_executable
+        )
+        self.audiveris_recovery_executable = Path(
+            audiveris_recovery_executable or os.getenv(
+                'AUDIVERIS_RECOVERY_EXECUTABLE',
+                '/opt/clairkeys-audiveris-recovery/bin/Audiveris',
+            )
         )
         concurrency = max_concurrent_conversions
         if concurrency is None:
@@ -162,8 +175,12 @@ class AudiverisProcessor:
             meter_result = await self._maybe_retry_meter(
                 musicxml_path, pdf_path, output_dir, deadline
             )
-            return await self._maybe_retry_whole_notes(
+            whole_note_result = await self._maybe_retry_whole_notes(
                 meter_result, pdf_path, output_dir, deadline
+            )
+            music_family = 'Leland' if whole_note_result != meter_result else None
+            return await self._maybe_retry_wedge(
+                whole_note_result, pdf_path, output_dir, deadline, music_family
             )
             
         except Exception as e:
@@ -240,6 +257,7 @@ class AudiverisProcessor:
         source = output_dir / f'{pdf_path.stem}.omr'
         if monotonic() >= deadline:
             return original
+
         try:
             converter = MusicXMLToClairKeysConverter()
             before = converter._parse_musicxml(original).getroot()
@@ -296,6 +314,116 @@ class AudiverisProcessor:
                 'Whole-note retry unavailable (%s); retaining first result',
                 type(error).__name__,
             )
+            return original
+
+    async def _maybe_retry_wedge(
+        self, original: Path, pdf_path: Path, output_dir: Path, deadline: float,
+        music_family: Optional[str] = None,
+    ) -> Path:
+        """Retry only a selected result with the D-054 export-loss signature.
+
+        The first result and graph are opened read-only. Both optional JVMs run
+        sequentially while ``process_pdf`` owns the existing semaphore and share
+        its original deadline. Any ambiguity returns the selected result.
+        """
+        source = original.with_suffix('.omr')
+        if monotonic() >= deadline or not source.is_file():
+            return original
+        try:
+            converter = MusicXMLToClairKeysConverter()
+            before = converter._parse_musicxml(original).getroot()
+            trigger = detect_wedge_export_loss(before, source)
+            if trigger is None:
+                return original
+            region_constant = recovery_region_constant(source, trigger)
+            if region_constant is None:
+                return original
+            retry_dir = Path(tempfile.mkdtemp(prefix='wedge-retry-', dir=output_dir))
+            symbols_dir = retry_dir / 'symbols'
+            symbols_dir.mkdir()
+            command = [
+                str(self.audiveris_recovery_executable), '-batch', '-step', 'SYMBOLS', '-save',
+            ]
+            if music_family:
+                command.extend((
+                    '-constant',
+                    f'org.audiveris.omr.ui.symbol.MusicFont.defaultMusicFamily={music_family}',
+                ))
+            command.extend(('-constant', region_constant,
+                            '-output', str(symbols_dir), '--', str(pdf_path)))
+            remaining = deadline - monotonic()
+            if remaining <= 0:
+                return original
+            logger.info('Running isolated wedge candidate for missing measure %s',
+                        trigger.measure_number)
+            process = await asyncio.create_subprocess_exec(
+                *command, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+                cwd=symbols_dir,
+            )
+            remaining = deadline - monotonic()
+            if remaining <= 0:
+                await self._kill_and_wait(process)
+                return original
+            await self._communicate_with_timeout(process, remaining)
+            if process.returncode != 0:
+                logger.warning('Wedge region candidate exited %s; retaining selected result',
+                               process.returncode)
+                return original
+            symbol_graphs = sorted(symbols_dir.glob('*.omr'))
+            if len(symbol_graphs) != 1 or monotonic() >= deadline:
+                return original
+            page_dir = retry_dir / 'page'
+            page_dir.mkdir()
+            prepared = page_dir / symbol_graphs[0].name
+            evidence = prepare_wedge_retry(symbol_graphs[0], source, prepared, trigger)
+            if evidence is None:
+                return original
+            command = [
+                str(self.audiveris_executable), '-batch', '-step', 'PAGE', '-save', '-export',
+            ]
+            if music_family:
+                command.extend((
+                    '-constant',
+                    f'org.audiveris.omr.ui.symbol.MusicFont.defaultMusicFamily={music_family}',
+                ))
+            command.extend(('-output', str(page_dir), '--', str(prepared)))
+            remaining = deadline - monotonic()
+            if remaining <= 0:
+                return original
+            process = await asyncio.create_subprocess_exec(
+                *command, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+                cwd=page_dir,
+            )
+            remaining = deadline - monotonic()
+            if remaining <= 0:
+                await self._kill_and_wait(process)
+                return original
+            await self._communicate_with_timeout(process, remaining)
+            if process.returncode != 0:
+                logger.warning('Wedge PAGE candidate exited %s; retaining selected result',
+                               process.returncode)
+                return original
+            outputs = sorted(page_dir.glob('*.mxl'))
+            if not outputs:
+                outputs = sorted(page_dir.glob('*.xml'))
+            graphs = sorted(page_dir.glob('*.omr'))
+            if len(outputs) != 1 or len(graphs) != 1 or monotonic() >= deadline:
+                return original
+            candidate = converter._parse_musicxml(outputs[0]).getroot()
+            if not accept_wedge_retry(before, candidate, source, graphs[0], evidence):
+                logger.warning(
+                    'Wedge retry failed source/event/direction/slur guards; retaining selected result'
+                )
+                return original
+            if monotonic() >= deadline:
+                return original
+            logger.info('Selected native source-backed wedge recovery')
+            return outputs[0]
+        except asyncio.CancelledError:
+            raise
+        except Exception as error:
+            logger.warning('Wedge retry unavailable (%s); retaining selected result',
+                           type(error).__name__)
             return original
     
     async def validate_audiveris_installation(self) -> bool:

--- a/omr-service/omr/recognition_evaluation.py
+++ b/omr-service/omr/recognition_evaluation.py
@@ -43,6 +43,12 @@ def _events(counter):
             for _ in range(count)]
 
 
+def _rests(counter):
+    return [dict(staff=staff, onset=float(onset), duration=float(duration))
+            for (staff, onset, duration), count in sorted(counter.items())
+            for _ in range(count)]
+
+
 def evaluate_reference(root: ET.Element, reference: dict) -> dict:
     part = root.find('part')
     if part is None:
@@ -52,7 +58,7 @@ def evaluate_reference(root: ET.Element, reference: dict) -> dict:
     meter = None
     for measure in part.findall('measure'):
         cursor = end = previous_onset = Fraction(0)
-        events = Counter()
+        events, rests = Counter(), Counter()
         for item in measure:
             if item.tag == 'attributes':
                 value = item.findtext('divisions')
@@ -81,6 +87,8 @@ def evaluate_reference(root: ET.Element, reference: dict) -> dict:
                     midi = (int(pitch.findtext('octave')) + 1) * 12
                     midi += {'C': 0, 'D': 2, 'E': 4, 'F': 5, 'G': 7, 'A': 9, 'B': 11}[pitch.findtext('step')]
                     events[(midi + int(alter), int(item.findtext('staff', '1')), onset, duration)] += 1
+                elif item.find('rest') is not None:
+                    rests[(int(item.findtext('staff', '1')), onset, duration)] += 1
                 end = max(end, onset + duration)
                 if not chord:
                     previous_onset = onset
@@ -88,25 +96,36 @@ def evaluate_reference(root: ET.Element, reference: dict) -> dict:
         number = measure.get('number')
         if number in measures:
             raise ValueError(f'Ambiguous repeated measure number: {number}')
-        measures[number] = (events, end, meter)
+        measures[number] = (events, rests, end, meter)
 
     results = []
     matched = expected_count = 0
     for expected in reference['measures']:
         wanted = Counter(_event_key(event) for event in expected['pitchedEvents'])
-        actual, length, actual_meter = measures.get(str(expected['number']), (Counter(), None, None))
+        actual, actual_rests, length, actual_meter = measures.get(
+            str(expected['number']), (Counter(), Counter(), None, None))
         count = sum((wanted & actual).values())
         matched += count
         expected_count += sum(wanted.values())
         missing, unexpected = _events(wanted - actual), _events(actual - wanted)
         meter_matches = actual_meter == expected.get('timeSignature', reference['timeSignature'])
         length_matches = length == Fraction(str(expected['quarterLength']))
+        rest_contract = expected.get('restEvents')
+        wanted_rests = Counter(
+            (int(event['staff']), Fraction(str(event['onset'])), Fraction(str(event['duration'])))
+            for event in (rest_contract or []))
+        matched_rests = sum((wanted_rests & actual_rests).values()) if rest_contract is not None else None
+        missing_rests = _rests(wanted_rests - actual_rests) if rest_contract is not None else []
+        unexpected_rests = _rests(actual_rests - wanted_rests) if rest_contract is not None else []
         results.append(dict(number=str(expected['number']), matchedEvents=count,
                             missing=missing, unexpected=unexpected,
+                            matchedRests=matched_rests, missingRests=missing_rests,
+                            unexpectedRests=unexpected_rests,
                             actualTimeSignature=actual_meter, meterMatches=meter_matches,
                             actualQuarterLength=float(length) if length is not None else None,
                             lengthMatches=length_matches,
-                            exact=not missing and not unexpected and meter_matches and length_matches))
+                            exact=(not missing and not unexpected and not missing_rests
+                                   and not unexpected_rests and meter_matches and length_matches)))
     return dict(scope='Referenced measures of the first part; raw events before tie merging only',
                 matchedEvents=matched, expectedEvents=expected_count, measures=results,
                 exact=bool(results) and all(result['exact'] for result in results))

--- a/omr-service/omr/wedge_retry.py
+++ b/omr-service/omr/wedge_retry.py
@@ -125,6 +125,20 @@ def _fraction(text, *, positive=False):
     return value
 
 
+def _finite_float(text):
+    """Parse a finite XML number, normalizing all malformed input to ValueError."""
+    if (text is None or not isinstance(text, str) or not text
+            or len(text) > 64 or not text.isascii()):
+        raise ValueError('invalid finite number')
+    try:
+        value = float(text)
+    except (TypeError, ValueError) as error:
+        raise ValueError('invalid finite number') from error
+    if not math.isfinite(value):
+        raise ValueError('invalid finite number')
+    return value
+
+
 def _xml(data):
     if len(data) > _MAX_XML_BYTES or b'<!DOCTYPE' in data.upper() or b'<!ENTITY' in data.upper():
         raise ValueError('unsafe XML')
@@ -330,7 +344,8 @@ def _staff_interlines(system):
             points = line.findall('point')
             if len(points) < 1:
                 raise ValueError('missing staff points')
-            ordinates.append(sum(float(point.get('y')) for point in points) / len(points))
+            ordinates.append(
+                sum(_finite_float(point.get('y')) for point in points) / len(points))
         gaps = [right - left for left, right in zip(ordinates, ordinates[1:])]
         if len(gaps) != 4 or min(gaps) <= 0:
             raise ValueError('invalid staff geometry')
@@ -345,10 +360,10 @@ def _line_y(staff, *, below, x):
     if not points:
         raise ValueError('missing staff line geometry')
     if len(points) == 1:
-        return float(points[0].get('y'))
+        return _finite_float(points[0].get('y'))
     left, right = points[0], points[-1]
-    x1, x2 = float(left.get('x')), float(right.get('x'))
-    y1, y2 = float(left.get('y')), float(right.get('y'))
+    x1, x2 = _finite_float(left.get('x')), _finite_float(right.get('x'))
+    y1, y2 = _finite_float(left.get('y')), _finite_float(right.get('y'))
     return y1 if x1 == x2 else y1 + ((x - x1) * (y2 - y1) / (x2 - x1))
 
 
@@ -971,7 +986,7 @@ def _row_runs(gray, y, left, right):
 def _source_ledger_signature(graph, ref, head, dot):
     if ref.element.get('abnormal') != 'true':
         return False
-    pitch_value = float(head.get('pitch'))
+    pitch_value = _finite_float(head.get('pitch'))
     pitch = round(pitch_value)
     if abs(pitch_value - pitch) > 0.01 or abs(pitch) < 5 or abs(pitch) % 2 != 1:
         return False
@@ -980,9 +995,9 @@ def _source_ledger_signature(graph, ref, head, dot):
     for other_ref in _measure_refs(graph):
         if other_ref.sheet_number == ref.sheet_number and other_ref.element.get('abnormal') != 'true':
             normal_heads.update(_graph_measure_heads(other_ref, sheet))
-    other_grades = [float(item.get('grade')) for item in normal_heads
+    other_grades = [_finite_float(item.get('grade')) for item in normal_heads
                     if item.get('grade') is not None]
-    if not other_grades or float(head.get('grade')) >= min(other_grades):
+    if not other_grades or _finite_float(head.get('grade')) >= min(other_grades):
         return False
     staff = next((staff for staff in ref.system.findall('part/staff')
                   if staff.get('id') == head.get('staff')), None)

--- a/omr-service/omr/wedge_retry.py
+++ b/omr-service/omr/wedge_retry.py
@@ -1,0 +1,1380 @@
+"""Fail-closed native retry for an exported measure lost to a null-time wedge.
+
+This module never manufactures MusicXML events or graph interpretations.  It
+can protect a rest that Audiveris already classified at SYMBOLS, then validates
+a separately generated PAGE candidate against the selected first result.  The
+paired ledger constants are isolated candidate inputs under D-054; they are not
+normal-pipeline settings and a candidate is accepted only when native graph and
+source-image evidence proves the missing-ledger/false-dot chain was removed.
+"""
+
+from collections import Counter
+from dataclasses import dataclass
+from fractions import Fraction
+from io import BytesIO
+import math
+from pathlib import Path
+import re
+import xml.etree.ElementTree as ET
+import zipfile
+
+from PIL import Image
+
+
+_RECOVERY_REGIONS_KEY = (
+    'org.audiveris.omr.sheet.ledger.LedgersPostAnalysis.recoveryRegions'
+)
+
+_MAX_ARCHIVE_ENTRIES = 64
+_MAX_ARCHIVE_BYTES = 100_000_000
+_MAX_XML_BYTES = 20_000_000
+_MAX_MEASURES = 1_000
+_INTER_TAGS = frozenset({
+    'head', 'head-chord', 'rest', 'rest-chord', 'wedge',
+    'augmentation-dot', 'ledger',
+})
+_MUSIC_LAYOUT_ATTRS = frozenset({
+    'default-x', 'default-y', 'relative-x', 'relative-y', 'placement',
+    'bezier-x', 'bezier-y', 'bezier-x2', 'bezier-y2', 'color',
+    'font-family', 'font-size', 'font-style', 'font-weight',
+})
+
+
+@dataclass(frozen=True)
+class WedgeTrigger:
+    sheet_number: int
+    system_index: int
+    stack_index: int
+    measure_number: int
+    graph_measure_id: str
+    missing_chords: tuple[str, ...]
+    wedge_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class RestEvidence:
+    sheet_number: int
+    system_index: int
+    stack_index: int
+    measure_number: int
+    rest_id: str
+    rest_chord_id: str
+    shape: str
+    staff_id: str
+    bounds: tuple[int, int, int, int]
+
+
+@dataclass(frozen=True)
+class WedgeRetryEvidence:
+    trigger: WedgeTrigger
+    rests: tuple[RestEvidence, ...]
+    eligible_measure_numbers: tuple[int, ...]
+
+    @property
+    def frozen_rest_ids(self):
+        return tuple(item.rest_id for item in self.rests)
+
+
+@dataclass
+class _Graph:
+    path: Path
+    book: ET.Element
+    sheets: list[ET.Element]
+    sheet_names: list[str]
+    raw_entries: dict[str, bytes]
+
+
+@dataclass(frozen=True)
+class _MeasureRef:
+    number: int
+    sheet_number: int
+    system_index: int
+    stack_index: int
+    element: ET.Element
+    stack: ET.Element
+    system: ET.Element
+
+
+def _integer(text, *, minimum=None, maximum=None):
+    if text is None or not text or len(text) > 12 or not text.isascii():
+        raise ValueError('invalid integer')
+    if text[0] in '+-':
+        digits = text[1:]
+    else:
+        digits = text
+    if not digits or not digits.isdecimal():
+        raise ValueError('invalid integer')
+    value = int(text)
+    if minimum is not None and value < minimum:
+        raise ValueError('integer below bound')
+    if maximum is not None and value > maximum:
+        raise ValueError('integer above bound')
+    return value
+
+
+def _fraction(text, *, positive=False):
+    if text is None or not re.fullmatch(
+            r'[+-]?[0-9]{1,12}(?:/[0-9]{1,12}|\.[0-9]{1,12})?', text):
+        raise ValueError('invalid rational')
+    try:
+        value = Fraction(text)
+    except ZeroDivisionError:
+        raise ValueError('zero denominator') from None
+    if positive and value <= 0:
+        raise ValueError('non-positive rational')
+    return value
+
+
+def _xml(data):
+    if len(data) > _MAX_XML_BYTES or b'<!DOCTYPE' in data.upper() or b'<!ENTITY' in data.upper():
+        raise ValueError('unsafe XML')
+    return ET.fromstring(data)
+
+
+def _read_graph(path: Path, *, required_step='PAGE'):
+    with zipfile.ZipFile(path) as archive:
+        infos = archive.infolist()
+        names = [info.filename for info in infos]
+        if (len(infos) > _MAX_ARCHIVE_ENTRIES or len(names) != len(set(names))
+                or sum(info.file_size for info in infos) > _MAX_ARCHIVE_BYTES
+                or any(info.flag_bits & 1 for info in infos)
+                or 'book.xml' not in names):
+            raise ValueError('unsafe graph archive')
+        raw = {name: archive.read(name) for name in names if not name.endswith('/')}
+    book = _xml(raw['book.xml'])
+    if book.get('software-version') != '5.11.0':
+        raise ValueError('unsupported engine version')
+    book_sheets = book.findall('sheet')
+    logical_parts = book.findall('score/logical-part')
+    if not 1 <= len(book_sheets) <= 2:
+        raise ValueError('unsupported book structure')
+    if required_step == 'PAGE':
+        if len(logical_parts) != 1 or logical_parts[0].get('staff-count') != '2':
+            raise ValueError('unsupported logical part')
+    elif logical_parts and (len(logical_parts) != 1
+                            or logical_parts[0].get('staff-count') != '2'):
+        raise ValueError('ambiguous logical part')
+    sheets, sheet_names = [], []
+    for number, book_sheet in enumerate(book_sheets, 1):
+        if book_sheet.get('number') != str(number):
+            raise ValueError('ambiguous sheet numbers')
+        steps = (book_sheet.findtext('steps') or '').split()
+        if required_step not in steps:
+            raise ValueError('incomplete graph')
+        if required_step == 'SYMBOLS' and any(step in steps for step in ('LINKS', 'RHYTHMS', 'PAGE')):
+            raise ValueError('symbols graph already reduced')
+        book_pages = book_sheet.findall('page')
+        if len(book_pages) != 1:
+            raise ValueError('unsupported internal pages')
+        name = f'sheet#{number}/sheet#{number}.xml'
+        image = f'sheet#{number}/BINARY.png'
+        if name not in raw or image not in raw:
+            raise ValueError('missing graph evidence')
+        sheet = _xml(raw[name])
+        pages = sheet.findall('page')
+        if len(pages) != 1:
+            raise ValueError('unsupported graph pages')
+        systems = pages[0].findall('system')
+        if not systems or len(systems) != len(book_pages[0].findall('system')):
+            raise ValueError('book/sheet system mismatch')
+        relevant_ids = [element.get('id') for element in sheet.iter()
+                        if element.tag in _INTER_TAGS and element.get('id')]
+        if len(relevant_ids) != len(set(relevant_ids)):
+            raise ValueError('duplicate inter IDs')
+        sheets.append(sheet)
+        sheet_names.append(name)
+    return _Graph(Path(path), book, sheets, sheet_names, raw)
+
+
+def _measure_refs(graph: _Graph):
+    refs, number = [], 0
+    for sheet_number, (book_sheet, sheet) in enumerate(
+            zip(graph.book.findall('sheet'), graph.sheets), 1):
+        book_page = book_sheet.find('page')
+        if sheet_number == 1:
+            if book_page.get('movement-start') != 'true':
+                raise ValueError('first page must start movement')
+        elif book_page.get('movement-start') is not None:
+            raise ValueError('multiple movements unsupported')
+        for system_index, system in enumerate(sheet.findall('page/system'), 1):
+            parts = system.findall('part')
+            stacks = system.findall('stack')
+            if len(parts) != 1 or not stacks:
+                raise ValueError('unsupported system')
+            staves = parts[0].findall('staff')
+            measures = parts[0].findall('measure')
+            if len(staves) != 2 or len(measures) != len(stacks):
+                raise ValueError('stack/measure mismatch')
+            for staff in staves:
+                if not staff.get('id') or len(staff.findall('lines/line')) != 5:
+                    raise ValueError('unsupported staff')
+            for stack_index, (stack, measure) in enumerate(zip(stacks, measures), 1):
+                number += 1
+                if not measure.get('id') or not stack.get('id'):
+                    raise ValueError('missing graph identity')
+                refs.append(_MeasureRef(number, sheet_number, system_index, stack_index,
+                                        measure, stack, system))
+    if not refs or len(refs) > _MAX_MEASURES:
+        raise ValueError('unsupported measure count')
+    return refs
+
+
+def _score_measure_numbers(root):
+    if root.tag != 'score-partwise' or len(root.findall('part')) != 1:
+        raise ValueError('unsupported score')
+    measures = root.findall('part/measure')
+    if not measures or len(measures) > _MAX_MEASURES:
+        raise ValueError('unsupported score length')
+    numbers = [_integer(measure.get('number'), minimum=1, maximum=100_000)
+               for measure in measures]
+    if numbers != sorted(set(numbers)):
+        raise ValueError('ambiguous score numbering')
+    return numbers
+
+
+def _uniform_four_four(root):
+    if root.tag != 'score-partwise' or len(root.findall('part')) != 1:
+        return False
+    measures = root.findall('part/measure')
+    if not measures or measures[0].find('attributes/time') is None:
+        return False
+    times = root.findall('.//attributes/time')
+    return bool(times) and all(
+        time.find('senza-misura') is None
+        and len(time.findall('beats')) == 1
+        and len(time.findall('beat-type')) == 1
+        and time.findtext('beats') == '4'
+        and time.findtext('beat-type') == '4'
+        for time in times
+    )
+
+
+def _voiced(measure):
+    result = set()
+    for voice in measure.findall('voice'):
+        if voice.get('measure-rest-chord'):
+            result.add(voice.get('measure-rest-chord'))
+        result.update(value.get('chord') for value in voice.iter('value')
+                      if value.get('status') == 'BEGIN' and value.get('chord'))
+    return result
+
+
+def detect_wedge_export_loss(root, graph_path: Path):
+    """Return the sole namespaced null-time-wedge export-loss trigger."""
+    try:
+        if not _uniform_four_four(root):
+            return None
+        numbers = _score_measure_numbers(root)
+        graph = _read_graph(Path(graph_path))
+        refs = _measure_refs(graph)
+        if numbers[0] != 1 or numbers[-1] != len(refs):
+            return None
+        missing = sorted(set(range(1, len(refs) + 1)) - set(numbers))
+        if len(missing) != 1:
+            return None
+        ref = refs[missing[0] - 1]
+        sheet = graph.sheets[ref.sheet_number - 1]
+        inters = {element.get('id'): element for element in sheet.iter()
+                  if element.tag in _INTER_TAGS and element.get('id')}
+        measure_chords = set((ref.element.findtext('head-chords') or '').split())
+        measure_chords.update((ref.element.findtext('rest-chords') or '').split())
+        unvoiced = measure_chords - _voiced(ref.element)
+        if not unvoiced or ref.element.get('abnormal') != 'true':
+            return None
+        by_wedge = {}
+        for relation in sheet.iter('relation'):
+            link = relation.find('chord-wedge')
+            if link is None or relation.get('source') not in unvoiced:
+                continue
+            wedge = relation.get('target')
+            if wedge not in inters or inters[wedge].tag != 'wedge':
+                return None
+            by_wedge.setdefault(wedge, set()).add(link.get('side'))
+        wedges = sorted(wedge for wedge, sides in by_wedge.items()
+                        if sides == {'LEFT', 'RIGHT'})
+        if len(wedges) != 1:
+            return None
+        wedge_chords = sorted(relation.get('source') for relation in sheet.iter('relation')
+                              if relation.get('target') == wedges[0]
+                              and relation.find('chord-wedge') is not None)
+        if not wedge_chords or any(chord not in unvoiced for chord in wedge_chords):
+            return None
+        return WedgeTrigger(ref.sheet_number, ref.system_index, ref.stack_index,
+                            ref.number, ref.element.get('id'), tuple(wedge_chords),
+                            tuple(wedges))
+    except (ET.ParseError, OSError, ValueError, KeyError, RecursionError,
+            zipfile.BadZipFile):
+        return None
+
+
+def _bounds(element):
+    box = element.find('bounds')
+    if box is None:
+        raise ValueError('missing bounds')
+    return tuple(_integer(box.get(key), minimum=0, maximum=1_000_000)
+                 for key in ('x', 'y', 'w', 'h'))
+
+
+def _overlap(left, right):
+    ax, ay, aw, ah = left
+    bx, by, bw, bh = right
+    return max(0, min(ax + aw, bx + bw) - max(ax, bx)) * max(
+        0, min(ay + ah, by + bh) - max(ay, by))
+
+
+def _staff_interlines(system):
+    result = {}
+    for staff in system.findall('part/staff'):
+        ordinates = []
+        for line in staff.findall('lines/line'):
+            points = line.findall('point')
+            if len(points) < 1:
+                raise ValueError('missing staff points')
+            ordinates.append(sum(float(point.get('y')) for point in points) / len(points))
+        gaps = [right - left for left, right in zip(ordinates, ordinates[1:])]
+        if len(gaps) != 4 or min(gaps) <= 0:
+            raise ValueError('invalid staff geometry')
+        result[staff.get('id')] = sum(gaps) / len(gaps)
+    return result
+
+
+def _line_y(staff, *, below, x):
+    lines = staff.findall('lines/line')
+    line = lines[-1] if below else lines[0]
+    points = line.findall('point')
+    if not points:
+        raise ValueError('missing staff line geometry')
+    if len(points) == 1:
+        return float(points[0].get('y'))
+    left, right = points[0], points[-1]
+    x1, x2 = float(left.get('x')), float(right.get('x'))
+    y1, y2 = float(left.get('y')), float(right.get('y'))
+    return y1 if x1 == x2 else y1 + ((x - x1) * (y2 - y1) / (x2 - x1))
+
+
+def _rest_profiles(sheet):
+    profiles = {}
+    systems = sheet.findall('page/system')
+    for system in systems:
+        interlines = _staff_interlines(system)
+        for rest in system.iter('rest'):
+            shape, staff = rest.get('shape'), rest.get('staff')
+            if not shape or staff not in interlines or rest.get('frozen') == 'true':
+                continue
+            x, y, width, height = _bounds(rest)
+            pitch = float(rest.get('pitch'))
+            profiles.setdefault(shape, []).append(
+                (width / interlines[staff], height / interlines[staff], pitch))
+    return profiles
+
+
+def _inside_profile(rest, interline, profile):
+    if not profile:
+        return False
+    _, _, width, height = _bounds(rest)
+    values = (width / interline, height / interline, float(rest.get('pitch')))
+    return all(min(row[index] for row in profile) <= values[index]
+               <= max(row[index] for row in profile) for index in range(3))
+
+
+def _freeze_raw(raw: bytes, entries):
+    text = raw.decode('utf-8')
+    for tag, identifier in entries:
+        pattern = re.compile(r'(<%s\b[^>]*?)( id="%s")'
+                             % (re.escape(tag), re.escape(identifier)))
+        text, count = pattern.subn(r'\1 frozen="true"\2', text, count=1)
+        if count != 1:
+            raise ValueError('inter is not uniquely serializable')
+    return text.encode('utf-8')
+
+
+def _copy_graph(source: Path, target: Path, changed_name: str, changed: bytes):
+    _copy_graph_entries(source, target, {changed_name: changed})
+
+
+def _copy_graph_entries(source: Path, target: Path, changes):
+    with zipfile.ZipFile(source) as archive, zipfile.ZipFile(target, 'x') as output:
+        for info in archive.infolist():
+            data = b'' if info.filename.endswith('/') else archive.read(info.filename)
+            if info.filename in changes:
+                data = changes[info.filename]
+            clone = zipfile.ZipInfo(info.filename, date_time=info.date_time)
+            clone.compress_type = info.compress_type
+            clone.external_attr = info.external_attr
+            clone.flag_bits = info.flag_bits & ~1
+            output.writestr(clone, data)
+
+
+def _defect_pair(graph, ref):
+    sheet = graph.sheets[ref.sheet_number - 1]
+    inters = {element.get('id'): element for element in sheet.iter()
+              if element.tag in _INTER_TAGS and element.get('id')}
+    heads = _graph_measure_heads(ref, sheet)
+    pairs = []
+    for relation in sheet.iter('relation'):
+        if relation.find('augmentation') is None:
+            continue
+        dot, head = inters.get(relation.get('source')), inters.get(relation.get('target'))
+        if head in heads and dot is not None and dot.tag == 'augmentation-dot':
+            pairs.append((head, dot))
+    if len(pairs) != 1 or not _source_ledger_signature(graph, ref, *pairs[0]):
+        raise ValueError('measure lacks one source-backed ledger defect')
+    return pairs[0]
+
+
+def prepare_wedge_retry(symbols_graph: Path, selected_graph: Path, target_graph: Path,
+                        trigger: WedgeTrigger | None):
+    """Protect the sole source-profiled SYMBOLS rest in the trigger stack."""
+    try:
+        if trigger is None:
+            return None
+        symbols = _read_graph(Path(symbols_graph), required_step='SYMBOLS')
+        selected = _read_graph(Path(selected_graph))
+        symbol_refs, selected_refs = _measure_refs(symbols), _measure_refs(selected)
+        if len(symbol_refs) != len(selected_refs):
+            return None
+        eligible_refs = _baseline_ledger_defects(selected, trigger)
+        eligible_numbers = tuple(ref.number for ref in eligible_refs)
+        if trigger.measure_number not in eligible_numbers:
+            return None
+        symbol_sheet = symbols.sheets[trigger.sheet_number - 1]
+        selected_sheet = selected.sheets[trigger.sheet_number - 1]
+        profiles = _rest_profiles(selected_sheet)
+        symbol_rests = list(symbol_sheet.iter('rest'))
+        selected_rests = list(selected_sheet.iter('rest'))
+        candidates = []
+        for eligible_ref in eligible_refs:
+            symbol_ref = symbol_refs[eligible_ref.number - 1]
+            interlines = _staff_interlines(symbol_ref.system)
+            left = _integer(symbol_ref.stack.get('left'), minimum=0)
+            right = _integer(symbol_ref.stack.get('right'), minimum=left + 1)
+            local = []
+            for rest in symbol_ref.system.iter('rest'):
+                box = _bounds(rest)
+                x, _, width, _ = box
+                staff, shape = rest.get('staff'), rest.get('shape')
+                if (x + width <= left or x >= right or staff not in interlines
+                        or not shape or rest.get('frozen') == 'true'
+                        or not _inside_profile(rest, interlines[staff], profiles.get(shape, []))):
+                    continue
+                if any(other is not rest and _overlap(box, _bounds(other))
+                       for other in symbol_rests):
+                    continue
+                if any(other.get('shape') == shape and other.get('staff') == staff
+                       and _overlap(box, _bounds(other)) for other in selected_rests):
+                    continue
+                owners = [relation.get('source') for relation in symbol_sheet.iter('relation')
+                          if relation.get('target') == rest.get('id')
+                          and relation.find('containment') is not None]
+                owner_nodes = [element for element in symbol_sheet.iter('rest-chord')
+                               if element.get('id') in owners]
+                if (len(owners) != 1 or len(owner_nodes) != 1
+                        or owner_nodes[0].get('frozen') == 'true'):
+                    continue
+                local.append((rest, owner_nodes[0], symbol_ref))
+            if len(local) != 1:
+                return None
+            candidates.extend(local)
+        entry_name = symbols.sheet_names[trigger.sheet_number - 1]
+        entries = tuple(item for rest, owner, _ in candidates
+                        for item in (('rest', rest.get('id')), ('rest-chord', owner.get('id'))))
+        if len({identifier for _, identifier in entries}) != len(entries):
+            return None
+        changed = _freeze_raw(symbols.raw_entries[entry_name], entries)
+        _copy_graph(Path(symbols_graph), Path(target_graph), entry_name, changed)
+        rest_evidence = tuple(RestEvidence(
+            ref.sheet_number, ref.system_index, ref.stack_index, ref.number,
+            rest.get('id'), owner.get('id'), rest.get('shape'),
+            rest.get('staff'), _bounds(rest)) for rest, owner, ref in candidates)
+        return WedgeRetryEvidence(trigger, rest_evidence, eligible_numbers)
+    except (ET.ParseError, OSError, ValueError, KeyError, RecursionError,
+            zipfile.BadZipFile):
+        return None
+
+
+def _normal_signature(element):
+    attributes = tuple(sorted((key, value) for key, value in element.attrib.items()
+                              if not (element.tag == 'slur' and key == 'number')))
+    return (element.tag, attributes, (element.text or '').strip(),
+            tuple(_normal_signature(child) for child in element if child.tag != 'slur'))
+
+
+def _music_signature(element, divisions=None):
+    attributes = tuple(sorted((key, value) for key, value in element.attrib.items()
+                              if key not in _MUSIC_LAYOUT_ATTRS
+                              and not (element.tag == 'slur' and key == 'number')))
+    transient_text = (element.tag in ('source', 'encoding-date')
+                      or (element.tag == 'miscellaneous-field'
+                          and element.get('name') == 'source-file'))
+    text = '' if transient_text else (element.text or '').strip()
+    if element.tag in ('duration', 'offset') and divisions is not None and text:
+        text = str(_fraction(text) / divisions)
+    return (element.tag, attributes, text,
+            tuple(_music_signature(child, divisions) for child in element
+                  if child.tag != 'slur'))
+
+
+def _score_state(root):
+    numbers = _score_measure_numbers(root)
+    measures = {}
+    divisions = Fraction(1)
+    slur_markers = []
+    ties = Counter()
+    for measure in root.findall('part/measure'):
+        number = _integer(measure.get('number'), minimum=1)
+        cursor = previous = Fraction(0)
+        pitched = Counter()
+        rests = Counter()
+        length = Fraction(0)
+        occurrence = Counter()
+        pitched_staff_occurrence = Counter()
+        for item in measure:
+            if item.tag == 'attributes' and item.findtext('divisions') is not None:
+                divisions = _fraction(item.findtext('divisions'), positive=True)
+            elif item.tag in ('backup', 'forward'):
+                duration = _fraction(item.findtext('duration'), positive=True) / divisions
+                cursor += -duration if item.tag == 'backup' else duration
+                if cursor < 0:
+                    raise ValueError('negative cursor')
+                length = max(length, cursor)
+            elif item.tag == 'note':
+                if item.find('grace') is not None:
+                    raise ValueError('unsupported grace')
+                duration = _fraction(item.findtext('duration'), positive=True) / divisions
+                onset = previous if item.find('chord') is not None else cursor
+                pitch = item.find('pitch')
+                rest = item.find('rest') is not None
+                if (pitch is None) == (not rest):
+                    raise ValueError('invalid note kind')
+                if pitch is None:
+                    pitch_key = ('rest',)
+                else:
+                    pitch_key = (pitch.findtext('step'),
+                                 _integer(pitch.findtext('alter', '0'), minimum=-2, maximum=2),
+                                 _integer(pitch.findtext('octave'), minimum=-1, maximum=9))
+                staff = _integer(item.findtext('staff', '1'), minimum=1, maximum=2)
+                voice = item.findtext('voice')
+                anchor_base = (number, pitch_key, staff, voice, onset, duration)
+                ordinal = occurrence[anchor_base]
+                occurrence[anchor_base] += 1
+                pitched_index = pitched_staff_occurrence[staff] if pitch is not None else -1
+                if pitch is not None:
+                    pitched_staff_occurrence[staff] += 1
+                anchor = anchor_base + (ordinal, pitched_index)
+                if pitch is not None:
+                    pitched[(pitch_key, staff, onset, duration, voice)] += 1
+                else:
+                    rests[(staff, onset, duration, voice,
+                           (item.findtext('type') or '').strip())] += 1
+                for slur in item.findall('notations/slur'):
+                    if slur.get('type') not in ('start', 'stop', 'continue') or not slur.get('number'):
+                        raise ValueError('unsupported slur')
+                    slur_markers.append((slur.get('number'), slur.get('type'), anchor))
+                for kind, marker in (
+                        [('tie', item_marker) for item_marker in item.findall('tie')]
+                        + [('tied', item_marker) for item_marker in item.findall('notations/tied')]):
+                    if marker.get('type') not in ('start', 'stop'):
+                        raise ValueError('unsupported tie')
+                    details = tuple(sorted((key, value) for key, value in marker.attrib.items()
+                                           if key != 'type'))
+                    ties[(kind, marker.get('type'), anchor, details)] += 1
+                length = max(length, onset + duration)
+                if item.find('chord') is None:
+                    previous = onset
+                    cursor += duration
+        measures[number] = (_music_signature(measure), pitched, length, rests)
+    open_slurs, pairs = {}, Counter()
+    for identifier, kind, anchor in slur_markers:
+        if kind == 'start':
+            if identifier in open_slurs:
+                pairs[(open_slurs.pop(identifier), None)] += 1
+            open_slurs[identifier] = anchor
+        elif kind == 'continue':
+            # Audiveris emits paired continuation markers at system boundaries.
+            # They carry geometry, not a new musical endpoint.
+            continue
+        else:
+            if identifier not in open_slurs:
+                pairs[(None, anchor)] += 1
+            else:
+                start = open_slurs.pop(identifier)
+                pairs[(start, anchor)] += 1
+    for start in open_slurs.values():
+        pairs[(start, None)] += 1
+    return numbers, measures, pairs, ties
+
+
+def _slurs_preserved(original, candidate, scope):
+    def endpoint(anchor):
+        if anchor is None or anchor[0] not in scope:
+            return anchor
+        return anchor[0], anchor[2], anchor[-1]
+
+    def project(pairs):
+        result = Counter()
+        for (start, stop), count in pairs.items():
+            result[(endpoint(start), endpoint(stop))] += count
+        return result
+
+    original, candidate = project(original), project(candidate)
+    remaining = candidate.copy()
+    unresolved = []
+    for pair, count in original.items():
+        matched = min(count, remaining[pair])
+        remaining[pair] -= matched
+        unresolved.extend([pair] * (count - matched))
+    for start, stop in unresolved:
+        endpoint = start if start is not None else stop
+        if endpoint is None:
+            return False
+        replacements = [pair for pair, count in remaining.items() if count
+                        and endpoint in pair
+                        and any(item is not None and item[0] in scope for item in pair)]
+        if len(replacements) != 1:
+            return False
+        remaining[replacements[0]] -= 1
+    return all(not count or any(item is not None and item[0] in scope for item in pair)
+               for pair, count in remaining.items())
+
+
+def _ties_preserved(original, candidate, scope):
+    def project(markers):
+        result = Counter()
+        for (kind, marker_type, anchor, details), count in markers.items():
+            endpoint = ((anchor[0], anchor[1], anchor[2], anchor[-1])
+                        if anchor[0] in scope else anchor)
+            result[(kind, marker_type, endpoint, details)] += count
+        return result
+
+    original_projected, candidate_projected = project(original), project(candidate)
+    if original_projected - candidate_projected:
+        return False
+    return all(not count or marker[2][0] in scope
+               for marker, count in (candidate_projected - original_projected).items())
+
+
+def _graph_measure_heads(ref, sheet):
+    chord_ids = set((ref.element.findtext('head-chords') or '').split())
+    head_ids = {relation.get('target') for relation in sheet.iter('relation')
+                if relation.get('source') in chord_ids
+                and relation.find('containment') is not None}
+    return [element for element in sheet.iter('head') if element.get('id') in head_ids]
+
+
+def _key_alters(root, target):
+    fifths = 0
+    for measure in root.findall('part/measure'):
+        number = _integer(measure.get('number'), minimum=1)
+        if number > target:
+            break
+        value = measure.findtext('attributes/key/fifths')
+        if value is not None:
+            fifths = _integer(value, minimum=-7, maximum=7)
+    result = {step: 0 for step in 'CDEFGAB'}
+    order = 'FCGDAEB' if fifths >= 0 else 'BEADGCF'
+    for step in order[:abs(fifths)]:
+        result[step] = 1 if fifths >= 0 else -1
+    return result
+
+
+def _head_pitch(head, clef_shape):
+    value = float(head.get('pitch'))
+    pitch = round(value)
+    if abs(value - pitch) > 0.01:
+        raise ValueError('non-integral head pitch')
+    if clef_shape == 'G_CLEF':
+        ordinal = 4 * 7 + 6  # B4 on the middle line.
+    elif clef_shape == 'F_CLEF':
+        ordinal = 3 * 7 + 1  # D3 on the middle line.
+    else:
+        raise ValueError('unsupported clef')
+    ordinal -= pitch
+    octave, index = divmod(ordinal, 7)
+    return 'CDEFGAB'[index], octave
+
+
+def _graph_pitched_events(ref, sheet, key_alters):
+    stack_slots = {slot.get('id'): _fraction(slot.get('time-offset')) * 4
+                   for slot in ref.stack.findall('slot')}
+    stack_duration = _fraction(ref.stack.get('duration'), positive=True) * 4
+    if not stack_slots or min(stack_slots.values()) != 0:
+        raise ValueError('unsupported stack slots')
+    system_inters = {element.get('id'): element for element in ref.system.iter()
+                     if element.tag in _INTER_TAGS.union({'clef'}) and element.get('id')}
+    chord_heads = {}
+    for relation in ref.system.iter('relation'):
+        if relation.find('containment') is None:
+            continue
+        chord, head = system_inters.get(relation.get('source')), system_inters.get(relation.get('target'))
+        if chord is not None and chord.tag == 'head-chord' and head is not None and head.tag == 'head':
+            chord_heads.setdefault(chord.get('id'), []).append(head)
+    staff_numbers, clefs = {}, {}
+    for number, staff in enumerate(ref.system.findall('part/staff'), 1):
+        staff_id = staff.get('id')
+        clef_id = staff.findtext('header/clef')
+        clef = system_inters.get(clef_id)
+        if clef is None or clef.tag != 'clef':
+            raise ValueError('missing staff clef')
+        staff_numbers[staff_id] = number
+        clefs[staff_id] = clef.get('shape')
+    events = Counter()
+    for voice in ref.element.findall('voice'):
+        beginnings = []
+        for entry in voice.findall('slots/entry'):
+            value = entry.find('value')
+            if value is None or value.get('status') != 'BEGIN':
+                continue
+            slot = entry.findtext('key')
+            chord = value.get('chord')
+            if slot not in stack_slots or not chord:
+                raise ValueError('invalid voice slot')
+            beginnings.append((stack_slots[slot], chord))
+        beginnings.sort()
+        for onset, chord in beginnings:
+            for head in chord_heads.get(chord, []):
+                staff_id = head.get('staff')
+                step, octave = _head_pitch(head, clefs.get(staff_id))
+                pitch = (step, key_alters[step], octave)
+                events[(pitch, staff_numbers[staff_id], onset, voice.get('id'))] += 1
+    return events, frozenset(stack_slots.values()) | {stack_duration}
+
+
+def _xml_matches_graph(measure_state, root, number, ref, sheet):
+    graph_events, graph_boundaries = _graph_pitched_events(
+        ref, sheet, _key_alters(root, number))
+    xml_events = Counter()
+    for (pitch, staff, onset, duration, voice), count in measure_state[1].items():
+        if onset + duration not in graph_boundaries:
+            return False
+        xml_events[(pitch, staff, onset, voice)] += count
+    return xml_events == graph_events
+
+
+def _measure_context(root, number):
+    divisions = Fraction(1)
+    for measure in root.findall('part/measure'):
+        current = _integer(measure.get('number'), minimum=1)
+        contexts = []
+        cursor = Fraction(0)
+        for child in measure:
+            if child.tag == 'attributes':
+                value = child.findtext('divisions')
+                if value is not None:
+                    divisions = _fraction(value, positive=True)
+                contexts.append((
+                    'attributes',
+                    tuple(_music_signature(item, divisions) for item in child
+                          if item.tag != 'divisions'),
+                ))
+            elif child.tag in ('backup', 'forward'):
+                duration = _fraction(child.findtext('duration'), positive=True) / divisions
+                cursor += -duration if child.tag == 'backup' else duration
+            elif child.tag == 'note':
+                if child.find('chord') is None:
+                    cursor += _fraction(child.findtext('duration'), positive=True) / divisions
+            else:
+                contexts.append((child.tag, cursor, _music_signature(child, divisions)))
+        if current == number:
+            return tuple(contexts)
+    raise ValueError('missing measure context')
+
+
+def _note_semantics(root, number):
+    divisions = Fraction(1)
+    for measure in root.findall('part/measure'):
+        current = _integer(measure.get('number'), minimum=1)
+        notes = []
+        for child in measure:
+            if child.tag == 'attributes' and child.findtext('divisions') is not None:
+                divisions = _fraction(child.findtext('divisions'), positive=True)
+            elif child.tag == 'note':
+                notes.append(_music_signature(child, divisions))
+        if current == number:
+            return tuple(notes)
+    raise ValueError('missing note semantics')
+
+
+def _score_header(root):
+    return tuple(_music_signature(child) for child in root if child.tag != 'part')
+
+
+def _pitched_onsets(root, number):
+    divisions = Fraction(1)
+    for measure in root.findall('part/measure'):
+        current = _integer(measure.get('number'), minimum=1)
+        cursor = previous = Fraction(0)
+        staff_ordinals = Counter()
+        result = {}
+        for child in measure:
+            if child.tag == 'attributes' and child.findtext('divisions') is not None:
+                divisions = _fraction(child.findtext('divisions'), positive=True)
+            elif child.tag in ('backup', 'forward'):
+                duration = _fraction(child.findtext('duration'), positive=True) / divisions
+                cursor += -duration if child.tag == 'backup' else duration
+            elif child.tag == 'note':
+                duration = _fraction(child.findtext('duration'), positive=True) / divisions
+                onset = previous if child.find('chord') is not None else cursor
+                pitch = child.find('pitch')
+                staff = _integer(child.findtext('staff', '1'), minimum=1, maximum=2)
+                if pitch is not None:
+                    pitch_key = (pitch.findtext('step'),
+                                 _integer(pitch.findtext('alter', '0'), minimum=-2, maximum=2),
+                                 _integer(pitch.findtext('octave'), minimum=-1, maximum=9))
+                    ordinal = staff_ordinals[staff]
+                    staff_ordinals[staff] += 1
+                    result.setdefault((staff, onset), set()).add((ordinal, pitch_key))
+                if child.find('chord') is None:
+                    previous = onset
+                    cursor += duration
+        if current == number:
+            return result
+    raise ValueError('missing pitched timeline')
+
+
+def _direction_staff(signature):
+    for child in signature[3]:
+        if child[0] == 'staff':
+            return _integer(child[2], minimum=1, maximum=2)
+    return 1
+
+
+def _in_scope_context_preserved(original_root, candidate_root, number):
+    original = _measure_context(original_root, number)
+    candidate = _measure_context(candidate_root, number)
+    original_other = tuple(item for item in original if item[0] != 'direction')
+    candidate_other = tuple(item for item in candidate if item[0] != 'direction')
+    if original_other != candidate_other:
+        return False
+    original_directions = [item for item in original if item[0] == 'direction']
+    candidate_directions = [item for item in candidate if item[0] == 'direction']
+    if len(original_directions) != len(candidate_directions):
+        return False
+    original_onsets = _pitched_onsets(original_root, number)
+    candidate_onsets = _pitched_onsets(candidate_root, number)
+    for old, new in zip(original_directions, candidate_directions):
+        if old[2] != new[2]:
+            return False
+        if old[1] == new[1]:
+            continue
+        staff = _direction_staff(old[2])
+        old_anchor = original_onsets.get((staff, old[1]))
+        new_anchor = candidate_onsets.get((staff, new[1]))
+        if not old_anchor or old_anchor != new_anchor:
+            return False
+    return True
+
+
+def _glyph_has_ink(sheet, glyph_id, expected_bounds):
+    matches = [glyph for glyph in sheet.iter('glyph') if glyph.get('id') == glyph_id]
+    if len(matches) != 1:
+        return False
+    glyph = matches[0]
+    x, y, width, height = expected_bounds
+    if (glyph.get('left') != str(x) or glyph.get('top') != str(y)):
+        return False
+    table = glyph.find('run-table')
+    if table is None or table.get('orientation') not in ('VERTICAL', 'HORIZONTAL'):
+        return False
+    if (_integer(table.get('width'), minimum=1, maximum=4096) != width
+            or _integer(table.get('height'), minimum=1, maximum=4096) != height):
+        return False
+    vertical = table.get('orientation') == 'VERTICAL'
+    sequences = table.findall('runs')
+    if len(sequences) != (width if vertical else height):
+        return False
+    limit, foreground = (height if vertical else width), 0
+    for sequence in sequences:
+        values = (sequence.text or '').split()
+        if not values:
+            return False
+        position = 0
+        for index, value in enumerate(values):
+            length = _integer(value, minimum=0, maximum=limit)
+            position += length
+            if position > limit:
+                return False
+            if index % 2 == 0:
+                foreground += length
+    return foreground > 0
+
+
+def _source_has_ledger(image_bytes, ledger_box):
+    x, y, width, height = ledger_box
+    if width <= 0 or height <= 0:
+        return False
+    with Image.open(BytesIO(image_bytes)) as image:
+        gray = image.convert('L')
+        if x + width > gray.width or y + height > gray.height:
+            return False
+        best = 0
+        for row in range(y, y + height):
+            foreground = sum(1 for column in range(x, x + width)
+                             if gray.getpixel((column, row)) < 128)
+            best = max(best, foreground)
+    return best * 4 >= width * 3
+
+
+def _ledger_contexts(sheet):
+    contexts = {}
+    for system in sheet.findall('page/system'):
+        interlines = _staff_interlines(system)
+        for staff in system.findall('part/staff'):
+            staff_id = staff.get('id')
+            for entry in staff.findall('ledgers/ledgers-entry'):
+                index = _integer(entry.get('index'), minimum=-100, maximum=100)
+                if index == 0:
+                    raise ValueError('invalid ledger index')
+                for identifier in (entry.text or '').split():
+                    if identifier in contexts:
+                        raise ValueError('ledger appears in multiple staff indexes')
+                    contexts[identifier] = (index, interlines[staff_id])
+    return contexts
+
+
+def _ledger_profiles(sheet):
+    contexts = _ledger_contexts(sheet)
+    ledgers = {ledger.get('id'): ledger for ledger in sheet.iter('ledger')}
+    profiles = {}
+    for identifier, (index, interline) in contexts.items():
+        ledger = ledgers.get(identifier)
+        if ledger is None:
+            continue
+        _, _, width, height = _bounds(ledger)
+        profiles.setdefault(index, []).append((width / interline, height / interline))
+    return profiles
+
+
+def _ledger_geometry_in_profile(width, height, interline, profile):
+    """Compare at the same integer-pixel quantization Audiveris uses."""
+    if not profile:
+        return False
+    return (int(min(row[0] for row in profile) * interline) <= width
+            <= math.ceil(max(row[0] for row in profile) * interline)
+            and int(min(row[1] for row in profile) * interline) <= height
+            <= math.ceil(max(row[1] for row in profile) * interline))
+
+
+def _row_runs(gray, y, left, right):
+    runs, start = [], None
+    for x in range(left, right):
+        foreground = gray.getpixel((x, y)) < 128
+        if foreground and start is None:
+            start = x
+        elif not foreground and start is not None:
+            runs.append((start, x))
+            start = None
+    if start is not None:
+        runs.append((start, right))
+    return runs
+
+
+def _source_ledger_signature(graph, ref, head, dot):
+    if ref.element.get('abnormal') != 'true':
+        return False
+    pitch_value = float(head.get('pitch'))
+    pitch = round(pitch_value)
+    if abs(pitch_value - pitch) > 0.01 or abs(pitch) < 5 or abs(pitch) % 2 != 1:
+        return False
+    normal_heads = set()
+    sheet = graph.sheets[ref.sheet_number - 1]
+    for other_ref in _measure_refs(graph):
+        if other_ref.sheet_number == ref.sheet_number and other_ref.element.get('abnormal') != 'true':
+            normal_heads.update(_graph_measure_heads(other_ref, sheet))
+    other_grades = [float(item.get('grade')) for item in normal_heads
+                    if item.get('grade') is not None]
+    if not other_grades or float(head.get('grade')) >= min(other_grades):
+        return False
+    staff = next((staff for staff in ref.system.findall('part/staff')
+                  if staff.get('id') == head.get('staff')), None)
+    if staff is None:
+        return False
+    interline = _staff_interlines(ref.system)[staff.get('id')]
+    index = (1 if pitch > 0 else -1) * ((abs(pitch) + 1 - 4) // 2)
+    profiles = _ledger_profiles(graph.sheets[ref.sheet_number - 1]).get(index, [])
+    if not profiles:
+        return False
+    defect_left = min(_bounds(head)[0], _bounds(dot)[0])
+    defect_right = max(_bounds(head)[0] + _bounds(head)[2], _bounds(dot)[0] + _bounds(dot)[2])
+    center_x = (defect_left + defect_right) / 2
+    target_y = _line_y(staff, below=index > 0, x=center_x) + index * interline
+    min_width = max(1, int(min(row[0] for row in profiles) * interline))
+    max_width = math.ceil(max(row[0] for row in profiles) * interline)
+    min_height = max(1, int(min(row[1] for row in profiles) * interline))
+    max_height = math.ceil(max(row[1] for row in profiles) * interline)
+    data = graph.raw_entries[f'sheet#{ref.sheet_number}/BINARY.png']
+    with Image.open(BytesIO(data)) as image:
+        gray = image.convert('L')
+        margin = int(max_width)
+        left = max(0, int(defect_left - margin))
+        right = min(gray.width, int(defect_right + margin))
+        top = max(0, int(target_y - max_height * 2))
+        bottom = min(gray.height, int(target_y + max_height * 2) + 1)
+        rows = []
+        for y in range(top, bottom):
+            matching = [run for run in _row_runs(gray, y, left, right)
+                        if run[1] > defect_left and run[0] < defect_right
+                        and min_width <= run[1] - run[0] <= max_width]
+            if matching:
+                rows.append((y, max(matching, key=lambda run: run[1] - run[0])))
+        groups, current = [], []
+        for row in rows:
+            if current and row[0] != current[-1][0] + 1:
+                groups.append(current)
+                current = []
+            current.append(row)
+        if current:
+            groups.append(current)
+    matches = [group for group in groups if min_height <= len(group) <= max_height
+               and group[0][0] - 1 <= target_y <= group[-1][0] + 1]
+    if len(matches) != 1:
+        return None
+    group = matches[0]
+    run_left = min(run[0] for _, run in group)
+    run_right = max(run[1] for _, run in group)
+    return run_left, group[0][0], run_right - run_left, len(group)
+
+
+def _baseline_ledger_defects(graph, trigger):
+    refs = _measure_refs(graph)
+    sheet = graph.sheets[trigger.sheet_number - 1]
+    inters = {element.get('id'): element for element in sheet.iter()
+              if element.tag in _INTER_TAGS and element.get('id')}
+    result = []
+    for ref in refs:
+        if (ref.sheet_number, ref.system_index) != (trigger.sheet_number, trigger.system_index):
+            continue
+        heads = _graph_measure_heads(ref, sheet)
+        augmented = []
+        for relation in sheet.iter('relation'):
+            if relation.find('augmentation') is None:
+                continue
+            dot, head = inters.get(relation.get('source')), inters.get(relation.get('target'))
+            if head in heads and dot is not None and dot.tag == 'augmentation-dot':
+                augmented.append((head, dot))
+        if len(augmented) == 1 and _source_ledger_signature(graph, ref, *augmented[0]):
+            result.append(ref)
+    return result
+
+
+def recovery_region_constant(graph_path: Path, trigger: WedgeTrigger | None):
+    """Encode graph/BINARY-derived regions for the patched native candidate."""
+    try:
+        if trigger is None:
+            return None
+        graph = _read_graph(Path(graph_path))
+        regions = []
+        defects = _baseline_ledger_defects(graph, trigger)
+        for ref in defects:
+            head, dot = _defect_pair(graph, ref)
+            source_bounds = _source_ledger_signature(graph, ref, head, dot)
+            if source_bounds is None:
+                return None
+            regions.append((ref.sheet_number, _integer(ref.system.get('id'), minimum=1),
+                            *source_bounds))
+        if trigger.measure_number not in {ref.number for ref in defects}:
+            return None
+        if not regions or len(regions) > 8:
+            return None
+        specification = ';'.join(','.join(str(value) for value in region)
+                                 for region in sorted(regions))
+        return f'{_RECOVERY_REGIONS_KEY}={specification}'
+    except (ET.ParseError, OSError, ValueError, KeyError, RecursionError,
+            zipfile.BadZipFile, StopIteration):
+        return None
+
+
+def _stable_graph_signature(element):
+    attributes = tuple(sorted((key, value) for key, value in element.attrib.items()
+                              if key not in ('id', 'glyph', 'grade', 'ctx-grade',
+                                             'left-extension', 'right-extension')
+                              and not (element.tag == 'relation'
+                                       and key in ('source', 'target'))))
+    return (element.tag, attributes, (element.text or '').strip(),
+            tuple(_stable_graph_signature(child) for child in element
+                  if child.tag != 'bounds'))
+
+
+def _stable_glyph_signature(glyph, *, keep_position=False):
+    attributes = tuple(sorted((key, value) for key, value in glyph.attrib.items()
+                              if key != 'id'
+                              and not (key == 'groups' and not keep_position)
+                              and (keep_position or key not in ('left', 'top'))))
+    return (glyph.tag, attributes, tuple(_stable_graph_signature(child) for child in glyph))
+
+
+def _relation_signature(relation):
+    return tuple((child.tag,
+                  tuple(sorted((key, value) for key, value in child.attrib.items()
+                               if key in ('side', 'cause', 'type'))),
+                  (child.text or '').strip()) for child in relation)
+
+
+def _stack_snapshot(ref, sheet):
+    left = _integer(ref.stack.get('left'), minimum=0)
+    right = _integer(ref.stack.get('right'), minimum=left + 1)
+    items, vertices, local_ids = [], {}, set()
+    glyphs = {glyph.get('id'): glyph for glyph in sheet.iter('glyph') if glyph.get('id')}
+    inters = ref.system.find('sig/inters')
+    if inters is None:
+        raise ValueError('missing SIG inters')
+    for element in inters:
+        glyph = glyphs.get(element.get('glyph'))
+        glyph_signature = _stable_glyph_signature(glyph) if glyph is not None else None
+        descriptor = (_stable_graph_signature(element), glyph_signature)
+        vertices[element.get('id')] = descriptor
+        try:
+            box = _bounds(element)
+            if left <= box[0] + box[2] / 2 < right:
+                local_ids.add(element.get('id'))
+                items.append(('inter', descriptor))
+        except ValueError:
+            pass
+    for relation in ref.system.iter('relation'):
+        source, target = relation.get('source'), relation.get('target')
+        if source not in local_ids and target not in local_ids:
+            continue
+        if source not in vertices or target not in vertices:
+            raise ValueError('relation endpoint missing from live graph')
+        items.append(('relation', vertices[source], vertices[target],
+                      _relation_signature(relation)))
+    free_ids = {identifier for group in ref.system.findall('free-glyphs')
+                for identifier in (group.text or '').split()}
+    interlines = _staff_interlines(ref.system)
+    max_interline = max(interlines.values())
+    staff_points = [float(point.get('y')) for staff in ref.system.findall('part/staff')
+                    for point in staff.findall('lines/line/point')]
+    if not staff_points:
+        raise ValueError('system lacks vertical geometry')
+    system_top = min(staff_points) - 4 * max_interline
+    system_bottom = max(staff_points) + 4 * max_interline
+    for identifier in free_ids:
+        glyph = glyphs.get(identifier)
+        if glyph is None:
+            # Completed books can retain weak free IDs after their cache entry
+            # is purged; stock repeat proves these are not live payloads.
+            continue
+        table = glyph.find('run-table')
+        if table is None:
+            raise ValueError('free glyph lacks ink')
+        glyph_left = _integer(glyph.get('left'), minimum=0)
+        glyph_top = _integer(glyph.get('top'), minimum=0)
+        glyph_width = _integer(table.get('width'), minimum=1)
+        glyph_height = _integer(table.get('height'), minimum=1)
+        if (left <= glyph_left + glyph_width / 2 < right
+                and system_top <= glyph_top + glyph_height / 2 < system_bottom):
+            items.append(('free-glyph', _stable_glyph_signature(
+                glyph, keep_position=True)))
+    return Counter(items)
+
+
+def _outside_graph_preserved(original, candidate, scope):
+    original_refs, candidate_refs = _measure_refs(original), _measure_refs(candidate)
+    if len(original_refs) != len(candidate_refs):
+        return False
+    for number in range(1, len(original.sheets) + 1):
+        name = f'sheet#{number}/BINARY.png'
+        if original.raw_entries[name] != candidate.raw_entries[name]:
+            return False
+    return all(_stack_snapshot(old, original.sheets[old.sheet_number - 1])
+               == _stack_snapshot(new, candidate.sheets[new.sheet_number - 1])
+               for old, new in zip(original_refs, candidate_refs)
+               if old.number not in scope)
+
+
+def _ledger_repair_proven(original: _Graph, candidate: _Graph,
+                          old_ref: _MeasureRef, new_ref: _MeasureRef):
+    if ((old_ref.sheet_number, old_ref.system_index, old_ref.stack_index)
+            != (new_ref.sheet_number, new_ref.system_index, new_ref.stack_index)):
+        return False
+    old_sheet = original.sheets[old_ref.sheet_number - 1]
+    new_sheet = candidate.sheets[new_ref.sheet_number - 1]
+    old_heads = _graph_measure_heads(old_ref, old_sheet)
+    new_heads = _graph_measure_heads(new_ref, new_sheet)
+    if not old_heads or len(old_heads) != len(new_heads):
+        return False
+    old_inters = {element.get('id'): element for element in old_sheet.iter()
+                  if element.tag in _INTER_TAGS and element.get('id')}
+    augmented = []
+    for relation in old_sheet.iter('relation'):
+        if relation.find('augmentation') is None:
+            continue
+        dot, head = old_inters.get(relation.get('source')), old_inters.get(relation.get('target'))
+        if head in old_heads and dot is not None and dot.tag == 'augmentation-dot':
+            augmented.append((head, dot))
+    if len(augmented) != 1:
+        return False
+    old_head, old_dot = augmented[0]
+    staff_id = old_head.get('staff')
+    old_contexts = _ledger_contexts(old_sheet)
+    new_contexts = _ledger_contexts(new_sheet)
+    old_ledgers = {ledger.get('id'): ledger for ledger in old_sheet.iter('ledger')}
+    new_ledgers = [ledger for ledger in new_sheet.iter('ledger')
+                   if ledger.get('staff') == staff_id and ledger.get('id') in new_contexts]
+    candidates = []
+    defect_box = _bounds(old_head)
+    dot_box = _bounds(old_dot)
+    for ledger in new_ledgers:
+        box = _bounds(ledger)
+        _, _, width, height = box
+        index, new_interline = new_contexts[ledger.get('id')]
+        profiles = []
+        for identifier, (old_index, old_interline) in old_contexts.items():
+            if old_index != index or identifier not in old_ledgers:
+                continue
+            _, _, old_width, old_height = _bounds(old_ledgers[identifier])
+            profiles.append((old_width / old_interline, old_height / old_interline))
+        if not profiles:
+            continue
+        if not _ledger_geometry_in_profile(width, height, new_interline, profiles):
+            continue
+        horizontal = max(0, min(box[0] + box[2], max(defect_box[0] + defect_box[2],
+                                                     dot_box[0] + dot_box[2]))
+                         - max(box[0], min(defect_box[0], dot_box[0])))
+        if horizontal <= 0 or not _glyph_has_ink(new_sheet, ledger.get('glyph'), box):
+            continue
+        if not _source_has_ledger(original.raw_entries[
+                f'sheet#{old_ref.sheet_number}/BINARY.png'], box):
+            continue
+        candidates.append(ledger)
+    if len(candidates) != 1:
+        return False
+    ledger = candidates[0]
+    matching_heads = [head for head in new_heads if head.get('staff') == staff_id
+                      and _overlap(_bounds(head), _bounds(ledger))]
+    if len(matching_heads) != 1:
+        return False
+    new_head = matching_heads[0]
+    head_pairs, used = {}, set()
+    for prior in old_heads:
+        matches = [head for head in new_heads if head.get('staff') == prior.get('staff')
+                   and _overlap(_bounds(prior), _bounds(head))]
+        if len(matches) != 1 or matches[0].get('id') in used:
+            return False
+        used.add(matches[0].get('id'))
+        head_pairs[prior.get('id')] = matches[0]
+    if len(used) != len(new_heads) or head_pairs.get(old_head.get('id')) is not new_head:
+        return False
+    for prior in old_heads:
+        current = head_pairs[prior.get('id')]
+        if prior is old_head:
+            if current.get('shape') != prior.get('shape'):
+                return False
+            continue
+        prior_glyph = next((glyph for glyph in old_sheet.iter('glyph')
+                            if glyph.get('id') == prior.get('glyph')), None)
+        current_glyph = next((glyph for glyph in new_sheet.iter('glyph')
+                              if glyph.get('id') == current.get('glyph')), None)
+        if (current.get('shape') != prior.get('shape')
+                or current.get('pitch') != prior.get('pitch')
+                or _bounds(current) != _bounds(prior)
+                or prior_glyph is None or current_glyph is None
+                or _stable_glyph_signature(prior_glyph)
+                != _stable_glyph_signature(current_glyph)):
+            return False
+    if (not _glyph_has_ink(new_sheet, new_head.get('glyph'), _bounds(new_head))
+            or abs(_integer(new_head.get('pitch')) - _integer(old_head.get('pitch'))) != 1
+            or new_head.get('abnormal') == 'true'):
+        return False
+    for relation in new_sheet.iter('relation'):
+        if relation.find('augmentation') is not None:
+            target = next((head for head in new_heads if head.get('id') == relation.get('target')), None)
+            if target is not None and _overlap(_bounds(target), _bounds(ledger)):
+                return False
+    return True
+
+
+def _rest_retained(candidate: _Graph, evidence: WedgeRetryEvidence):
+    for item in evidence.rests:
+        sheet = candidate.sheets[item.sheet_number - 1]
+        rests = [rest for rest in sheet.iter('rest') if rest.get('shape') == item.shape
+                 and rest.get('staff') == item.staff_id
+                 and _overlap(_bounds(rest), item.bounds)]
+        if (len(rests) != 1 or rests[0].get('frozen') != 'true'
+                or not _glyph_has_ink(sheet, rests[0].get('glyph'), _bounds(rests[0]))):
+            return False
+        relations = [relation for relation in sheet.iter('relation')
+                     if relation.get('target') == rests[0].get('id')
+                     and relation.find('containment') is not None]
+        if len(relations) != 1:
+            return False
+        owners = [node for node in sheet.iter('rest-chord')
+                  if node.get('id') == relations[0].get('source')]
+        if len(owners) != 1 or owners[0].get('frozen') != 'true':
+            return False
+        ref = _measure_refs(candidate)[item.measure_number - 1]
+        if owners[0].get('id') not in (ref.element.findtext('rest-chords') or '').split():
+            return False
+    return True
+
+
+def accept_wedge_retry(original_root, candidate_root, original_graph: Path,
+                       candidate_graph: Path, evidence: WedgeRetryEvidence | None):
+    """Accept only native, image-backed repair with strict untouched measures."""
+    try:
+        if evidence is None:
+            return False
+        if not _uniform_four_four(original_root) or not _uniform_four_four(candidate_root):
+            return False
+        original = _read_graph(Path(original_graph))
+        candidate = _read_graph(Path(candidate_graph))
+        old_numbers, old_measures, old_slurs, old_ties = _score_state(original_root)
+        new_numbers, new_measures, new_slurs, new_ties = _score_state(candidate_root)
+        if _score_header(original_root) != _score_header(candidate_root):
+            return False
+        target = evidence.trigger.measure_number
+        old_refs, new_refs = _measure_refs(original), _measure_refs(candidate)
+        if new_numbers != list(range(1, len(old_refs) + 1)):
+            return False
+        if old_numbers != [number for number in new_numbers if number != target]:
+            return False
+        eligible = set(evidence.eligible_measure_numbers)
+        if target not in eligible:
+            return False
+        expected_rests = Counter(item.measure_number for item in evidence.rests)
+        if set(expected_rests) != eligible:
+            return False
+        proven = {number for number in eligible if _ledger_repair_proven(
+            original, candidate, old_refs[number - 1], new_refs[number - 1])}
+        if (proven != eligible or not _slurs_preserved(old_slurs, new_slurs, proven)
+                or not _ties_preserved(old_ties, new_ties, proven)):
+            return False
+        for number in old_numbers:
+            if number not in proven:
+                if (old_measures[number][1:] != new_measures[number][1:]
+                        or _note_semantics(original_root, number)
+                        != _note_semantics(candidate_root, number)
+                        or _measure_context(original_root, number)
+                        != _measure_context(candidate_root, number)):
+                    return False
+                continue
+            if (not _in_scope_context_preserved(original_root, candidate_root, number)
+                    or sum(old_measures[number][1].values()) != sum(new_measures[number][1].values())
+                    or old_measures[number][3] - new_measures[number][3]
+                    or sum((new_measures[number][3] - old_measures[number][3]).values())
+                    != expected_rests[number]
+                    or abs(new_measures[number][2] - 4) >= abs(old_measures[number][2] - 4)):
+                return False
+            ref = new_refs[number - 1]
+            if not _xml_matches_graph(
+                    new_measures[number], candidate_root, number, ref,
+                    candidate.sheets[ref.sheet_number - 1]):
+                return False
+        if new_measures[target][2] != 4:
+            return False
+        if sum(new_measures[target][3].values()) != expected_rests[target]:
+            return False
+        target_ref = new_refs[target - 1]
+        target_sheet = candidate.sheets[target_ref.sheet_number - 1]
+        if target_ref.element.get('abnormal') == 'true':
+            return False
+        if not _xml_matches_graph(
+                new_measures[target], candidate_root, target, target_ref, target_sheet):
+            return False
+        if detect_wedge_export_loss(candidate_root, candidate_graph) is not None:
+            return False
+        return (_outside_graph_preserved(original, candidate, proven)
+                and _rest_retained(candidate, evidence)
+                and target in proven)
+    except (ET.ParseError, OSError, ValueError, KeyError, RecursionError,
+            zipfile.BadZipFile):
+        return False

--- a/omr-service/tests/test_audiveris_runtime.py
+++ b/omr-service/tests/test_audiveris_runtime.py
@@ -41,6 +41,13 @@ class HangingProcess:
 
 
 class AudiverisProcessorTests(unittest.TestCase):
+    def test_existing_positional_constructor_contract_is_preserved(self):
+        processor = AudiverisProcessor(Path('/tmp/stock-audiveris'), 2, 3)
+
+        self.assertEqual(processor.audiveris_executable, Path('/tmp/stock-audiveris'))
+        self.assertEqual(processor._conversion_slots._value, 2)
+        self.assertEqual(processor.process_timeout_seconds, 3)
+
     def test_native_launcher_receives_output_folder_and_returns_mxl(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             temp_dir = Path(temporary_directory)
@@ -256,7 +263,35 @@ class DeploymentStaticContractTests(unittest.TestCase):
         self.assertIn("AUDIVERIS_TIMEOUT_SECONDS=900", dockerfile)
         self.assertIn("grep -Fqx 'java-options=-Xmx3G'", dockerfile)
         self.assertGreaterEqual(dockerfile.count("--no-install-recommends"), 2)
-        self.assertNotIn("openjdk", dockerfile.lower())
+        self.assertNotRegex(dockerfile.lower(), r"apt-get install[^\n]*openjdk")
+        self.assertIn("rm -rf /tmp/jdk25", dockerfile)
+
+    def test_container_builds_an_isolated_region_recovery_engine(self):
+        dockerfile = (OMR_SERVICE_ROOT / "Dockerfile.audiveris").read_text(encoding="utf-8")
+        patch_file = (
+            OMR_SERVICE_ROOT / "audiveris-patches/0001-region-scoped-ledger-recovery.patch"
+        )
+
+        self.assertTrue(patch_file.is_file())
+        self.assertIn(
+            "555ce0821e4fe175ea50d54518cd6fbece9663c1998de529bc6ce429534457df",
+            dockerfile,
+        )
+        self.assertIn(
+            "81202a3d8b10912c132a8340d3de6d6a70782d39cd15e0972410a95212f46f3c",
+            dockerfile,
+        )
+        self.assertIn("cp -a /opt/audiveris /opt/clairkeys-audiveris-recovery", dockerfile)
+        self.assertIn("/opt/clairkeys-audiveris-recovery/bin/Audiveris -version", dockerfile)
+        checksum = dockerfile.index('echo "${LEDGERS_POST_ANALYSIS_SHA256}')
+        normalize = dockerfile.index("sed -i 's/\\r$//'", checksum)
+        apply_patch = dockerfile.index('patch --directory=/tmp/audiveris-source', normalize)
+        self.assertLess(checksum, normalize)
+        self.assertLess(normalize, apply_patch)
+        self.assertIn(
+            'Math.floor(info.height) == maxHeight + 1',
+            patch_file.read_text(encoding="utf-8"),
+        )
 
     def test_container_replaces_english_data_with_checksum_pinned_legacy_model(self):
         dockerfile = (OMR_SERVICE_ROOT / "Dockerfile.audiveris").read_text(encoding="utf-8")

--- a/omr-service/tests/test_wedge_reference.py
+++ b/omr-service/tests/test_wedge_reference.py
@@ -1,0 +1,116 @@
+"""Evaluate wedge measure integrity contracts for OMR-Q3."""
+import json
+from pathlib import Path
+import unittest
+
+from omr.recognition_evaluation import evaluate_reference, read_musicxml
+
+
+class WedgeReferenceTests(unittest.TestCase):
+    def setUp(self):
+        self.fixtures = Path(__file__).resolve().parents[2] / 'fixtures' / 'recognition'
+        self.reference = json.loads((self.fixtures / 'wedge-reference.json').read_text())
+
+    def test_baseline_failure_contract(self):
+        # The baseline candidate lacks measure 21 but has measure 22.
+        # This confirms that our evaluation script catches the missing measure.
+        result = evaluate_reference(
+            read_musicxml(self.fixtures / 'wedge-baseline-candidate.xml'),
+            self.reference
+        )
+        self.assertFalse(result['exact'])
+        # Measure 21 should be completely missing, so its match count is 0
+        m21_result = next(r for r in result['measures'] if r['number'] == '21')
+        self.assertEqual(m21_result['matchedEvents'], 0)
+        self.assertEqual(len(m21_result['missing']), 13) # All 13 raw events missing
+
+        # Measure 22 should be perfectly matched; this synthetic m22 agreement validates the comparator/reference, NOT deployed PR144 preservation.
+        m22_result = next(r for r in result['measures'] if r['number'] == '22')
+        self.assertTrue(m22_result['exact'])
+        self.assertEqual(m22_result['matchedEvents'], 10) # 2 whole notes + 8 eighth notes
+
+    def test_positive_control_contract(self):
+        # A perfectly constructed candidate should pass exact match.
+        result = evaluate_reference(
+            read_musicxml(self.fixtures / 'wedge-positive-control.xml'),
+            self.reference
+        )
+        self.assertTrue(result['exact'])
+        self.assertEqual(result['expectedEvents'], 23) # 13 for m21 + 10 for m22
+        self.assertEqual(result['matchedEvents'], 23)
+
+    def test_metadata_regression(self):
+        # Verify that the fixture specifies the correct PDF hash for Love Affair
+        self.assertEqual(
+            self.reference['sourcePdfSha256'],
+            'acdd4ee03f8da75493491f677519dbce4fecf0275b106caf268fa6899ea34253',
+            'Reference must be explicitly linked to Love Affair PDF'
+        )
+
+    def _mutate_positive_control_and_evaluate(self, mutate_fn):
+        import copy
+        root = read_musicxml(self.fixtures / 'wedge-positive-control.xml')
+        mutate_fn(root)
+        return evaluate_reference(root, self.reference)
+
+    def test_negative_mutation_pitch(self):
+        def mutate(root):
+            # Find the first note in m21 and change its pitch step from A to B
+            note = root.find('.//measure[@number="21"]/note/pitch/step')
+            note.text = 'B'
+        result = self._mutate_positive_control_and_evaluate(mutate)
+        self.assertFalse(result['exact'])
+        m21 = next(r for r in result['measures'] if r['number'] == '21')
+        self.assertEqual(m21['matchedEvents'], 12) # 1 of 13 events mismatched
+
+    def test_negative_mutation_onset(self):
+        def mutate(root):
+            # Insert a forward element to shift onset of all following notes
+            import xml.etree.ElementTree as ET
+            measure = root.find('.//measure[@number="21"]')
+            forward = ET.Element('forward')
+            dur = ET.SubElement(forward, 'duration')
+            dur.text = '1' # Shift by 0.5 beats
+            measure.insert(1, forward) # Insert after attributes
+        result = self._mutate_positive_control_and_evaluate(mutate)
+        self.assertFalse(result['exact'])
+
+    def test_negative_mutation_duration(self):
+        def mutate(root):
+            # Change duration of first note from 4 to 2
+            dur = root.find('.//measure[@number="21"]/note/duration')
+            dur.text = '2'
+        result = self._mutate_positive_control_and_evaluate(mutate)
+        self.assertFalse(result['exact'])
+
+    def test_negative_mutation_staff(self):
+        def mutate(root):
+            # Move first note from staff 1 to staff 2
+            staff = root.find('.//measure[@number="21"]/note/staff')
+            staff.text = '2'
+        result = self._mutate_positive_control_and_evaluate(mutate)
+        self.assertFalse(result['exact'])
+
+    def test_negative_mutation_extra_note(self):
+        def mutate(root):
+            import xml.etree.ElementTree as ET
+            # Add an extra invented note to measure 21
+            measure = root.find('.//measure[@number="21"]')
+            note = ET.Element('note')
+            pitch = ET.SubElement(note, 'pitch')
+            step = ET.SubElement(pitch, 'step')
+            step.text = 'C'
+            octave = ET.SubElement(pitch, 'octave')
+            octave.text = '4'
+            duration = ET.SubElement(note, 'duration')
+            duration.text = '2'
+            staff = ET.SubElement(note, 'staff')
+            staff.text = '1'
+            measure.append(note)
+        result = self._mutate_positive_control_and_evaluate(mutate)
+        self.assertFalse(result['exact'])
+        m21 = next(r for r in result['measures'] if r['number'] == '21')
+        self.assertEqual(len(m21['unexpected']), 1)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/omr-service/tests/test_wedge_reference.py
+++ b/omr-service/tests/test_wedge_reference.py
@@ -2,6 +2,7 @@
 import json
 from pathlib import Path
 import unittest
+import xml.etree.ElementTree as ET
 
 from omr.recognition_evaluation import evaluate_reference, read_musicxml
 
@@ -58,6 +59,62 @@ class WedgeReferenceTests(unittest.TestCase):
         self.assertEqual(len(measure['pitchedEvents']), 15)
         self.assertEqual(measure['restEvents'], [
             {'staff': 1, 'onset': 2, 'duration': 0.5},
+        ])
+
+    def _evaluate_rest_contract(self, rest_specs):
+        root = ET.fromstring(
+            '<score-partwise><part id="P1"><measure number="1">'
+            '<attributes><divisions>2</divisions><time><beats>4</beats>'
+            '<beat-type>4</beat-type></time></attributes></measure></part>'
+            '</score-partwise>'
+        )
+        measure = root.find('part/measure')
+        consumed = 0
+        for staff, duration in rest_specs:
+            note = ET.SubElement(measure, 'note')
+            ET.SubElement(note, 'rest')
+            ET.SubElement(note, 'duration').text = str(duration)
+            ET.SubElement(note, 'staff').text = str(staff)
+            consumed += duration
+        forward = ET.SubElement(measure, 'forward')
+        ET.SubElement(forward, 'duration').text = str(8 - consumed)
+        reference = {
+            'timeSignature': '4/4',
+            'measures': [{
+                'number': 1,
+                'quarterLength': 4,
+                'pitchedEvents': [],
+                'restEvents': [{'staff': 1, 'onset': 0, 'duration': 0.5}],
+            }],
+        }
+        return evaluate_reference(root, reference)['measures'][0]
+
+    def test_rest_event_contract_reports_matching_actual_rest(self):
+        result = self._evaluate_rest_contract([(1, 1)])
+
+        self.assertTrue(result['exact'])
+        self.assertEqual(result['matchedRests'], 1)
+        self.assertEqual(result['missingRests'], [])
+        self.assertEqual(result['unexpectedRests'], [])
+
+    def test_rest_event_contract_reports_missing_actual_rest(self):
+        result = self._evaluate_rest_contract([])
+
+        self.assertFalse(result['exact'])
+        self.assertEqual(result['matchedRests'], 0)
+        self.assertEqual(result['missingRests'], [
+            {'staff': 1, 'onset': 0.0, 'duration': 0.5},
+        ])
+        self.assertEqual(result['unexpectedRests'], [])
+
+    def test_rest_event_contract_reports_unexpected_actual_rest(self):
+        result = self._evaluate_rest_contract([(1, 1), (2, 1)])
+
+        self.assertFalse(result['exact'])
+        self.assertEqual(result['matchedRests'], 1)
+        self.assertEqual(result['missingRests'], [])
+        self.assertEqual(result['unexpectedRests'], [
+            {'staff': 2, 'onset': 0.5, 'duration': 0.5},
         ])
 
     def _mutate_positive_control_and_evaluate(self, mutate_fn):

--- a/omr-service/tests/test_wedge_reference.py
+++ b/omr-service/tests/test_wedge_reference.py
@@ -10,6 +10,8 @@ class WedgeReferenceTests(unittest.TestCase):
     def setUp(self):
         self.fixtures = Path(__file__).resolve().parents[2] / 'fixtures' / 'recognition'
         self.reference = json.loads((self.fixtures / 'wedge-reference.json').read_text())
+        self.existing_reference = json.loads(
+            (self.fixtures / 'wedge-existing-ledger-reference.json').read_text())
 
     def test_baseline_failure_contract(self):
         # The baseline candidate lacks measure 21 but has measure 22.
@@ -46,6 +48,17 @@ class WedgeReferenceTests(unittest.TestCase):
             'acdd4ee03f8da75493491f677519dbce4fecf0275b106caf268fa6899ea34253',
             'Reference must be explicitly linked to Love Affair PDF'
         )
+
+    def test_existing_measure_reference_is_source_linked_and_complete(self):
+        self.assertEqual(self.existing_reference['sourcePdfSha256'],
+                         self.reference['sourcePdfSha256'])
+        measure = self.existing_reference['measures'][0]
+        self.assertEqual(measure['number'], 20)
+        self.assertEqual(measure['quarterLength'], 4)
+        self.assertEqual(len(measure['pitchedEvents']), 15)
+        self.assertEqual(measure['restEvents'], [
+            {'staff': 1, 'onset': 2, 'duration': 0.5},
+        ])
 
     def _mutate_positive_control_and_evaluate(self, mutate_fn):
         import copy

--- a/omr-service/tests/test_wedge_retry.py
+++ b/omr-service/tests/test_wedge_retry.py
@@ -405,7 +405,31 @@ class WedgeRetryContractTests(unittest.TestCase):
         self.assertIn('dD.isBlank()', patch_text)
         self.assertIn('"HEIGHT".equals(hH)', patch_text)
         self.assertIn('Math.floor(info.height) == maxHeight + 1', patch_text)
+        self.assertIn('info.ledger.getGlyph() != null', patch_text)
         self.assertNotIn('minLedgerLengthLow=', constant)
+
+    def test_recovery_region_missing_or_non_finite_numbers_fail_closed(self):
+        trigger = detect_wedge_export_loss(score(), self.selected)
+        mutations = {
+            'missing-grade': lambda sheet: sheet.find(
+                ".//head[@id='head-bad']").attrib.pop('grade'),
+            'missing-pitch': lambda sheet: sheet.find(
+                ".//head[@id='head-bad']").attrib.pop('pitch'),
+            'missing-staff-y': lambda sheet: sheet.find(
+                "page/system/part/staff/lines/line/point").attrib.pop('y'),
+            'non-finite-grade': lambda sheet: sheet.find(
+                ".//head[@id='head-bad']").set('grade', 'nan'),
+            'non-finite-pitch': lambda sheet: sheet.find(
+                ".//head[@id='head-bad']").set('pitch', 'inf'),
+            'non-finite-staff-y': lambda sheet: sheet.find(
+                "page/system/part/staff/lines/line/point").set('y', '-inf'),
+        }
+        for name, mutate in mutations.items():
+            sheet = fixture_sheet('selected-sheet.xml')
+            mutate(sheet)
+            graph = archive(self.directory, f'{name}.omr', sheet)
+            with self.subTest(name=name):
+                self.assertIsNone(recovery_region_constant(graph, trigger))
 
     def test_ledger_profile_uses_engine_pixel_quantization_without_fuzzy_tolerance(self):
         profile = [(38 / 21.4375, 7 / 21.4375)]

--- a/omr-service/tests/test_wedge_retry.py
+++ b/omr-service/tests/test_wedge_retry.py
@@ -1,0 +1,527 @@
+import copy
+from collections import Counter
+from fractions import Fraction
+from pathlib import Path
+import tempfile
+import unittest
+import xml.etree.ElementTree as ET
+import zipfile
+
+from PIL import Image, ImageDraw
+
+from omr.recognition_evaluation import read_musicxml
+from omr.wedge_retry import (
+    _ledger_geometry_in_profile,
+    _in_scope_context_preserved,
+    _note_semantics,
+    _ties_preserved,
+    accept_wedge_retry,
+    detect_wedge_export_loss,
+    prepare_wedge_retry,
+    recovery_region_constant,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = ROOT / 'fixtures' / 'recognition' / 'wedge-retry'
+
+
+def score(*, include_target=False):
+    root = ET.Element('score-partwise')
+    part_list = ET.SubElement(root, 'part-list')
+    score_part = ET.SubElement(part_list, 'score-part', id='P1')
+    ET.SubElement(score_part, 'part-name').text = 'Piano'
+    part = ET.SubElement(root, 'part', id='P1')
+    for number in ([1, 2, 3] if include_target else [1, 3]):
+        measure = ET.SubElement(part, 'measure', number=str(number))
+        if number == 1:
+            attributes = ET.SubElement(measure, 'attributes')
+            ET.SubElement(attributes, 'divisions').text = '2'
+            time = ET.SubElement(attributes, 'time')
+            ET.SubElement(time, 'beats').text = '4'
+            ET.SubElement(time, 'beat-type').text = '4'
+            ET.SubElement(attributes, 'staves').text = '2'
+        if number == 2:
+            direction = ET.SubElement(measure, 'direction', placement='below')
+            direction_type = ET.SubElement(direction, 'direction-type')
+            ET.SubElement(direction_type, 'wedge', type='diminuendo', number='1')
+            add_note(measure, 'A', 4, 1, 4, voice='1')
+            backup = ET.SubElement(measure, 'backup')
+            ET.SubElement(backup, 'duration').text = '8'
+            add_note(measure, 'E', 2, 2, 4, voice='5')
+            backup = ET.SubElement(measure, 'backup')
+            ET.SubElement(backup, 'duration').text = '8'
+            rest = ET.SubElement(measure, 'note')
+            ET.SubElement(rest, 'rest')
+            ET.SubElement(rest, 'duration').text = '1'
+            ET.SubElement(rest, 'type').text = 'eighth'
+            ET.SubElement(rest, 'voice').text = '1'
+            ET.SubElement(rest, 'staff').text = '1'
+            forward = ET.SubElement(measure, 'forward')
+            ET.SubElement(forward, 'duration').text = '7'
+            continue
+        note = add_note(measure, 'C' if number == 1 else 'D', 4, 1, 4, voice='1')
+        notations = ET.SubElement(note, 'notations')
+        ET.SubElement(notations, 'slur', type='start' if number == 1 else 'stop', number='1')
+    return root
+
+
+def add_note(measure, step, octave, staff, quarters, *, voice):
+    note = ET.SubElement(measure, 'note')
+    pitch = ET.SubElement(note, 'pitch')
+    ET.SubElement(pitch, 'step').text = step
+    ET.SubElement(pitch, 'octave').text = str(octave)
+    ET.SubElement(note, 'duration').text = str(quarters * 2)
+    ET.SubElement(note, 'type').text = 'whole'
+    ET.SubElement(note, 'voice').text = voice
+    ET.SubElement(note, 'staff').text = str(staff)
+    return note
+
+
+def binary_png(*, include_target=True):
+    image = Image.new('1', (320, 180), 1)
+    draw = ImageDraw.Draw(image)
+    # Existing native ledger and the target's source ledger ink. Coordinates
+    # live only in this synthetic fixture; production discovers them from graph nodes.
+    draw.rectangle((26, 149, 45, 151), fill=0)
+    if include_target:
+        draw.rectangle((126, 149, 145, 151), fill=0)
+    draw.ellipse((30, 145, 43, 155), fill=0)
+    if include_target:
+        draw.ellipse((130, 145, 143, 155), fill=0)
+    draw.rectangle((70, 53, 79, 72), fill=0)
+    draw.rectangle((150, 53, 159, 72), fill=0)
+    with tempfile.NamedTemporaryFile(suffix='.png') as output:
+        image.save(output.name)
+        return Path(output.name).read_bytes()
+
+
+def archive(directory, name, sheet_xml, *, symbols=False, image_bytes=None):
+    path = Path(directory) / name
+    book = ET.parse(FIXTURES / 'book.xml').getroot()
+    if symbols:
+        book.find('sheet/steps').text = (
+            'LOAD BINARY SCALE GRID HEADERS STEM_SEEDS BEAMS LEDGERS HEADS STEMS '
+            'REDUCTION CUE_BEAMS TEXTS MEASURES CHORDS CURVES SYMBOLS')
+    with zipfile.ZipFile(path, 'w', zipfile.ZIP_DEFLATED) as output:
+        output.writestr('book.xml', ET.tostring(book))
+        output.writestr('sheet#1/sheet#1.xml', ET.tostring(sheet_xml))
+        output.writestr('sheet#1/BINARY.png', image_bytes or binary_png())
+    return path
+
+
+def fixture_sheet(name):
+    return ET.parse(FIXTURES / name).getroot()
+
+
+def candidate_sheet():
+    sheet = fixture_sheet('selected-sheet.xml')
+    sig = sheet.find('page/system/sig')
+    inters = sig.find('inters')
+    staff = sheet.find("page/system/part/staff[@id='2']")
+    staff.find("ledgers/ledgers-entry[@index='1']").text += ' ledger-target'
+    head = sheet.find(".//head[@id='head-bad']")
+    head.set('pitch', '6')
+    head.set('grade', '0.70')
+    head.set('glyph', 'glyph-head-corrected')
+    head.attrib.pop('abnormal')
+    head.find('bounds').set('y', '145')
+    dot = sheet.find(".//augmentation-dot[@id='false-dot']")
+    inters.remove(dot)
+    relations = sig.find('relations')
+    for relation in list(relations):
+        if relation.get('source') == 'false-dot':
+            relations.remove(relation)
+    ledger = ET.fromstring(
+        '<ledger thickness="3" shape="LEDGER" glyph="glyph-ledger-target" grade="0.72" '
+        'staff="2" id="ledger-target"><bounds x="126" y="149" w="20" h="3"/>'
+        '<median><p1 x="126" y="150"/><p2 x="146" y="150"/></median></ledger>')
+    inters.insert(0, ledger)
+    glyph = ET.fromstring(
+        '<glyph left="126" top="149" id="glyph-ledger-target"><run-table orientation="HORIZONTAL" width="20" height="3">'
+        '<runs>20</runs><runs>20</runs><runs>20</runs></run-table></glyph>')
+    sheet.find('glyph-index').append(glyph)
+    sheet.find('glyph-index').append(ET.fromstring(
+        '<glyph left="130" top="145" id="glyph-head-corrected"><run-table orientation="VERTICAL" width="12" height="11">'
+        '<runs>3 5 3</runs><runs>2 7 2</runs><runs>1 9 1</runs><runs>1 9 1</runs>'
+        '<runs>1 9 1</runs><runs>1 9 1</runs><runs>1 9 1</runs><runs>2 7 2</runs>'
+        '<runs>3 5 3</runs><runs>11</runs><runs>11</runs><runs>11</runs></run-table></glyph>'))
+    rest = ET.fromstring(
+        '<rest pitch="-0.5" shape="EIGHTH_REST" glyph="glyph-rest-target" grade="0.36" '
+        'staff="1" frozen="true" id="rest-target"><bounds x="150" y="53" w="10" h="20"/></rest>')
+    rest_chord = ET.fromstring(
+        '<rest-chord grade="0.36" staff="1" frozen="true" id="rest-chord-target">'
+        '<bounds x="150" y="53" w="10" h="20"/></rest-chord>')
+    inters.append(rest)
+    inters.append(rest_chord)
+    sheet.find('glyph-index').append(ET.fromstring(
+        '<glyph left="150" top="53" id="glyph-rest-target"><run-table orientation="VERTICAL" width="10" height="20">'
+        '<runs>20</runs><runs>20</runs><runs>20</runs><runs>20</runs><runs>20</runs>'
+        '<runs>20</runs><runs>20</runs><runs>20</runs><runs>20</runs><runs>20</runs>'
+        '</run-table></glyph>'))
+    relations.append(ET.fromstring(
+        '<relation source="rest-chord-target" target="rest-target"><containment/></relation>'))
+    measure = sheet.find("page/system/part/measure[@id='2']")
+    measure.attrib.pop('abnormal')
+    sheet.find("page/system/stack[@id='2']").set('duration', '1')
+    voices = {voice.get('id'): voice for voice in measure.findall('voice')}
+    bass_slots = ET.SubElement(voices['5'], 'slots')
+    bass_slots.append(ET.fromstring(
+        '<entry><key>1</key><value status="BEGIN" chord="chord-target"/></entry>'))
+    treble_slots = ET.SubElement(voices['1'], 'slots')
+    treble_slots.append(ET.fromstring(
+        '<entry><key>1</key><value status="BEGIN" chord="chord-target-2"/></entry>'))
+    ET.SubElement(measure, 'rest-chords').text = 'rest-chord-target'
+    return sheet
+
+
+class WedgeRetryContractTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.directory = Path(self.temporary.name)
+        self.selected = archive(
+            self.directory, 'selected.omr', fixture_sheet('selected-sheet.xml'))
+
+    def test_trigger_requires_one_missing_measure_and_null_time_wedge(self):
+        trigger = detect_wedge_export_loss(score(), self.selected)
+        self.assertIsNotNone(trigger)
+        self.assertEqual((trigger.sheet_number, trigger.system_index, trigger.stack_index), (1, 1, 2))
+        self.assertEqual(trigger.measure_number, 2)
+
+    def test_missing_measure_without_null_time_wedge_abstains(self):
+        sheet = fixture_sheet('selected-sheet.xml')
+        relations = sheet.find('page/system/sig/relations')
+        for relation in list(relations):
+            if relation.find('chord-wedge') is not None:
+                relations.remove(relation)
+        graph = archive(self.directory, 'no-wedge.omr', sheet)
+        self.assertIsNone(detect_wedge_export_loss(score(), graph))
+
+    def test_multiple_export_gaps_abstain_even_with_one_wedge(self):
+        original = score()
+        part = original.find('part')
+        part.remove(part.find("measure[@number='3']"))
+        self.assertIsNone(detect_wedge_export_loss(original, self.selected))
+
+    def test_non_four_four_export_gap_abstains(self):
+        original = score()
+        original.find('part/measure/attributes/time/beats').text = '3'
+        self.assertIsNone(detect_wedge_export_loss(original, self.selected))
+
+    def test_duplicate_graph_ids_fail_closed(self):
+        sheet = fixture_sheet('selected-sheet.xml')
+        duplicate = copy.deepcopy(sheet.find(".//head[@id='head-bad']"))
+        sheet.find('page/system/sig').append(duplicate)
+        graph = archive(self.directory, 'duplicate.omr', sheet)
+        self.assertIsNone(detect_wedge_export_loss(score(), graph))
+
+    def test_prepare_freezes_only_engine_rest_in_target_stack(self):
+        symbols = archive(
+            self.directory, 'symbols.omr', fixture_sheet('symbols-sheet.xml'), symbols=True)
+        prepared = self.directory / 'prepared.omr'
+        trigger = detect_wedge_export_loss(score(), self.selected)
+        evidence = prepare_wedge_retry(symbols, self.selected, prepared, trigger)
+        self.assertIsNotNone(evidence)
+        self.assertEqual(evidence.frozen_rest_ids, ('rest-target',))
+        with zipfile.ZipFile(prepared) as result:
+            sheet = ET.fromstring(result.read('sheet#1/sheet#1.xml'))
+        self.assertEqual(sheet.find(".//rest[@id='rest-target']").get('frozen'), 'true')
+        self.assertEqual(sheet.find(".//rest-chord[@id='rest-chord-target']").get('frozen'), 'true')
+        self.assertIsNone(sheet.find(".//rest[@id='rest-other']").get('frozen'))
+
+    def test_candidate_requires_native_source_backed_ledger_and_false_dot_removal(self):
+        symbols = archive(
+            self.directory, 'symbols.omr', fixture_sheet('symbols-sheet.xml'), symbols=True)
+        prepared = self.directory / 'prepared.omr'
+        trigger = detect_wedge_export_loss(score(), self.selected)
+        evidence = prepare_wedge_retry(symbols, self.selected, prepared, trigger)
+        candidate = archive(self.directory, 'candidate.omr', candidate_sheet())
+        self.assertTrue(accept_wedge_retry(
+            score(), score(include_target=True), self.selected, candidate, evidence))
+
+        cache_group = candidate_sheet()
+        cache_group.find(".//glyph[@id='glyph-head-ledger-ok']").attrib.pop('groups')
+        cache_group_graph = archive(self.directory, 'candidate-cache-group.omr', cache_group)
+        self.assertTrue(accept_wedge_retry(
+            score(), score(include_target=True), self.selected, cache_group_graph, evidence))
+
+        no_ledger = candidate_sheet()
+        ledger = no_ledger.find(".//ledger[@id='ledger-target']")
+        no_ledger.find('page/system/sig/inters').remove(ledger)
+        missing = archive(self.directory, 'candidate-no-ledger.omr', no_ledger)
+        self.assertFalse(accept_wedge_retry(
+            score(), score(include_target=True), self.selected, missing, evidence))
+
+        changed_head = candidate_sheet()
+        changed_head.find(".//head[@id='head-target-2']").set('pitch', '2')
+        changed_graph = archive(self.directory, 'candidate-other-head.omr', changed_head)
+        changed_score = score(include_target=True)
+        changed_score.find(
+            "part/measure[@number='2']/note[staff='1']/pitch/step").text = 'G'
+        self.assertFalse(accept_wedge_retry(
+            score(), changed_score, self.selected, changed_graph, evidence))
+
+    def test_out_of_scope_direction_change_is_rejected(self):
+        symbols = archive(
+            self.directory, 'symbols.omr', fixture_sheet('symbols-sheet.xml'), symbols=True)
+        trigger = detect_wedge_export_loss(score(), self.selected)
+        evidence = prepare_wedge_retry(
+            symbols, self.selected, self.directory / 'prepared.omr', trigger)
+        candidate_root = score(include_target=True)
+        direction = ET.SubElement(candidate_root.find("part/measure[@number='1']"), 'direction')
+        ET.SubElement(ET.SubElement(direction, 'direction-type'), 'words').text = 'changed'
+        candidate = archive(self.directory, 'candidate.omr', candidate_sheet())
+        self.assertFalse(accept_wedge_retry(
+            score(), candidate_root, self.selected, candidate, evidence))
+
+        candidate_root = score(include_target=True)
+        candidate_root.find('part-list/score-part/part-name').text = 'Changed'
+        self.assertFalse(accept_wedge_retry(
+            score(), candidate_root, self.selected, candidate, evidence))
+
+        original_with_articulation = score()
+        notations = original_with_articulation.find(
+            "part/measure[@number='1']/note/notations")
+        articulations = ET.SubElement(notations, 'articulations')
+        ET.SubElement(articulations, 'tenuto', placement='above')
+        self.assertFalse(accept_wedge_retry(
+            original_with_articulation, score(include_target=True),
+            self.selected, candidate, evidence))
+
+    def test_target_musicxml_must_match_native_graph_pitch_staff_onset_and_duration(self):
+        symbols = archive(
+            self.directory, 'symbols.omr', fixture_sheet('symbols-sheet.xml'), symbols=True)
+        trigger = detect_wedge_export_loss(score(), self.selected)
+        evidence = prepare_wedge_retry(
+            symbols, self.selected, self.directory / 'prepared.omr', trigger)
+        candidate_graph = archive(self.directory, 'candidate.omr', candidate_sheet())
+        mutations = {
+            'pitch': lambda root: setattr(
+                root.find("part/measure[@number='2']/note[staff='2']/pitch/step"), 'text', 'F'),
+            'staff': lambda root: setattr(
+                root.find("part/measure[@number='2']/note[staff='2']/staff"), 'text', '1'),
+            'duration': lambda root: setattr(
+                root.find("part/measure[@number='2']/note[staff='2']/duration"), 'text', '6'),
+            'onset': lambda root: root.find("part/measure[@number='2']").insert(
+                1, ET.fromstring('<forward><duration>1</duration></forward>')),
+        }
+        for name, mutate in mutations.items():
+            candidate = score(include_target=True)
+            mutate(candidate)
+            with self.subTest(name=name):
+                self.assertFalse(accept_wedge_retry(
+                    score(), candidate, self.selected, candidate_graph, evidence))
+
+    def test_bogus_glyph_absent_source_ink_and_unrelated_graph_change_are_rejected(self):
+        symbols = archive(
+            self.directory, 'symbols.omr', fixture_sheet('symbols-sheet.xml'), symbols=True)
+        trigger = detect_wedge_export_loss(score(), self.selected)
+        evidence = prepare_wedge_retry(
+            symbols, self.selected, self.directory / 'prepared.omr', trigger)
+        bogus = candidate_sheet()
+        table = bogus.find(".//glyph[@id='glyph-ledger-target']/run-table")
+        table.set('width', '1')
+        table.set('height', '1')
+        for child in list(table):
+            table.remove(child)
+        ET.SubElement(table, 'runs').text = '1'
+        bogus_graph = archive(self.directory, 'bogus.omr', bogus)
+        self.assertFalse(accept_wedge_retry(
+            score(), score(include_target=True), self.selected, bogus_graph, evidence))
+
+        no_ink_graph = archive(
+            self.directory, 'no-ink.omr', candidate_sheet(),
+            image_bytes=binary_png(include_target=False))
+        self.assertFalse(accept_wedge_retry(
+            score(), score(include_target=True), self.selected, no_ink_graph, evidence))
+
+        unrelated = candidate_sheet()
+        unrelated.find('page/system/sig/inters').append(ET.fromstring(
+            '<rest pitch="0" shape="QUARTER_REST" grade="0.8" staff="1" id="unrelated">'
+            '<bounds x="230" y="50" w="10" h="20"/></rest>'))
+        unrelated_graph = archive(self.directory, 'unrelated.omr', unrelated)
+        self.assertFalse(accept_wedge_retry(
+            score(), score(include_target=True), self.selected, unrelated_graph, evidence))
+
+        outside_pitch = candidate_sheet()
+        outside_pitch.find(".//head[@id='head-ledger-ok']").set('pitch', '7')
+        outside_pitch_graph = archive(self.directory, 'outside-pitch.omr', outside_pitch)
+        self.assertFalse(accept_wedge_retry(
+            score(), score(include_target=True), self.selected, outside_pitch_graph, evidence))
+
+        outside_ink = candidate_sheet()
+        outside_ink.find(
+            ".//glyph[@id='glyph-head-ledger-ok']/run-table/runs").text = '11'
+        outside_ink_graph = archive(self.directory, 'outside-ink.omr', outside_ink)
+        self.assertFalse(accept_wedge_retry(
+            score(), score(include_target=True), self.selected, outside_ink_graph, evidence))
+
+        free_ink = candidate_sheet()
+        free_ink.find(".//glyph[@id='glyph-free']/run-table/runs").text = '5 5'
+        free_ink_graph = archive(self.directory, 'free-ink.omr', free_ink)
+        self.assertFalse(accept_wedge_retry(
+            score(), score(include_target=True), self.selected, free_ink_graph, evidence))
+
+        free_group = candidate_sheet()
+        free_group.find(".//glyph[@id='glyph-free']").attrib.pop('groups')
+        free_group_graph = archive(self.directory, 'free-group.omr', free_group)
+        self.assertFalse(accept_wedge_retry(
+            score(), score(include_target=True), self.selected, free_group_graph, evidence))
+
+        outside_relation = candidate_sheet()
+        relation = next(item for item in outside_relation.findall('.//relation')
+                        if item.get('source') == 'chord-ledger-ok')
+        relation.set('target', 'head-target-2')
+        outside_relation_graph = archive(
+            self.directory, 'outside-relation.omr', outside_relation)
+        self.assertFalse(accept_wedge_retry(
+            score(), score(include_target=True), self.selected, outside_relation_graph, evidence))
+
+    def test_slur_number_regeneration_is_allowed_but_endpoint_change_is_not(self):
+        symbols = archive(
+            self.directory, 'symbols.omr', fixture_sheet('symbols-sheet.xml'), symbols=True)
+        trigger = detect_wedge_export_loss(score(), self.selected)
+        evidence = prepare_wedge_retry(
+            symbols, self.selected, self.directory / 'prepared.omr', trigger)
+        candidate_graph = archive(self.directory, 'candidate.omr', candidate_sheet())
+        renumbered = score(include_target=True)
+        for slur in renumbered.findall('.//slur'):
+            slur.set('number', '9')
+        self.assertTrue(accept_wedge_retry(
+            score(), renumbered, self.selected, candidate_graph, evidence))
+        renumbered.find("part/measure[@number='3']/note/notations/slur").set('type', 'start')
+        self.assertFalse(accept_wedge_retry(
+            score(), renumbered, self.selected, candidate_graph, evidence))
+
+    def test_recovery_region_is_graph_derived_and_post_boundary_is_exact(self):
+        trigger = detect_wedge_export_loss(score(), self.selected)
+        constant = recovery_region_constant(self.selected, trigger)
+        self.assertTrue(constant.startswith(
+            'org.audiveris.omr.sheet.ledger.LedgersPostAnalysis.recoveryRegions='))
+        self.assertIn('1,1,', constant)
+        patch_text = (ROOT / 'omr-service/audiveris-patches/'
+                      '0001-region-scoped-ledger-recovery.patch').read_text()
+        self.assertIn('dD.isBlank()', patch_text)
+        self.assertIn('"HEIGHT".equals(hH)', patch_text)
+        self.assertIn('Math.floor(info.height) == maxHeight + 1', patch_text)
+        self.assertNotIn('minLedgerLengthLow=', constant)
+
+    def test_ledger_profile_uses_engine_pixel_quantization_without_fuzzy_tolerance(self):
+        profile = [(38 / 21.4375, 7 / 21.4375)]
+        self.assertTrue(_ledger_geometry_in_profile(38, 7, 21.5, profile))
+        self.assertFalse(_ledger_geometry_in_profile(37, 7, 21.5, profile))
+        self.assertFalse(_ledger_geometry_in_profile(40, 7, 21.5, profile))
+        self.assertFalse(_ledger_geometry_in_profile(38, 9, 21.5, profile))
+
+    def test_tie_pair_endpoints_survive_corrected_onset_and_voice(self):
+        old_anchor = (20, ('A', 0, 4), 1, '2', Fraction(11, 4), Fraction(1, 2), 0)
+        new_anchor = (20, ('A', 0, 4), 1, '1', Fraction(5, 2), Fraction(1, 2), 0)
+        original = Counter({('tie', 'start', old_anchor, ()): 1})
+        candidate = Counter({('tie', 'start', new_anchor, ()): 1})
+        self.assertTrue(_ties_preserved(original, candidate, {20, 21}))
+        changed_pitch = (20, ('B', 0, 4), 1, '1', Fraction(5, 2), Fraction(1, 2), 0)
+        self.assertFalse(_ties_preserved(
+            original, Counter({('tie', 'start', changed_pitch, ()): 1}), {20, 21}))
+
+    def test_direction_cursor_may_only_follow_the_same_native_chord(self):
+        def timeline(first_duration, *, gap_after_direction=False):
+            root = score()
+            measure = root.find("part/measure[@number='1']")
+            attributes = measure.find('attributes')
+            for child in list(measure):
+                if child is not attributes:
+                    measure.remove(child)
+            add_note(measure, 'C', 4, 1, first_duration / 2, voice='1')
+            direction = ET.SubElement(measure, 'direction')
+            direction_type = ET.SubElement(direction, 'direction-type')
+            ET.SubElement(direction_type, 'wedge', type='diminuendo', spread='15')
+            ET.SubElement(direction, 'staff').text = '1'
+            if gap_after_direction:
+                forward = ET.SubElement(measure, 'forward')
+                ET.SubElement(forward, 'duration').text = '1'
+            remaining = 8 - first_duration - (1 if gap_after_direction else 0)
+            add_note(measure, 'D', 4, 1, remaining / 2, voice='1')
+            return root
+
+        original = timeline(2)
+        corrected = timeline(1)
+        self.assertTrue(_in_scope_context_preserved(original, corrected, 1))
+        self.assertFalse(_in_scope_context_preserved(
+            original, timeline(1, gap_after_direction=True), 1))
+
+    def test_ordered_note_metadata_cannot_move_between_repeated_notes(self):
+        original = score()
+        measure = original.find("part/measure[@number='1']")
+        first = measure.find('note')
+        second = copy.deepcopy(first)
+        measure.append(second)
+        articulations = ET.SubElement(first.find('notations'), 'articulations')
+        ET.SubElement(articulations, 'tenuto')
+        candidate = copy.deepcopy(original)
+        candidate_notes = candidate.findall("part/measure[@number='1']/note")
+        candidate_notes[0].find('notations').remove(
+            candidate_notes[0].find('notations/articulations'))
+        moved = ET.SubElement(candidate_notes[1].find('notations'), 'articulations')
+        ET.SubElement(moved, 'tenuto')
+        self.assertNotEqual(_note_semantics(original, 1), _note_semantics(candidate, 1))
+
+    def test_retained_native_love_triggers_and_controls_abstain(self):
+        retained = ROOT / 'local-test-data' / 'results' / 'whole-note-integrity'
+        cases = {
+            'love': retained / 'wrapper-final-love/whole-note-retry-gsmt1hik/solo.mxl',
+            'satie': retained / 'wrapper-satie/satie-gymnopedie-1.mxl',
+            'goodsatie': retained / 'wrapper-satie-good/Premiere_Gymnopedie_300dpi.mxl',
+            'always': retained / 'wrapper-always/Always_With_Me_2pages_300dpi.mxl',
+        }
+        if not all(path.is_file() and path.with_suffix('.omr').is_file()
+                   for path in cases.values()):
+            self.skipTest('retained native selected-result pairs are not present')
+        self.assertEqual(
+            detect_wedge_export_loss(
+                read_musicxml(cases['love']), cases['love'].with_suffix('.omr')).measure_number,
+            21,
+        )
+        love_trigger = detect_wedge_export_loss(
+            read_musicxml(cases['love']), cases['love'].with_suffix('.omr'))
+        region = recovery_region_constant(cases['love'].with_suffix('.omr'), love_trigger)
+        encoded = region.split('=', 1)[1].split(';')
+        self.assertEqual(len(encoded), 2)
+        self.assertTrue(all(item.startswith('2,2,') for item in encoded))
+        for name in ('satie', 'goodsatie', 'always'):
+            with self.subTest(name=name):
+                self.assertIsNone(detect_wedge_export_loss(
+                    read_musicxml(cases[name]), cases[name].with_suffix('.omr')))
+
+    def test_retained_native_symbols_select_both_source_defect_rests(self):
+        selected = (ROOT / 'local-test-data/results/whole-note-integrity/'
+                    'wrapper-final-love/whole-note-retry-gsmt1hik/solo.mxl')
+        symbols = (ROOT / 'local-test-data/results/wedge-integrity/stage-probe-2026-09-06/'
+                   'wedge-stage-331NZG/stage-SYMBOLS/solo.omr')
+        if not selected.is_file() or not selected.with_suffix('.omr').is_file() or not symbols.is_file():
+            self.skipTest('retained native SYMBOLS lineage is not present')
+        trigger = detect_wedge_export_loss(read_musicxml(selected), selected.with_suffix('.omr'))
+        evidence = prepare_wedge_retry(
+            symbols, selected.with_suffix('.omr'), self.directory / 'native-prepared.omr', trigger)
+        self.assertEqual(evidence.eligible_measure_numbers, (20, 21))
+        self.assertEqual(len(evidence.rests), 2)
+
+    def test_retained_post_boundary_native_candidate_is_accepted(self):
+        directory = (ROOT / 'local-test-data/results/wedge-implementation-sol/native-postfix/'
+                     'wedge-postfix-case-7PgBRB')
+        paths = [directory / name for name in (
+            'selected-love.mxl', 'selected-love.omr', 'symbols.omr',
+            'love-page/love.mxl', 'love-page/love.omr')]
+        if not all(path.is_file() for path in paths):
+            self.skipTest('retained final post-boundary native candidate is not present')
+        original_xml, original_graph, symbols, candidate_xml, candidate_graph = paths
+        original = read_musicxml(original_xml)
+        trigger = detect_wedge_export_loss(original, original_graph)
+        evidence = prepare_wedge_retry(
+            symbols, original_graph, self.directory / 'post-native-prepared.omr', trigger)
+        self.assertTrue(accept_wedge_retry(
+            original, read_musicxml(candidate_xml), original_graph, candidate_graph, evidence))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/omr-service/tests/test_wedge_retry_runtime.py
+++ b/omr-service/tests/test_wedge_retry_runtime.py
@@ -1,0 +1,168 @@
+import asyncio
+from pathlib import Path
+import tempfile
+from time import monotonic
+import unittest
+from unittest.mock import AsyncMock, patch
+import xml.etree.ElementTree as ET
+
+from omr.audiveris import AudiverisProcessor
+from test_audiveris_runtime import HangingProcess, SuccessfulProcess
+from test_wedge_retry import archive, candidate_sheet, fixture_sheet, score
+
+
+class WedgeRetryRuntimeTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.directory = Path(self.temporary.name)
+        self.pdf = self.directory / 'input.pdf'
+        self.pdf.write_bytes(b'%PDF source')
+        self.original = self.directory / 'input.xml'
+        self.original.write_bytes(ET.tostring(score()))
+        archive(self.directory, 'input.omr', fixture_sheet('selected-sheet.xml'))
+        self.processor = AudiverisProcessor()
+
+    def run_retry(self, deadline=None, family='Leland'):
+        return asyncio.run(self.processor._maybe_retry_wedge(
+            self.original, self.pdf, self.directory,
+            deadline if deadline is not None else monotonic() + 5,
+            family,
+        ))
+
+    async def native_candidate(self, *command, **kwargs):
+        output = Path(command[command.index('-output') + 1])
+        step = command[command.index('-step') + 1]
+        if step == 'SYMBOLS':
+            archive(output, 'input.omr', fixture_sheet('symbols-sheet.xml'), symbols=True)
+        else:
+            (output / 'input.xml').write_bytes(ET.tostring(score(include_target=True)))
+            archive(output, 'input.omr', candidate_sheet())
+        return SuccessfulProcess()
+
+    def test_success_runs_scoped_symbols_then_stock_page(self):
+        original_xml = self.original.read_bytes()
+        original_graph = self.original.with_suffix('.omr').read_bytes()
+        with patch('omr.audiveris.asyncio.create_subprocess_exec',
+                   side_effect=self.native_candidate) as create:
+            result = self.run_retry()
+        self.assertNotEqual(result, self.original)
+        self.assertEqual(self.original.read_bytes(), original_xml)
+        self.assertEqual(self.original.with_suffix('.omr').read_bytes(), original_graph)
+        self.assertEqual(create.call_count, 2)
+        symbols, page = (call.args for call in create.call_args_list)
+        self.assertEqual(symbols[0], str(self.processor.audiveris_recovery_executable))
+        self.assertIn('org.audiveris.omr.ui.symbol.MusicFont.defaultMusicFamily=Leland', symbols)
+        self.assertTrue(any(
+            arg.startswith('org.audiveris.omr.sheet.ledger.LedgersPostAnalysis.recoveryRegions=')
+            for arg in symbols))
+        self.assertFalse(any('LedgersBuilder.maxThicknessHigh=' in arg for arg in symbols))
+        self.assertFalse(any('LedgersBuilder.maxThicknessHigh=' in arg for arg in page))
+        self.assertEqual(page[0], str(self.processor.audiveris_executable))
+        self.assertEqual(symbols[-1], str(self.pdf))
+        self.assertTrue(str(result.parent).startswith(str(self.directory / 'wedge-retry-')))
+
+    def test_complete_export_and_multiple_gap_controls_never_spawn(self):
+        cases = [score(include_target=True), score()]
+        cases[1].find('part').remove(cases[1].find("part/measure[@number='3']"))
+        for index, root in enumerate(cases):
+            self.original.write_bytes(ET.tostring(root))
+            with self.subTest(index=index), patch(
+                    'omr.audiveris.asyncio.create_subprocess_exec') as create:
+                self.assertEqual(self.run_retry(), self.original)
+                create.assert_not_called()
+
+    def test_rejected_native_candidate_preserves_selected_result(self):
+        async def changed_direction(*command, **kwargs):
+            output = Path(command[command.index('-output') + 1])
+            step = command[command.index('-step') + 1]
+            if step == 'SYMBOLS':
+                archive(output, 'input.omr', fixture_sheet('symbols-sheet.xml'), symbols=True)
+            else:
+                candidate = score(include_target=True)
+                direction = ET.SubElement(candidate.find("part/measure[@number='1']"), 'direction')
+                ET.SubElement(ET.SubElement(direction, 'direction-type'), 'words').text = 'changed'
+                (output / 'input.xml').write_bytes(ET.tostring(candidate))
+                archive(output, 'input.omr', candidate_sheet())
+            return SuccessfulProcess()
+
+        with patch('omr.audiveris.asyncio.create_subprocess_exec', side_effect=changed_direction):
+            self.assertEqual(self.run_retry(), self.original)
+
+    def test_exhausted_budget_does_not_spawn(self):
+        with patch('omr.audiveris.asyncio.create_subprocess_exec') as create:
+            self.assertEqual(self.run_retry(monotonic() - 1), self.original)
+            create.assert_not_called()
+
+    def test_timeout_kills_candidate_and_preserves_selected_result(self):
+        process = HangingProcess()
+        with patch('omr.audiveris.asyncio.create_subprocess_exec',
+                   new=AsyncMock(return_value=process)):
+            self.assertEqual(self.run_retry(monotonic() + .02), self.original)
+        self.assertTrue(process.killed)
+        self.assertTrue(process.waited)
+
+    def test_expiration_during_acceptance_keeps_selected_result(self):
+        expired = False
+
+        def clock():
+            return 2 if expired else 0
+
+        def accept(*args):
+            nonlocal expired
+            expired = True
+            return True
+
+        with patch('omr.audiveris.asyncio.create_subprocess_exec',
+                   side_effect=self.native_candidate), patch(
+                       'omr.audiveris.accept_wedge_retry', side_effect=accept), patch(
+                       'omr.audiveris.monotonic', side_effect=clock):
+            self.assertEqual(self.run_retry(deadline=1), self.original)
+
+    def test_page_stage_cancellation_kills_candidate_and_propagates(self):
+        page_process = HangingProcess()
+        calls = 0
+
+        async def processes(*command, **kwargs):
+            nonlocal calls
+            calls += 1
+            output = Path(command[command.index('-output') + 1])
+            if calls == 1:
+                archive(output, 'input.omr', fixture_sheet('symbols-sheet.xml'), symbols=True)
+                return SuccessfulProcess()
+            return page_process
+
+        async def run():
+            task = asyncio.create_task(self.processor._maybe_retry_wedge(
+                self.original, self.pdf, self.directory, monotonic() + 5, 'Leland'))
+            await page_process.communicate_started.wait()
+            task.cancel()
+            with self.assertRaises(asyncio.CancelledError):
+                await task
+
+        with patch('omr.audiveris.asyncio.create_subprocess_exec', side_effect=processes):
+            asyncio.run(run())
+        self.assertEqual(calls, 2)
+        self.assertTrue(page_process.killed)
+        self.assertTrue(page_process.waited)
+
+    def test_cancellation_kills_candidate_and_propagates(self):
+        process = HangingProcess()
+
+        async def run():
+            task = asyncio.create_task(self.processor._maybe_retry_wedge(
+                self.original, self.pdf, self.directory, monotonic() + 5, 'Leland'))
+            await process.communicate_started.wait()
+            task.cancel()
+            with self.assertRaises(asyncio.CancelledError):
+                await task
+
+        with patch('omr.audiveris.asyncio.create_subprocess_exec',
+                   new=AsyncMock(return_value=process)):
+            asyncio.run(run())
+        self.assertTrue(process.killed)
+        self.assertTrue(process.waited)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/utils/__tests__/omrRuntimeContract.test.ts
+++ b/src/utils/__tests__/omrRuntimeContract.test.ts
@@ -14,6 +14,9 @@ describe('OMR processor and recognition evaluation contracts', () => {
     'test_time_numeral.py',
     'test_whole_note_retry.py',
     'test_whole_note_retry_runtime.py',
+    'test_wedge_reference.py',
+    'test_wedge_retry.py',
+    'test_wedge_retry_runtime.py',
   ])('passes %s', (suite) => {
     // unittest discovery exits successfully even when a named suite is absent.
     expect(existsSync(path.join(OMR_DIR, 'tests', suite))).toBe(true)


### PR DESCRIPTION
Audiveris can remove an entire recognized measure when a missing rest leaves a wedge endpoint without a time offset. This change recovers that measure from source-backed native symbols: a candidate-only post-analysis exception retains an evidenced ledger at the one-pixel height boundary, and a copied SYMBOLS checkpoint retains the engine-classified rests before stock PAGE processing.

The normal executable stays unchanged. The retry shares the original concurrency limit and deadline, preserves the selected result on rejection, and accepts only source-backed head correspondence plus existing event, notation, direction, tie, slur, image and graph preservation. D-054 records the policy; original PDF and private diagnostic artifacts are excluded from this PR.

Validation:
- Actual isolated `AudiverisProcessor.process_pdf` selects recovery: measure21 13/13; measure20 15/15 plus its printed rest; measure22 10/10, all exact4-quarter measures.
- Four no-region native controls (Love, Satie, good-Satie, Always) preserve live graphs and immutable entries.
- 149 Python tests pass; 102 Jest suites/977 tests pass; separate type, lint and build checks pass.
- The exact Dockerfile checksum/CRLF-normalization/GNU-patch/javac path produces byte-identical classes to the tested engine.

Risk and rollback: this adds a tightly guarded optional native retry and a separately packaged recovery executable. Unsupported or ambiguous inputs retain the earlier selected result. Reverting this change restores the prior retry chain; no production deployment, storage migration or stored-score rewrite is included.

Evidence: docs/recovery/validation/2026-09-06-wedge-implementation.md. Overall musical accuracy beyond the defined wedge/ledger/rest defect remains outside this phase.
