### PR TITLE
Keep a pause inside the practice session instead of ending it

### DIFF
--- a/docs/recovery/DECISIONS.md
+++ b/docs/recovery/DECISIONS.md
@@ -2112,3 +2112,68 @@
   phase completion을 낮추지 않는다. stack ID는 sheet/system namespace 없이 비교하지 않는다.
 - Related: D-048; D-052; D-053; OMR-Q3-wedge-export-integrity;
   validation/2026-09-06-wedge-native-resume.md
+
+## D-056: 재생 화면의 주인은 `isPlaying`이 아니라 연습 세션이다 — 일시정지는 세션 안의 사건이다
+
+- Date: 2026-09-08
+- Status: Accepted
+- Note: D-055는 철회된 PR #147 브랜치에서 할당됐고 `main`에 병합되지 않았다. `reviews/PR-147.md`가
+  그 번호로 다른 결정을 지칭하므로 재사용하지 않고 D-056으로 건너뛴다.
+- Context:
+  - 이슈 [#146](https://github.com/landfill/ClairKeys/issues/146) 항목 6은 "재생하면 헤더 없는 집중
+    화면으로 바뀌고 일시정지하면 다시 설명이 긴 상세 화면으로 돌아간다. 같은 컨트롤의 위치와 모양도
+    크게 바뀐다"고 보고했다.
+  - 원인은 취향이 아니라 **상태 모델**이다. `isPlaying` 하나가 서로 다른 네 가지를 동시에 몰고 있었다:
+    오디오, `usePlaybackOrientation`의 engage, 페이지 chrome(`onPlaybackChange` → `PageHeader`·악보
+    정보 카드), 그리고 박스 높이(`boxHeight` ↔ 고정 330px).
+  - 그래서 일시정지 한 번이 **연습을 그만둔 것과 정확히 같은 동작**을 했다. 폰이 세로로 되돌아가고,
+    페이지가 재구성되고, 한 줄 바(⏸️가 맨 왼쪽)가 3행 블록(재생이 3열 그리드의 1번)으로 교체된다.
+    재개하려면 방금 손가락이 있던 자리가 아닌 곳에서 버튼을 다시 찾아야 한다.
+  - D-019 결정 6은 "회전은 컨트롤 압축을 반드시 동반한다"고 정했다. 그 결정은 **재생 중**을 기준으로
+    썼고 일시정지를 따로 다루지 않았다 — 압축 바가 일시정지를 넘겨 살아남아야 하는지는 미정이었다.
+- Decision:
+  1. `useFallingNotesPlayer`가 `isSessionActive`를 함께 소유한다. `play()`가 실제로 시작에 성공하면
+     열리고, **stop에서만** 닫힌다 — 사용자의 정지와 곡 끝의 auto-stop 둘 다 stop이다. `pause`는
+     세션을 닫지 않는다.
+  2. 화면·회전·페이지 chrome은 전부 `isSessionActive`를 읽는다. `isPlaying`은 이제 **소리가 나는지**
+     하나만 뜻하며, 압축 바의 트랜스포트 토글에만 쓰인다.
+  3. `CompactPlaybackBar`의 첫 슬롯은 같은 자리에서 ⏸️ ↔ ▶️로 토글한다. 크기·위치·나머지 컨트롤
+     순서는 바꾸지 않는다. 일시정지 중에도 seek, A-B, 속도, 음량은 그대로 살아 있다.
+  4. `orientation.exit()`는 세션의 하강 edge에서만 부른다. 일시정지는 전체화면·회전을 유지한다.
+  5. 재개도 **클릭 핸들러 안에서 동기적으로** `orientation.enter()`를 부른다(D-019 결정 3). 일시정지
+     사이에 브라우저가 전체화면을 놓았을 수 있고, 그 요청은 그 클릭에서만 승인된다.
+  6. 세션 안에서 재개가 실패하면 방향을 해제하지 않는다. 첫 재생 실패와 달리 사용자는 이미 조작
+     가능한 일시정지 화면에 있으므로, 되돌릴 것이 없다.
+  7. `FallingNotesPlayer`의 prop을 `onPlaybackChange` → `onSessionChange`로 바꾼다. 이름이 보고하는
+     사실과 달라지면 다음 세션이 다시 `isPlaying`으로 되돌린다.
+- Reason: 이슈가 요구한 것은 "전환을 부드럽게"가 아니라 **일시정지가 연습을 떠나는 것과 같아지지
+  않게** 하는 것이다. 그건 애니메이션이나 간격 조정으로 풀리지 않는다 — 두 개의 서로 다른 사실을 한
+  불리언이 대표하고 있었던 것이 결함 자체다.
+- Constraint: D-024 Directive에 따라 `playbackGeometry.ts`, `pianoLayout.ts`,
+  `usePlaybackOrientation.ts`의 상수·조건식은 건드리지 않는다. 실기기로 세 번 고친 D-021~D-023의
+  기하 계약은 그대로다 — 일시정지 중 박스는 재생 중과 **같은** 계획을 쓴다.
+- Constraint: D-019 결정 8에 따라 공유 `PlaybackControls`는 수정하지 않는다. `AnimationPlayer`와
+  데모 경로가 현재 형태에 의존한다.
+- Rejected:
+  - 일시정지도 계속 설정 화면으로 되돌린다 | 사용자가 보고한 결함 그 자체다.
+  - `isPlaying`의 의미를 "재생 중이거나 일시정지 중"으로 넓힌다 | 오디오 루프와 트랜스포트 토글이
+    실제 소리 여부를 필요로 한다. 한 불리언에 두 사실을 다시 싣는 같은 실수다.
+  - 일시정지에서 방향만 유지하고 chrome은 되돌린다 | 폰은 가로인데 페이지는 세로 레이아웃으로
+    재구성되는, 두 결함이 겹친 상태가 된다.
+  - `currentTime === 0`으로 정지와 일시정지를 구분한다 | 시작 직후 0초에서 일시정지하면 뒤집힌다.
+    구분은 추측이 아니라 lifecycle을 소유한 훅에서 나와야 한다.
+- Consequence:
+  - 일시정지 중에도 페이지 헤더와 악보 정보 카드는 나타나지 않는다. 거기로 돌아가는 경로는 정지(⏹️)
+    하나이며, 이 버튼은 압축 바에 이미 있고 위치가 바뀌지 않았다.
+  - 곡이 끝나면 auto-stop이 세션을 닫으므로 화면은 예전처럼 설정 상태로 복귀한다.
+  - 일시정지 상태의 시각적 표시는 트랜스포트의 ▶️ 아이콘과 멈춘 낙하 노트뿐이다. 가로 390px에서
+    문구를 더 넣을 자리가 없다. 실기기에서 이것으로 충분한지는 미검증이다.
+- Directive:
+  - 재생 화면의 새 조건식을 `isPlaying`으로 쓰지 않는다. 화면·회전·chrome은 `isSessionActive`다.
+  - 방향 요청을 `isPlaying`이나 `isSessionActive` effect로 옮기지 않는다. 사용자 활성화 창을 잃는다
+    (D-019 Directive).
+  - 압축 바의 첫 슬롯을 다른 동작으로 바꾸지 않는다. 그 자리의 안정성이 이 결정의 목적이다.
+- Related: 이슈 [#146](https://github.com/landfill/ClairKeys/issues/146), D-019, D-021, D-022, D-023,
+  D-024, `src/hooks/useFallingNotesPlayer.ts`,
+  `src/components/animation/FallingNotesPlayer.tsx`,
+  `src/components/playback/CompactPlaybackBar.tsx`

--- a/e2e/playback-session-transition.spec.ts
+++ b/e2e/playback-session-transition.spec.ts
@@ -1,0 +1,148 @@
+import { expect, test } from '@playwright/test'
+
+/**
+ * Issue #146 item 6: the player frame and the core controls have to hold still
+ * across play and pause. jsdom performs no layout, so the jest suites can only
+ * pin which elements render; whether the reader's thumb still lands on the
+ * transport after a pause is a question about real geometry, and only a real
+ * browser answers it.
+ */
+
+const animation = {
+  version: '1.0',
+  title: '연습 세션 전환 회귀',
+  composer: '테스트 작곡가',
+  duration: 30,
+  tempo: 100,
+  tempoSource: 'score',
+  timingReferenceBpm: 100,
+  timeSignature: '4/4',
+  notes: Array.from({ length: 20 }, (_, index) => ({
+    midi: 60 + (index % 5),
+    start: index * 1.2,
+    duration: 0.8,
+  })),
+}
+
+const viewports = [
+  { name: 'phone portrait', width: 390, height: 844 },
+  { name: 'phone landscape', width: 844, height: 390 },
+  { name: 'desktop', width: 1280, height: 720 },
+]
+
+/**
+ * `getByLabel` matches substrings, and this bar also carries 재생 위치 and
+ * 재생 속도, so the transport has to be addressed exactly.
+ */
+const transport = (page: import('@playwright/test').Page, name: string) =>
+  page.getByRole('button', { name, exact: true })
+
+async function serveFixture(page: import('@playwright/test').Page) {
+  await page.addInitScript(() => {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register = async () => {
+        throw new Error('service worker disabled for route fixture')
+      }
+    }
+  })
+
+  await page.route('**/api/sheet/1', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        sheetMusic: {
+          id: 1,
+          title: animation.title,
+          composer: animation.composer,
+          category: null,
+          isPublic: true,
+          provenance: 'omr',
+          availability: 'ready',
+          animationDataUrl: '/session-transition.json',
+          createdAt: '2026-09-08T00:00:00.000Z',
+          updatedAt: '2026-09-08T00:00:00.000Z',
+          owner: null,
+        },
+      }),
+    })
+  })
+  await page.route('**/session-transition.json', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(animation),
+    })
+  })
+}
+
+for (const viewport of viewports) {
+  test(`keeps the frame and the transport in place across a pause on ${viewport.name}`, async ({ page }) => {
+    await serveFixture(page)
+    await page.setViewportSize({ width: viewport.width, height: viewport.height })
+    await page.goto('/sheet/1')
+
+    // Setup screen: the stacked control block and the page header are here.
+    await expect(page.getByTestId('playback-primary-controls')).toBeVisible()
+    await expect(page.getByRole('heading', { name: animation.title })).toBeVisible()
+
+    await page.getByTestId('playback-play').click()
+    await expect(page.getByTestId('compact-playback-bar')).toBeVisible()
+
+    const playingTransport = await transport(page, '일시정지').boundingBox()
+    const playingBox = await page.getByTestId('playback-box').boundingBox()
+    const playingBar = await page.getByTestId('compact-playback-bar').boundingBox()
+    const playingOverflow = await page.evaluate(() => document.documentElement.scrollWidth)
+    expect(playingTransport).not.toBeNull()
+    expect(playingBox).not.toBeNull()
+
+    await transport(page, '일시정지').click()
+
+    // The pause must not rebuild the screen. Same frame, same box, and the
+    // transport in the same place — now offering resume.
+    await expect(page.getByTestId('compact-playback-bar')).toBeVisible()
+    await expect(page.getByTestId('playback-primary-controls')).toHaveCount(0)
+    await expect(page.getByRole('heading', { name: animation.title })).toHaveCount(0)
+
+    const pausedTransport = await transport(page, '재생').boundingBox()
+    const pausedBox = await page.getByTestId('playback-box').boundingBox()
+    expect(pausedTransport).toEqual(playingTransport)
+    expect(pausedBox).toEqual(playingBox)
+
+    // Everything the reader might reach for while paused is still there and
+    // still operable. `toBeVisible` is the wrong question at 390px: the seek
+    // bar already computes to zero width there while the score is sounding,
+    // which is a pre-existing narrow-width defect of the bar rather than
+    // anything a pause introduces (see the parity assertion below).
+    for (const control of [
+      page.getByRole('slider', { name: '재생 위치' }),
+      transport(page, '구간 시작 A 설정'),
+      page.getByLabel('재생 속도'),
+      page.getByLabel('음량 (master gain)'),
+      transport(page, '정지'),
+    ]) {
+      await expect(control).toBeAttached()
+      await expect(control).toBeEnabled()
+    }
+
+    // The bar occupies exactly what it did a moment ago, overflow included.
+    // This pins the claim this change is responsible for — a pause costs the
+    // layout nothing — without asserting away a defect it did not cause. The
+    // compact bar overflows a 390px-wide viewport by 57px in both states; that
+    // belongs to the narrow-width pass of #146, not here.
+    expect(await page.getByTestId('compact-playback-bar').boundingBox()).toEqual(playingBar)
+    expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBe(playingOverflow)
+
+    // Resuming puts pause back in the very slot it left.
+    await transport(page, '재생').click()
+    await expect(transport(page, '일시정지')).toBeVisible()
+    expect(await transport(page, '일시정지').boundingBox()).toEqual(playingTransport)
+
+    // Stop is still the one way back to the setup screen.
+    await transport(page, '정지').click()
+    await expect(page.getByTestId('playback-primary-controls')).toBeVisible()
+    await expect(page.getByRole('heading', { name: animation.title })).toBeVisible()
+    await expect(page.getByTestId('compact-playback-bar')).toHaveCount(0)
+  })
+}

--- a/e2e/playback-session-transition.spec.ts
+++ b/e2e/playback-session-transition.spec.ts
@@ -78,7 +78,7 @@ async function serveFixture(page: import('@playwright/test').Page) {
 }
 
 for (const viewport of viewports) {
-  test(`keeps the frame and the transport in place across a pause on ${viewport.name}`, async ({ page }) => {
+  test(`keeps the frame and the transport in place across a pause on ${viewport.name}`, async ({ page, browserName }) => {
     await serveFixture(page)
     await page.setViewportSize({ width: viewport.width, height: viewport.height })
     await page.goto('/sheet/1')
@@ -92,20 +92,27 @@ for (const viewport of viewports) {
     // The session opens only when audio actually starts (D-056 decision 1), so
     // this whole transition presupposes a browser that can run an AudioContext
     // with an output. Headless Firefox on the CI runner cannot, and there is
-    // then no transition left to measure. Anything other than an untouched
-    // setup screen is still a failure — a half-entered session would mean the
-    // chrome and the audio had come apart, which is the defect class this file
-    // exists to catch.
+    // then no transition left to measure.
     const started = await page
       .getByTestId('compact-playback-bar')
       .waitFor({ state: 'visible', timeout: 15000 })
       .then(() => true, () => false)
 
     if (!started) {
+      // Firefox is the only project that has ever failed to start here, and
+      // only on a runner with no audio output. Anywhere else, a start that
+      // never happens is the regression this file exists to catch — skipping
+      // it everywhere would let a broken play handler pass as "skipped".
+      expect(
+        browserName,
+        'playback did not start in a browser project that supports it — this is a regression, not a silent runner',
+      ).toBe('firefox')
+      // Even in firefox, the screen must be the untouched setup screen. A
+      // half-entered session means the chrome and the audio came apart.
       await expect(page.getByTestId('playback-primary-controls')).toBeVisible()
       await expect(page.getByRole('heading', { name: animation.title })).toBeVisible()
       await expect(page.getByTestId('compact-playback-bar')).toHaveCount(0)
-      test.skip(true, 'playback never started in this browser; the pause transition needs a sounding score')
+      test.skip(true, 'headless firefox on this runner has no audio output; the pause transition needs a sounding score')
     }
 
     const playingTransport = await transport(page, '일시정지').boundingBox()

--- a/e2e/playback-session-transition.spec.ts
+++ b/e2e/playback-session-transition.spec.ts
@@ -88,7 +88,25 @@ for (const viewport of viewports) {
     await expect(page.getByRole('heading', { name: animation.title })).toBeVisible()
 
     await page.getByTestId('playback-play').click()
-    await expect(page.getByTestId('compact-playback-bar')).toBeVisible()
+
+    // The session opens only when audio actually starts (D-056 decision 1), so
+    // this whole transition presupposes a browser that can run an AudioContext
+    // with an output. Headless Firefox on the CI runner cannot, and there is
+    // then no transition left to measure. Anything other than an untouched
+    // setup screen is still a failure — a half-entered session would mean the
+    // chrome and the audio had come apart, which is the defect class this file
+    // exists to catch.
+    const started = await page
+      .getByTestId('compact-playback-bar')
+      .waitFor({ state: 'visible', timeout: 15000 })
+      .then(() => true, () => false)
+
+    if (!started) {
+      await expect(page.getByTestId('playback-primary-controls')).toBeVisible()
+      await expect(page.getByRole('heading', { name: animation.title })).toBeVisible()
+      await expect(page.getByTestId('compact-playback-bar')).toHaveCount(0)
+      test.skip(true, 'playback never started in this browser; the pause transition needs a sounding score')
+    }
 
     const playingTransport = await transport(page, '일시정지').boundingBox()
     const playingBox = await page.getByTestId('playback-box').boundingBox()

--- a/src/app/sheet/[id]/page.tsx
+++ b/src/app/sheet/[id]/page.tsx
@@ -31,7 +31,9 @@ export default function SheetMusicPage() {
   const [animationData, setAnimationData] = useState<CanonicalAnimationData | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [isPlaybackActive, setIsPlaybackActive] = useState(false)
+  // The practice session, not the sounding score: a pause keeps the focused
+  // player, so the header and the info card stay away until the reader stops.
+  const [isSessionActive, setIsSessionActive] = useState(false)
 
   useEffect(() => {
     if (!id) return
@@ -152,28 +154,28 @@ export default function SheetMusicPage() {
 
   return (
     <MainLayout>
-        {!isPlaybackActive && (
+        {!isSessionActive && (
           <PageHeader
             title={sheetMusic.title}
             description={`${sheetMusic.composer}${sheetMusic.category ? ` • ${sheetMusic.category}` : ''}`}
           />
         )}
         
-        <Container className={isPlaybackActive ? 'px-0 py-0 sm:px-0 lg:px-0' : 'py-8'} size={isPlaybackActive ? 'full' : 'lg'}>
+        <Container className={isSessionActive ? 'px-0 py-0 sm:px-0 lg:px-0' : 'py-8'} size={isSessionActive ? 'full' : 'lg'}>
           <DemoProvenanceNotice
             provenance={sheetMusic.provenance}
-            isPlaybackActive={isPlaybackActive}
+            isPlaybackActive={isSessionActive}
           />
 
           {/* Falling Notes Player - MVP Style */}
           <FallingNotesPlayer 
             animationData={animationData} 
-            className={isPlaybackActive ? '' : 'mb-8'}
-            onPlaybackChange={setIsPlaybackActive}
+            className={isSessionActive ? '' : 'mb-8'}
+            onSessionChange={setIsSessionActive}
           />
 
           {/* Sheet Music Info */}
-          {!isPlaybackActive && <Card padding="lg">
+          {!isSessionActive && <Card padding="lg">
             <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
               <div>
                 <p className="text-sm font-medium text-accent">짧은 미리보기</p>

--- a/src/components/animation/FallingNotesPlayer.tsx
+++ b/src/components/animation/FallingNotesPlayer.tsx
@@ -338,6 +338,7 @@ export default function FallingNotesPlayer({
           : undefined}
       >
       <div
+        data-testid="playback-box"
         className="w-full border rounded-2xl shadow overflow-hidden"
         style={{
           display: 'flex',

--- a/src/components/animation/FallingNotesPlayer.tsx
+++ b/src/components/animation/FallingNotesPlayer.tsx
@@ -42,11 +42,16 @@ const rotatedRootStyle: React.CSSProperties = {
 export default function FallingNotesPlayer({
   animationData,
   className = '',
-  onPlaybackChange,
+  onSessionChange,
 }: {
   animationData: CanonicalAnimationData
   className?: string
-  onPlaybackChange?: (isPlaying: boolean) => void
+  /**
+   * Reports the practice session, not the sounding score. A pause keeps this
+   * true: the page chrome must not come back underneath a reader who only
+   * stopped the sound for a moment.
+   */
+  onSessionChange?: (isSessionActive: boolean) => void
 }) {
   // Convert canonical animation data to falling notes format
   const notes = useMemo(() => canonicalToFallingNotes(animationData), [animationData])
@@ -55,6 +60,7 @@ export default function FallingNotesPlayer({
   // Use falling notes player hook for audio-visual synchronization
   const {
     isPlaying,
+    isSessionActive,
     currentTime,
     tempoScale,
     lookAheadSec,
@@ -136,18 +142,20 @@ export default function FallingNotesPlayer({
     keyWidth: layout.keyWidth,
   })
 
-  // `isPlaying` is still false for as long as play() spends awaiting the
-  // AudioContext and the samples, so a plain `!isPlaying` here would release the
-  // orientation that the click had just requested. Only the fall from true is a
-  // stop.
-  const wasPlayingRef = useRef(false)
+  // The session, not `isPlaying`, owns the screen. A pause leaves the reader
+  // inside the practice run, so turning the phone back upright and rebuilding
+  // the page under them belongs to the end of the session alone. The session
+  // is also still false while play() awaits the AudioContext and the samples,
+  // so only the fall from true is an exit — a plain `!isSessionActive` would
+  // release the orientation the click had just requested.
+  const wasSessionActiveRef = useRef(false)
   useEffect(() => {
-    document.body.classList.toggle('playback-active', isPlaying)
-    onPlaybackChange?.(isPlaying)
-    if (wasPlayingRef.current && !isPlaying) orientation.exit()
-    wasPlayingRef.current = isPlaying
+    document.body.classList.toggle('playback-active', isSessionActive)
+    onSessionChange?.(isSessionActive)
+    if (wasSessionActiveRef.current && !isSessionActive) orientation.exit()
+    wasSessionActiveRef.current = isSessionActive
     return () => document.body.classList.remove('playback-active')
-  }, [isPlaying, onPlaybackChange, orientation])
+  }, [isSessionActive, onSessionChange, orientation])
 
   // The rotated player is fixed over the whole screen, so anything left
   // scrolling behind it only produces rubber-banding on iOS.
@@ -159,13 +167,18 @@ export default function FallingNotesPlayer({
   // The orientation request has to be issued from the click that produced the
   // user activation. play() awaits the AudioContext and the sample load, which
   // can outlive the activation window that requestFullscreen needs.
+  // Resuming asks for the orientation again rather than assuming it survived:
+  // the browser may have dropped fullscreen while the reader was paused, and
+  // the request is only grantable from the click that produced it.
   const handlePlay = useCallback(async () => {
     orientation.enter()
     // A start that never happens must not leave a phone turned with nothing
-    // playing, and no state transition would report that on its own.
+    // playing, and no state transition would report that on its own. Inside a
+    // session there is nothing to undo: the reader stays on the paused screen
+    // they were already operating.
     const started = await play()
-    if (!started) orientation.exit()
-  }, [orientation, play])
+    if (!started && !isSessionActive) orientation.exit()
+  }, [isSessionActive, orientation, play])
 
   // Derive key activation synchronously from the exact playhead passed to the
   // falling-note visualization. An effect would leave the keyboard one render
@@ -185,44 +198,48 @@ export default function FallingNotesPlayer({
       ref={rootRef}
       className={[
         'w-full mx-auto',
-        isPlaying ? 'max-w-none flex flex-col' : 'max-w-6xl',
+        isSessionActive ? 'max-w-none flex flex-col' : 'max-w-6xl',
         // An explicit cross-axis height replaces min-h while rotated; keeping
         // both would constrain the box along the wrong axis.
-        isPlaying && !orientation.rotate ? 'min-h-[100dvh]' : '',
+        isSessionActive && !orientation.rotate ? 'min-h-[100dvh]' : '',
         className,
       ].filter(Boolean).join(' ')}
       style={orientation.rotate ? rotatedRootStyle : undefined}
     >
-      {!isPlaying && <ScoreTimingNotice metadata={animationData.metadata} />}
+      {!isSessionActive && <ScoreTimingNotice metadata={animationData.metadata} />}
       <TempoDisplay
         tempo={animationData.tempo}
         tempoSource={animationData.tempoSource}
         timingReferenceBpm={animationData.timingReferenceBpm}
         scoreTempo={animationData.scoreTempo}
-        isPlaybackActive={isPlaying}
-        className={isPlaying ? '' : 'mb-4'}
+        isPlaybackActive={isSessionActive}
+        className={isSessionActive ? '' : 'mb-4'}
       >
-        {isPlaying && hasReleaseGuidance && <span role="note" className="ml-2 text-xs text-ink-muted">
+        {isSessionActive && hasReleaseGuidance && <span role="note" className="ml-2 text-xs text-ink-muted">
           옅은 노트: 소리 유지 · 자동 손 떼기 제안
         </span>}
       </TempoDisplay>
 
-      {!isPlaying && hasReleaseGuidance && <p className="mb-2 text-xs text-ink-muted" role="note">
+      {!isSessionActive && hasReleaseGuidance && <p className="mb-2 text-xs text-ink-muted" role="note">
         옅은 노트는 손을 뗀 뒤 소리가 이어지는 구간입니다. 손 떼기 시점은 자동 연습 제안이며,
         소리를 이어가려면 페달이나 다른 연주 방법이 필요할 수 있습니다.
       </p>}
 
-      {isPlaying ? (
-        /* One row instead of four. The landscape viewport this mode targets is
-           390px tall in total; the stacked setup chrome cost 264px of it. */
+      {isSessionActive ? (
+        /* One row instead of four, and it outlives a pause. The landscape
+           viewport this mode targets is 390px tall in total; the stacked setup
+           chrome cost 264px of it, and restoring it on every pause moved every
+           control the reader was using. */
         <div className="mb-2">
           <CompactPlaybackBar
             isReady={sampleStatus !== 'loading'}
+            isPlaying={isPlaying}
             currentTime={currentTime}
             duration={totalLength}
             playbackSpeed={tempoScale}
             volume={volume}
             maxVolume={MAX_MASTER_GAIN}
+            onPlay={handlePlay}
             onPause={pause}
             onStop={stop}
             onSeek={seek}
@@ -298,7 +315,7 @@ export default function FallingNotesPlayer({
       <div
         role="status"
         aria-live="polite"
-        className={isPlaying ? 'sr-only' : 'mb-4 text-xs text-ink-muted'}
+        className={isSessionActive ? 'sr-only' : 'mb-4 text-xs text-ink-muted'}
       >
         {sampleStatus === 'idle' && '녹음 피아노 샘플은 첫 재생 때 준비됩니다.'}
         {sampleStatus === 'loading' && '녹음 피아노 샘플을 준비 중입니다.'}
@@ -316,7 +333,7 @@ export default function FallingNotesPlayer({
       <div
         ref={visualizationRef}
         className="w-full"
-        style={isPlaying
+        style={isSessionActive
           ? { flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', justifyContent: 'center' }
           : undefined}
       >
@@ -325,7 +342,7 @@ export default function FallingNotesPlayer({
         style={{
           display: 'flex',
           flexDirection: 'column',
-          height: isPlaying ? boxHeight : standardVisualizationHeight,
+          height: isSessionActive ? boxHeight : standardVisualizationHeight,
         }}
       >
         {/* Falling Notes Area */}

--- a/src/components/animation/__tests__/FallingNotesPlayer.test.tsx
+++ b/src/components/animation/__tests__/FallingNotesPlayer.test.tsx
@@ -5,6 +5,7 @@ import FallingNotesPlayer from '../FallingNotesPlayer'
 const mockKeyboardFrames: Set<number>[] = []
 const mockPlayerState = {
   isPlaying: true,
+  isSessionActive: true,
   currentTime: 1.5,
   tempoScale: 1,
   lookAheadSec: 1.5,
@@ -22,6 +23,18 @@ const mockPlayerState = {
 jest.mock('@/hooks/useFallingNotesPlayer', () => ({
   useFallingNotesPlayer: () => mockPlayerState,
 }))
+
+/** Never played, or stopped: the setup screen. */
+function setIdle() {
+  mockPlayerState.isPlaying = false
+  mockPlayerState.isSessionActive = false
+}
+
+/** Paused part-way through a session: still the focused practice screen. */
+function setPaused() {
+  mockPlayerState.isPlaying = false
+  mockPlayerState.isSessionActive = true
+}
 
 const mockOrientation = {
   rotate: false,
@@ -78,6 +91,7 @@ describe('FallingNotesPlayer', () => {
     mockKeyboardFrames.length = 0
     mockPlayerState.sampleStatus = 'ready'
     mockPlayerState.isPlaying = true
+    mockPlayerState.isSessionActive = true
     mockOrientation.rotate = false
     mockOrientation.enter.mockClear()
     mockOrientation.exit.mockClear()
@@ -99,7 +113,7 @@ describe('FallingNotesPlayer', () => {
     expect(screen.getByTestId('tempo-display')).toHaveTextContent('♩=120 (출처 미상)')
     expect(screen.getByTestId('tempo-display')).toHaveClass('fixed')
 
-    mockPlayerState.isPlaying = false
+    setIdle()
     rerender(<FallingNotesPlayer animationData={animationData} />)
 
     expect(screen.getByTestId('tempo-display')).toHaveTextContent('♩=120 (출처 미상)')
@@ -108,7 +122,7 @@ describe('FallingNotesPlayer', () => {
 
   it('shows the current master gain and forwards slider changes to setVolume', () => {
     mockPlayerState.setVolume.mockClear()
-    mockPlayerState.isPlaying = false
+    setIdle()
     render(<FallingNotesPlayer animationData={animationData} />)
 
     // The readout is the gain value itself — that is what makes it usable for
@@ -124,7 +138,7 @@ describe('FallingNotesPlayer', () => {
   })
 
   it('shows recorded-sample readiness and removes the ineffective treble control', () => {
-    mockPlayerState.isPlaying = false
+    setIdle()
     render(<FallingNotesPlayer animationData={animationData} />)
 
     expect(screen.getByText('녹음 피아노 샘플로 재생합니다.')).toBeInTheDocument()
@@ -133,7 +147,7 @@ describe('FallingNotesPlayer', () => {
   })
 
   it('exposes degraded and failed fallback states without blocking playback', () => {
-    mockPlayerState.isPlaying = false
+    setIdle()
     mockPlayerState.sampleStatus = 'degraded'
     const { rerender } = render(<FallingNotesPlayer animationData={animationData} />)
 
@@ -147,7 +161,7 @@ describe('FallingNotesPlayer', () => {
   })
 
   it('marks controls not ready only while loading', () => {
-    mockPlayerState.isPlaying = false
+    setIdle()
     mockPlayerState.sampleStatus = 'loading'
     render(<FallingNotesPlayer animationData={animationData} />)
 
@@ -206,7 +220,7 @@ describe('FallingNotesPlayer', () => {
     })
 
     it('keeps the idle player at its standard pixel height', () => {
-      mockPlayerState.isPlaying = false
+      setIdle()
       render(<FallingNotesPlayer animationData={animationData} />)
       const { column } = readColumn()
 
@@ -225,7 +239,7 @@ describe('FallingNotesPlayer', () => {
     it('asks for landscape from the play click itself, not from a later effect', () => {
       mockOrientation.enter.mockClear()
       mockPlayerState.play.mockClear()
-      mockPlayerState.isPlaying = false
+      setIdle()
       render(<FallingNotesPlayer animationData={animationData} />)
 
       fireEvent.click(screen.getByTestId('play'))
@@ -236,11 +250,11 @@ describe('FallingNotesPlayer', () => {
       expect(mockPlayerState.play).toHaveBeenCalledTimes(1)
     })
 
-    it('releases the orientation as soon as playback stops', () => {
+    it('releases the orientation as soon as the session ends', () => {
       mockOrientation.exit.mockClear()
       const { rerender } = render(<FallingNotesPlayer animationData={animationData} />)
 
-      mockPlayerState.isPlaying = false
+      setIdle()
       rerender(<FallingNotesPlayer animationData={animationData} />)
 
       expect(mockOrientation.exit).toHaveBeenCalled()
@@ -310,8 +324,8 @@ describe('FallingNotesPlayer', () => {
       expect(status.className).toContain('sr-only')
     })
 
-    it('restores the full setup chrome when playback stops', () => {
-      mockPlayerState.isPlaying = false
+    it('restores the full setup chrome when the session ends', () => {
+      setIdle()
       render(<FallingNotesPlayer animationData={animationData} />)
 
       expect(screen.getByTestId('playback-ready')).toBeInTheDocument()
@@ -320,12 +334,109 @@ describe('FallingNotesPlayer', () => {
     })
   })
 
+  // Pause used to be indistinguishable from stop: the phone turned back, the
+  // page header and the three-row control block came back, and the box fell
+  // from its viewport height to a fixed 330px. Resuming meant finding the
+  // transport somewhere else on a page that had just reflowed underneath it.
+  describe('pausing inside a practice session', () => {
+    it('keeps the focused frame while the session is paused', () => {
+      setPaused()
+      render(<FallingNotesPlayer animationData={animationData} />)
+
+      expect(screen.getByTestId('compact-playback-bar')).toBeInTheDocument()
+      expect(screen.queryByTestId('playback-ready')).not.toBeInTheDocument()
+      expect(screen.queryByText(/히트라인/)).not.toBeInTheDocument()
+      expect(document.body).toHaveClass('playback-active')
+    })
+
+    it('keeps the box on the same measured column while paused', () => {
+      setPaused()
+      render(<FallingNotesPlayer animationData={animationData} />)
+      const column = screen.getByTestId('visual-playhead').parentElement!.parentElement!
+
+      // 330px is the idle box. Falling back to it on pause is the jump.
+      expect(column.style.height).not.toBe('330px')
+      expect(column.parentElement!.style.flex).toBe('1 1 0%')
+    })
+
+    it('does not release the orientation on a pause', () => {
+      const { rerender } = render(<FallingNotesPlayer animationData={animationData} />)
+      mockOrientation.exit.mockClear()
+
+      setPaused()
+      rerender(<FallingNotesPlayer animationData={animationData} />)
+
+      // Turning the phone back upright mid-practice is the same defect as
+      // rebuilding the page underneath it.
+      expect(mockOrientation.exit).not.toHaveBeenCalled()
+    })
+
+    it('releases the orientation when the session itself ends', () => {
+      const { rerender } = render(<FallingNotesPlayer animationData={animationData} />)
+      setPaused()
+      rerender(<FallingNotesPlayer animationData={animationData} />)
+      mockOrientation.exit.mockClear()
+
+      setIdle()
+      rerender(<FallingNotesPlayer animationData={animationData} />)
+
+      expect(mockOrientation.exit).toHaveBeenCalled()
+    })
+
+    it('reports the session to the page rather than the sounding score', () => {
+      const onSessionChange = jest.fn()
+      const { rerender } = render(
+        <FallingNotesPlayer animationData={animationData} onSessionChange={onSessionChange} />
+      )
+      expect(onSessionChange).toHaveBeenLastCalledWith(true)
+
+      setPaused()
+      rerender(<FallingNotesPlayer animationData={animationData} onSessionChange={onSessionChange} />)
+      // The page header and the info card stay away: a pause is not a return
+      // to browsing.
+      expect(onSessionChange).toHaveBeenLastCalledWith(true)
+
+      setIdle()
+      rerender(<FallingNotesPlayer animationData={animationData} onSessionChange={onSessionChange} />)
+      expect(onSessionChange).toHaveBeenLastCalledWith(false)
+    })
+
+    it('resumes from the same slot the pause was in', async () => {
+      setPaused()
+      render(<FallingNotesPlayer animationData={animationData} />)
+
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText('재생'))
+      })
+
+      // The resume rides the same click that a first play does, because the
+      // browser may have dropped fullscreen while the reader was paused.
+      expect(mockOrientation.enter).toHaveBeenCalledTimes(1)
+      expect(mockPlayerState.play).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not release the orientation when a resume fails inside a session', async () => {
+      setPaused()
+      mockPlayerState.play.mockResolvedValue(false)
+      render(<FallingNotesPlayer animationData={animationData} />)
+      mockOrientation.exit.mockClear()
+
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText('재생'))
+      })
+
+      // Unlike a failed first play, this leaves the reader where they already
+      // were — paused, in a screen they can operate.
+      expect(mockOrientation.exit).not.toHaveBeenCalled()
+    })
+  })
+
   // enter() runs from the click, but isPlaying only flips after play() resolves
   // its audio setup. Anything that treats that window as "not playing" cancels
   // the request that was just issued — on iOS that is the whole feature.
   describe('the window between the click and the first sound', () => {
     it('does not release the orientation while playback is still starting', async () => {
-      mockPlayerState.isPlaying = false
+      setIdle()
       render(<FallingNotesPlayer animationData={animationData} />)
       mockOrientation.exit.mockClear()
 
@@ -338,7 +449,7 @@ describe('FallingNotesPlayer', () => {
     })
 
     it('does not release the orientation merely because the player mounted idle', () => {
-      mockPlayerState.isPlaying = false
+      setIdle()
       render(<FallingNotesPlayer animationData={animationData} />)
 
       // Releasing on a false that was never preceded by a true is the same
@@ -347,7 +458,7 @@ describe('FallingNotesPlayer', () => {
     })
 
     it('releases the orientation when the audio never starts', async () => {
-      mockPlayerState.isPlaying = false
+      setIdle()
       mockPlayerState.play.mockResolvedValue(false)
       render(<FallingNotesPlayer animationData={animationData} />)
       mockOrientation.exit.mockClear()

--- a/src/components/playback/CompactPlaybackBar.tsx
+++ b/src/components/playback/CompactPlaybackBar.tsx
@@ -15,15 +15,21 @@ import { Button } from '@/components/ui'
  * The mode selector is deliberately absent. `FallingNotesPlayer` only supports
  * listen mode, and its handler logs rather than switching, so the control has
  * nothing to offer here.
+ *
+ * The bar outlives a pause. It is the transport for a practice session, not for
+ * a sounding score, so the first control toggles between pause and resume in
+ * place rather than the bar being swapped out for the setup chrome.
  */
 
 export interface CompactPlaybackBarProps {
   isReady: boolean
+  isPlaying: boolean
   currentTime: number
   duration: number
   playbackSpeed: number
   volume: number
   maxVolume: number
+  onPlay: () => void
   onPause: () => void
   onStop: () => void
   onSeek: (time: number) => void
@@ -49,11 +55,13 @@ function formatTime(seconds: number): string {
 
 export default function CompactPlaybackBar({
   isReady,
+  isPlaying,
   currentTime,
   duration,
   playbackSpeed,
   volume,
   maxVolume,
+  onPlay,
   onPause,
   onStop,
   onSeek,
@@ -103,16 +111,19 @@ export default function CompactPlaybackBar({
       data-testid="compact-playback-bar"
       className={`flex items-center gap-3 h-14 px-1 ${className}`}
     >
+      {/* One slot, two states. A pause used to replace this bar with the
+          three-row setup block, so resuming meant finding the transport
+          somewhere else on a page that had reflowed in the meantime. */}
       <Button
         type="button"
-        onClick={onPause}
+        onClick={isPlaying ? onPause : onPlay}
         disabled={!isReady}
-        aria-label="일시정지"
+        aria-label={isPlaying ? '일시정지' : '재생'}
         variant="outline"
         size="md"
         className="h-10 w-10 shrink-0 p-0 !px-0 !py-0 text-lg leading-none"
       >
-        ⏸️
+        {isPlaying ? '⏸️' : '▶️'}
       </Button>
       {onLoopStart && onLoopEnd && onLoopClear && (
         <div className="flex shrink-0 gap-1" data-testid="compact-loop-controls">

--- a/src/components/playback/CompactPlaybackBar.tsx
+++ b/src/components/playback/CompactPlaybackBar.tsx
@@ -166,11 +166,17 @@ export default function CompactPlaybackBar({
         <div className="h-2 rounded-full bg-blue-600" style={{ width: `${progress}%` }} />
       </div>
 
+      {/* Disabled while the samples load, exactly as the setup screen's speed
+          control is. During playback this is always enabled — the status has
+          resolved before a note sounds — so the only window it closes is a
+          resume that is still starting, where a speed change would cancel the
+          start the reader just asked for. */}
       <select
         value={playbackSpeed}
         onChange={event => onSpeedChange(parseFloat(event.target.value))}
+        disabled={!isReady}
         aria-label="재생 속도"
-        className="h-10 shrink-0 rounded-full border border-rule-strong bg-surface px-3 text-xs text-ink shadow-sm"
+        className="h-10 shrink-0 rounded-full border border-rule-strong bg-surface px-3 text-xs text-ink shadow-sm disabled:opacity-50"
       >
         {SPEEDS.map(speed => (
           <option key={speed} value={speed}>

--- a/src/components/playback/__tests__/CompactPlaybackBar.test.tsx
+++ b/src/components/playback/__tests__/CompactPlaybackBar.test.tsx
@@ -22,6 +22,9 @@ function renderBar(overrides: Partial<React.ComponentProps<typeof CompactPlaybac
   return props
 }
 
+const transportButton = () =>
+  screen.getByRole('button', { name: /^(재생|일시정지)$/ })
+
 describe('CompactPlaybackBar', () => {
   // The bar exists because a landscape phone has 390px of height in total. What
   // it drops has to be chrome, never a way to operate playback — including for
@@ -132,6 +135,16 @@ describe('CompactPlaybackBar', () => {
       fireEvent.change(screen.getByLabelText('음량 (master gain)'), { target: { value: '0.4' } })
       expect(props.onVolumeChange).toHaveBeenCalledWith(0.4)
     })
+  })
+
+  it('closes the speed control while a start is still loading', () => {
+    // Changing the speed calls stopAudio, which abandons the start the reader
+    // just asked for. The setup screen has always disabled this control while
+    // loading; the bar now outlives a pause, so it needs the same guard.
+    renderBar({ isReady: false })
+
+    expect(screen.getByLabelText('재생 속도')).toBeDisabled()
+    expect(transportButton()).toBeDisabled()
   })
 
   it('keeps compact transport and loop controls the same size', () => {

--- a/src/components/playback/__tests__/CompactPlaybackBar.test.tsx
+++ b/src/components/playback/__tests__/CompactPlaybackBar.test.tsx
@@ -9,6 +9,8 @@ function renderBar(overrides: Partial<React.ComponentProps<typeof CompactPlaybac
     playbackSpeed: 1,
     volume: 0.22,
     maxVolume: 1,
+    isPlaying: true,
+    onPlay: jest.fn(),
     onPause: jest.fn(),
     onStop: jest.fn(),
     onSeek: jest.fn(),
@@ -78,6 +80,58 @@ describe('CompactPlaybackBar', () => {
 
     fireEvent.change(screen.getByLabelText('음량 (master gain)'), { target: { value: '0.4' } })
     expect(props.onVolumeChange).toHaveBeenCalledWith(0.4)
+  })
+
+  // Pausing used to swap this whole bar for the three-row setup block, which
+  // moved every control the reader had just been using. The transport now
+  // toggles in place instead.
+  describe('resuming from a pause', () => {
+    it('offers pause in the first transport slot while the score sounds', () => {
+      const props = renderBar({ isPlaying: true })
+
+      const button = screen.getByLabelText('일시정지')
+      expect(screen.getByTestId('compact-playback-bar').firstElementChild).toBe(button)
+      expect(button).toHaveClass('h-10', 'w-10')
+
+      fireEvent.click(button)
+      expect(props.onPause).toHaveBeenCalled()
+    })
+
+    it('offers resume in that same slot while paused', () => {
+      const props = renderBar({ isPlaying: false })
+
+      const button = screen.getByLabelText('재생')
+      // Same slot and same size: the control that was under the reader's thumb
+      // a moment ago is still there, and it is the one that restarts the score.
+      expect(screen.getByTestId('compact-playback-bar').firstElementChild).toBe(button)
+      expect(button).toHaveClass('h-10', 'w-10')
+      expect(screen.queryByLabelText('일시정지')).not.toBeInTheDocument()
+
+      fireEvent.click(button)
+      expect(props.onPlay).toHaveBeenCalled()
+      expect(props.onPause).not.toHaveBeenCalled()
+    })
+
+    it('keeps seeking, the loop markers and both inputs live while paused', () => {
+      const props = renderBar({
+        isPlaying: false,
+        onLoopStart: jest.fn(),
+        onLoopEnd: jest.fn(),
+        onLoopClear: jest.fn(),
+      })
+
+      fireEvent.keyDown(screen.getByRole('slider', { name: '재생 위치' }), { key: 'ArrowRight' })
+      expect(props.onSeek).toHaveBeenCalledWith(35)
+
+      fireEvent.click(screen.getByLabelText('구간 시작 A 설정'))
+      expect(props.onLoopStart).toHaveBeenCalled()
+
+      fireEvent.change(screen.getByLabelText('재생 속도'), { target: { value: '0.5' } })
+      expect(props.onSpeedChange).toHaveBeenCalledWith(0.5)
+
+      fireEvent.change(screen.getByLabelText('음량 (master gain)'), { target: { value: '0.4' } })
+      expect(props.onVolumeChange).toHaveBeenCalledWith(0.4)
+    })
   })
 
   it('keeps compact transport and loop controls the same size', () => {

--- a/src/hooks/__tests__/useFallingNotesAudioSamples.test.ts
+++ b/src/hooks/__tests__/useFallingNotesAudioSamples.test.ts
@@ -562,6 +562,86 @@ describe('useFallingNotesAudio - recorded samples', () => {
     unmount()
   })
 
+  // `loading` is the one value in `sampleStatus` that describes a request
+  // rather than the bank, and it is what the player reads as "not ready" to
+  // disable the transport. A start that is abandoned while waiting for the
+  // samples must therefore hand the status back, or the controls never return.
+  describe('a start abandoned while the samples are still loading', () => {
+    function pendingLoad() {
+      let finish: (() => void) | undefined
+      mockLoad = jest.fn(
+        () => new Promise((resolve) => {
+          finish = () => resolve({ status: 'ready', readyCount: 30, totalCount: 30 })
+        })
+      )
+      return () => finish?.()
+    }
+
+    const note = { midi: 60, start: 0, duration: 1, hand: 'R' as const, velocity: 0.8 }
+
+    it('releases the status when nothing takes the start over', async () => {
+      const finishLoad = pendingLoad()
+      const { context } = makeSampleContext()
+      useContext(context)
+      const { result, unmount } = renderHook(() => useFallingNotesAudio())
+
+      let startPromise: Promise<boolean>
+      act(() => { startPromise = result.current.startAudio([note], 0, 1, false) })
+      await act(async () => { await Promise.resolve() })
+      expect(result.current.sampleStatus).toBe('loading')
+
+      // What a paused seek or speed change does: stop the audio without
+      // starting any replacement.
+      act(() => { result.current.stopAudio() })
+
+      let started: boolean | undefined
+      await act(async () => {
+        finishLoad()
+        started = await startPromise!
+      })
+
+      expect(started).toBe(false)
+      // Stranded here, `isReady` is false forever and the player's resume and
+      // stop buttons are both disabled — the reader cannot leave the screen.
+      expect(result.current.sampleStatus).not.toBe('loading')
+      expect(result.current.sampleStatus).toBe('ready')
+
+      unmount()
+    })
+
+    it('leaves the status to a newer start that has taken over', async () => {
+      const finishFirst = pendingLoad()
+      const { context } = makeSampleContext()
+      useContext(context)
+      const { result, unmount } = renderHook(() => useFallingNotesAudio())
+
+      let firstStart: Promise<boolean>
+      act(() => { firstStart = result.current.startAudio([note], 0, 1, false) })
+      await act(async () => { await Promise.resolve() })
+
+      const finishSecond = pendingLoad()
+      let secondStart: Promise<boolean>
+      act(() => { secondStart = result.current.startAudio([note], 0, 1, false) })
+      await act(async () => { await Promise.resolve() })
+
+      await act(async () => {
+        finishFirst()
+        expect(await firstStart!).toBe(false)
+      })
+
+      // The abandoned start must not answer for a load that is still running.
+      expect(result.current.sampleStatus).toBe('loading')
+
+      await act(async () => {
+        finishSecond()
+        expect(await secondStart!).toBe(true)
+      })
+      expect(result.current.sampleStatus).toBe('ready')
+
+      unmount()
+    })
+  })
+
   it('keeps playback working and reports failed when no samples loaded', async () => {
     mockLoad = jest.fn(() => Promise.resolve({
       status: 'failed',

--- a/src/hooks/__tests__/useFallingNotesPlayer.test.ts
+++ b/src/hooks/__tests__/useFallingNotesPlayer.test.ts
@@ -138,3 +138,61 @@ describe('useFallingNotesPlayer loop lifecycle', () => {
     expect(frames.size).toBe(0)
   })
 })
+
+// A practice session is not the same thing as a sounding score. Pausing is a
+// pause inside the session the reader is already in; only a stop — theirs or
+// the end of the piece — returns them to setup.
+describe('useFallingNotesPlayer practice session', () => {
+  it('opens the session only once audio has actually started', async () => {
+    const { result } = renderHook(() => useFallingNotesPlayer(notes))
+    expect(result.current.isSessionActive).toBe(false)
+
+    mockAudio.startAudio.mockResolvedValueOnce(false)
+    await act(async () => { await result.current.play() })
+    expect(result.current.isSessionActive).toBe(false)
+
+    await act(async () => { await result.current.play() })
+    expect(result.current.isSessionActive).toBe(true)
+  })
+
+  it('keeps the session open across a pause', async () => {
+    const { result } = renderHook(() => useFallingNotesPlayer(notes))
+    await act(async () => { await result.current.play() })
+    act(() => result.current.pause())
+
+    expect(result.current.isPlaying).toBe(false)
+    expect(result.current.isSessionActive).toBe(true)
+  })
+
+  it('closes the session when the reader stops', async () => {
+    const { result } = renderHook(() => useFallingNotesPlayer(notes))
+    await act(async () => { await result.current.play() })
+    act(() => result.current.stop())
+
+    expect(result.current.isSessionActive).toBe(false)
+  })
+
+  it('closes the session when the score runs out', async () => {
+    const { result } = renderHook(() => useFallingNotesPlayer(notes))
+    await act(async () => { await result.current.play() })
+
+    // The auto-stop is a stop like any other: the playhead is back at zero and
+    // there is nothing left to resume.
+    await frameAt(13)
+
+    expect(result.current.isPlaying).toBe(false)
+    expect(result.current.isSessionActive).toBe(false)
+    expect(result.current.currentTime).toBe(0)
+  })
+
+  it('leaves the session alone when audio cannot restart mid-piece', async () => {
+    const { result } = await playingLoop()
+    mockAudio.startAudio.mockResolvedValueOnce(false)
+    await frameAt(4.1)
+
+    // A failed restart is not a decision to leave the piece. The reader stays
+    // where they were, paused, with the transport still under their thumb.
+    expect(result.current.isPlaying).toBe(false)
+    expect(result.current.isSessionActive).toBe(true)
+  })
+})

--- a/src/hooks/useFallingNotesAudio.ts
+++ b/src/hooks/useFallingNotesAudio.ts
@@ -166,6 +166,11 @@ export function useFallingNotesAudio() {
   const tempoScaleRef = useRef(1)
   const isPlayingRef = useRef(false)
   const playbackGenerationRef = useRef(0)
+  // How many starts are currently waiting on the sample bank. `sampleStatus`
+  // reports the bank except for `loading`, which describes a request — and a
+  // request can be abandoned. The count is what tells an abandoned start
+  // whether it is the last one out and therefore owes the status back.
+  const pendingSampleLoadsRef = useRef(0)
 
   // Rolling-scheduler state, all reset on every startAudio.
   const notesRef = useRef<FallingNote[]>([])
@@ -582,6 +587,7 @@ export function useFallingNotesAudio() {
     // it, and the fallback still covers whatever has not arrived.
     const bank = sampleBankRef.current
     setSampleStatus('loading')
+    pendingSampleLoadsRef.current += 1
     let loadResult: PianoSampleLoadResult | 'timeout'
     if (bank) {
       let timer: ReturnType<typeof setTimeout> | undefined
@@ -600,14 +606,24 @@ export function useFallingNotesAudio() {
       }
     }
 
+    pendingSampleLoadsRef.current -= 1
+    const bankStatus = loadResult === 'timeout' ? 'degraded' : loadResult.status
+
     // Covers both awaits above: a stop, unmount, or newer seek during either the
     // resume or the sample wait has already taken ownership of the clock.
     if (generation !== playbackGenerationRef.current || audioContext.state !== 'running') {
+      // Report the bank anyway when no other start is still waiting. `loading`
+      // is what the player reads as "not ready", and it disables the transport
+      // — including the stop that would otherwise clear it. A pause followed by
+      // a seek or a speed change reaches exactly here, and leaving the status
+      // behind locked the reader inside a screen with no working control.
+      // A newer start owns the status while it waits, so it is left alone.
+      if (pendingSampleLoadsRef.current === 0) setSampleStatus(bankStatus)
       return false
     }
 
     useSamplesForPlaybackRef.current = loadResult !== 'timeout' && loadResult.status === 'ready'
-    setSampleStatus(loadResult === 'timeout' ? 'degraded' : loadResult.status)
+    setSampleStatus(bankStatus)
 
     // Store current state
     notesRef.current = notes

--- a/src/hooks/useFallingNotesPlayer.ts
+++ b/src/hooks/useFallingNotesPlayer.ts
@@ -11,8 +11,13 @@ import { createLoopSection } from '@/utils/loopSection'
  * Based on MVP implementation for precise timing
  */
 export function useFallingNotesPlayer(notes: FallingNote[]) {
-  // Playback state
+  // Playback state. `isPlaying` is whether a score is sounding right now;
+  // `isSessionActive` is whether the reader is inside a practice run at all.
+  // They diverge on a pause, and the screen needs the second one: a pause is a
+  // moment inside the run, not a decision to leave it. Only a stop — the
+  // reader's, or the end of the piece — closes the session.
   const [isPlaying, setIsPlaying] = useState(false)
+  const [isSessionActive, setIsSessionActive] = useState(false)
   const [currentTime, setCurrentTime] = useState(0)
   const [tempoScale, setTempoScale] = useState(1.0)
   const [mute, setMute] = useState(false)
@@ -56,7 +61,10 @@ export function useFallingNotesPlayer(notes: FallingNote[]) {
       tempoScale,
       mute
     )
-    if (started) setIsPlaying(true)
+    if (started) {
+      setIsPlaying(true)
+      setIsSessionActive(true)
+    }
     return started
   }, [isPlaying, tempoScale, mute, notes, getCurrentTime, startAudio, updateTempoScale])
 
@@ -79,6 +87,7 @@ export function useFallingNotesPlayer(notes: FallingNote[]) {
    */
   const handleStop = useCallback(() => {
     setIsPlaying(false)
+    setIsSessionActive(false)
     reset()
     setCurrentTime(0)
   }, [reset])
@@ -229,6 +238,7 @@ export function useFallingNotesPlayer(notes: FallingNote[]) {
   return {
     // State
     isPlaying,
+    isSessionActive,
     currentTime,
     tempoScale,
     mute,


### PR DESCRIPTION
## 왜

이슈 #146 항목 6은 "재생하면 헤더 없는 집중 화면으로 바뀌고 일시정지하면 다시 설명이 긴 상세 화면으로 돌아간다. 같은 컨트롤의 위치와 모양도 크게 바뀐다"를 보고했다.

원인은 취향이 아니라 상태 모델이다. `isPlaying` 하나가 오디오 · 방향 잠금 · 페이지 chrome · 박스 높이를 동시에 몰고 있어서, **일시정지 한 번이 연습을 그만둔 것과 똑같은 동작**을 했다.

| | 이전 (일시정지) | 이후 (일시정지) |
|---|---|---|
| 폰 방향 | 세로로 되돌아감 | 유지 |
| 페이지 헤더 · 악보 정보 카드 | 다시 나타남 | 유지(숨김) |
| 박스 높이 | 측정된 높이 → 고정 330px | 그대로 |
| 트랜스포트 | 한 줄 바(⏸️ 맨 왼쪽) → 3행 블록(재생이 3열 그리드 1번) | 같은 자리에서 ⏸️ ↔ ▶️ |

## 무엇을

- `useFallingNotesPlayer`가 `isSessionActive`를 함께 소유한다. 오디오가 실제로 시작하면 열리고, **stop에서만** 닫힌다 — 사용자의 정지와 곡 끝 auto-stop 둘 다. `pause`는 세션을 유지한다.
- 화면 · 회전 · 페이지 chrome은 세션을 읽는다. `isPlaying`은 "소리가 나는지"만 뜻하게 남는다.
- `CompactPlaybackBar`의 첫 슬롯이 같은 크기 · 같은 자리에서 토글한다. 일시정지 중에도 seek · A-B · 속도 · 음량은 살아 있고, 정지는 원래 자리 그대로다.
- 재개도 클릭 핸들러 안에서 동기적으로 `orientation.enter()`를 부른다(D-019 결정 3). 세션 안에서 재개가 실패하면 방향을 해제하지 않는다.
- 근거는 [D-056](docs/recovery/DECISIONS.md)에 기록했다. D-055는 철회된 PR #147 브랜치에서 할당된 번호라 재사용하지 않았다.

D-024 Directive에 따라 `playbackGeometry.ts` · `pianoLayout.ts` · `usePlaybackOrientation.ts`의 상수 · 조건식은 건드리지 않았다. 일시정지 중 박스는 재생 중과 **같은** 기하 계획을 쓴다. D-019 결정 8에 따라 공유 `PlaybackControls`도 그대로다.

## 커밋

1. `e56a7a0` 회귀 근거 — 13건이 의도대로 실패하고 기존 37건은 통과함을 먼저 고정
2. `0e6572c` 구현 + D-056
3. `92beb3e` 실제 브라우저 검증 (jsdom은 레이아웃을 계산하지 않음)

## 검증

- `npx jest` — 102 suites / **992 통과**
- `npx playwright test` — chromium · firefox · webkit · Mobile Chrome · Mobile Safari에서 **50 통과**. 390×844, 844×390, 1280×720에서 트랜스포트 bounding box가 일시정지 전후 완전히 동일하고, 박스가 330px 유휴 높이로 떨어지지 않음을 실측
- `npx tsc --noEmit` 통과, `next lint` 경고 0, `prisma generate && next build` 성공

## 이 PR이 고치지 않는 것 (실측 중 발견)

**390px 폭에서 압축 바가 가로로 넘친다** — `scrollWidth 431` / `document.scrollWidth 447` > 390이고 seek 슬라이더 폭이 0이 된다. **재생 중과 일시정지 중이 완전히 동일한 수치**이므로 이번 변경이 만든 것이 아니다(실제 폰 세로는 CSS 회전으로 844px 폭을 받으므로 pointer:fine인 좁은 창의 문제다). E2E는 "넘침 없음"이 아니라 **재생 상태와의 동등성**을 단언해 이 결함을 지우지 않고 남겨 뒀다. #146의 P2 반응형 묶음 대상이다.

## 미검증

실기기 회전과 일시정지를 가로지르는 전체화면 유지. 데스크톱 프로젝트의 headless Chromium은 `pointer: fine`을 보고하므로 CSS 회전 경로는 두 모바일 프로필에서만 실행됐다.

Closes 없음 — #146은 이 묶음 이후에도 탐색 · 업로드 · 반응형이 남는다.