### PR TITLE
Keep the seek control usable in narrow desktop practice windows

### DIFF
--- a/e2e/playback-session-transition.spec.ts
+++ b/e2e/playback-session-transition.spec.ts
@@ -191,6 +191,19 @@ for (const viewport of viewports) {
       await seek.press('Home')
       await expect(seek).toHaveAttribute('aria-valuenow', '0')
       if (viewport.width === 390) {
+        for (const label of ['재생 속도', '음량 (master gain)']) {
+          const control = page.getByLabel(label)
+          await control.evaluate(element => element.setAttribute('data-focus-probe', 'retained'))
+          await control.focus()
+          await page.setViewportSize({ width: 844, height: viewport.height })
+          await expect(control).toBeFocused()
+          await expect(control).toHaveAttribute('data-focus-probe', 'retained')
+          await page.setViewportSize({ width: viewport.width, height: viewport.height })
+          await expect(control).toBeFocused()
+          await expect(control).toHaveAttribute('data-focus-probe', 'retained')
+          await control.evaluate(element => element.removeAttribute('data-focus-probe'))
+        }
+        await seek.focus()
         await page.setViewportSize({ width: 844, height: viewport.height })
         await expect(seek).toBeFocused()
         await page.setViewportSize({ width: viewport.width, height: viewport.height })

--- a/e2e/playback-session-transition.spec.ts
+++ b/e2e/playback-session-transition.spec.ts
@@ -190,10 +190,20 @@ for (const viewport of viewports) {
       await expect(seek).toHaveAttribute('aria-valuenow', '5')
       await seek.press('Home')
       await expect(seek).toHaveAttribute('aria-valuenow', '0')
+      if (viewport.width === 390) {
+        await page.setViewportSize({ width: 844, height: viewport.height })
+        await expect(seek).toBeFocused()
+        await page.setViewportSize({ width: viewport.width, height: viewport.height })
+        await expect(seek).toBeFocused()
+        await seek.press('ArrowRight')
+        await expect(seek).toHaveAttribute('aria-valuenow', '5')
+        await seek.press('Home')
+        await expect(seek).toHaveAttribute('aria-valuenow', '0')
+      }
     }
 
     // Pause preserves the frame and transport across the responsive layout.
-    expect(await page.getByTestId('compact-playback-bar').boundingBox()).toEqual(playingBar)
+    await expect.poll(() => page.getByTestId('compact-playback-bar').boundingBox()).toEqual(playingBar)
     expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBe(playingOverflow)
 
     // Resuming puts pause back in the very slot it left.

--- a/e2e/playback-session-transition.spec.ts
+++ b/e2e/playback-session-transition.spec.ts
@@ -25,6 +25,7 @@ const animation = {
 }
 
 const viewports = [
+  { name: '320 CSS pixels', width: 320, height: 800 },
   { name: 'phone portrait', width: 390, height: 844 },
   { name: 'phone landscape', width: 844, height: 390 },
   { name: 'desktop', width: 1280, height: 720 },
@@ -164,7 +165,8 @@ for (const viewport of viewports) {
         documentWidth: document.documentElement.scrollWidth,
       }))
       expect(metrics.width).toBeGreaterThanOrEqual(44)
-      expect(await page.getByTestId('compact-playback-bar').evaluate(element => (element as HTMLElement).offsetHeight)).toBe(56)
+      expect(await page.getByLabel('재생 속도').evaluate(element => (element as HTMLElement).offsetWidth)).toBeGreaterThanOrEqual(56)
+      expect(await page.getByTestId('compact-playback-bar').evaluate(element => (element as HTMLElement).offsetHeight)).toBe(viewport.width <= 375 ? 64 : 56)
       expect(metrics.documentWidth).toBeLessThanOrEqual(viewport.width)
       if (viewport.width === 390) {
         await page.screenshot({ path: test.info().outputPath('toolbar-390.png') })

--- a/e2e/playback-session-transition.spec.ts
+++ b/e2e/playback-session-transition.spec.ts
@@ -120,6 +120,9 @@ for (const viewport of viewports) {
       test.skip(true, 'headless firefox on this runner has no audio output; the pause transition needs a sounding score')
     }
 
+    // Exercise a nonzero pause position, as on slower CI audio startup.
+    await expect.poll(async () => Number(await page.getByRole('slider', { name: '재생 위치' }).getAttribute('aria-valuenow'))).toBeGreaterThanOrEqual(1)
+
     const playingTransport = await transport(page, '일시정지').boundingBox()
     const playingBox = await page.getByTestId('playback-box').boundingBox()
     const playingBar = await page.getByTestId('compact-playback-bar').boundingBox()
@@ -168,6 +171,10 @@ for (const viewport of viewports) {
       }
       await seek.focus()
       await expect(seek).toBeFocused()
+      // A pause can happen after playback has advanced on a slower runner.
+      // Establish the starting position before checking the relative step.
+      await seek.press('Home')
+      await expect(seek).toHaveAttribute('aria-valuenow', '0')
       await seek.press('ArrowRight')
       await expect(seek).toHaveAttribute('aria-valuenow', '5')
       await seek.press('Home')

--- a/e2e/playback-session-transition.spec.ts
+++ b/e2e/playback-session-transition.spec.ts
@@ -28,6 +28,8 @@ const viewports = [
   { name: 'phone portrait', width: 390, height: 844 },
   { name: 'phone landscape', width: 844, height: 390 },
   { name: 'desktop', width: 1280, height: 720 },
+  { name: 'large desktop', width: 1440, height: 900 },
+  { name: 'large desktop with CSS zoom 200%', width: 1440, height: 900, zoom: 2 },
 ]
 
 /**
@@ -82,6 +84,9 @@ for (const viewport of viewports) {
     await serveFixture(page)
     await page.setViewportSize({ width: viewport.width, height: viewport.height })
     await page.goto('/sheet/1')
+    if ('zoom' in viewport) {
+      await page.evaluate(zoom => { document.documentElement.style.zoom = String(zoom) }, viewport.zoom)
+    }
 
     // Setup screen: the stacked control block and the page header are here.
     await expect(page.getByTestId('playback-primary-controls')).toBeVisible()
@@ -135,11 +140,8 @@ for (const viewport of viewports) {
     expect(pausedTransport).toEqual(playingTransport)
     expect(pausedBox).toEqual(playingBox)
 
-    // Everything the reader might reach for while paused is still there and
-    // still operable. `toBeVisible` is the wrong question at 390px: the seek
-    // bar already computes to zero width there while the score is sounding,
-    // which is a pre-existing narrow-width defect of the bar rather than
-    // anything a pause introduces (see the parity assertion below).
+    // Existing touch/rotation paths retain their parity coverage. The new
+    // layout regression specifically targets narrow fine-pointer windows.
     for (const control of [
       page.getByRole('slider', { name: '재생 위치' }),
       transport(page, '구간 시작 A 설정'),
@@ -151,11 +153,28 @@ for (const viewport of viewports) {
       await expect(control).toBeEnabled()
     }
 
-    // The bar occupies exactly what it did a moment ago, overflow included.
-    // This pins the claim this change is responsible for — a pause costs the
-    // layout nothing — without asserting away a defect it did not cause. The
-    // compact bar overflows a 390px-wide viewport by 57px in both states; that
-    // belongs to the narrow-width pass of #146, not here.
+    const finePointer = await page.evaluate(() => matchMedia('(pointer: fine)').matches)
+    if (finePointer) {
+      const seek = page.getByRole('slider', { name: '재생 위치' })
+      const metrics = await seek.evaluate(element => ({
+        width: (element as HTMLElement).offsetWidth,
+        documentWidth: document.documentElement.scrollWidth,
+      }))
+      expect(metrics.width).toBeGreaterThanOrEqual(44)
+      expect(await page.getByTestId('compact-playback-bar').evaluate(element => (element as HTMLElement).offsetHeight)).toBe(56)
+      expect(metrics.documentWidth).toBeLessThanOrEqual(viewport.width)
+      if (viewport.width === 390) {
+        await page.screenshot({ path: test.info().outputPath('toolbar-390.png') })
+      }
+      await seek.focus()
+      await expect(seek).toBeFocused()
+      await seek.press('ArrowRight')
+      await expect(seek).toHaveAttribute('aria-valuenow', '5')
+      await seek.press('Home')
+      await expect(seek).toHaveAttribute('aria-valuenow', '0')
+    }
+
+    // Pause preserves the frame and transport across the responsive layout.
     expect(await page.getByTestId('compact-playback-bar').boundingBox()).toEqual(playingBar)
     expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBe(playingOverflow)
 

--- a/e2e/playback-session-transition.spec.ts
+++ b/e2e/playback-session-transition.spec.ts
@@ -169,6 +169,15 @@ for (const viewport of viewports) {
       if (viewport.width === 390) {
         await page.screenshot({ path: test.info().outputPath('toolbar-390.png') })
       }
+      await transport(page, '정지').focus()
+      await page.keyboard.press('Tab')
+      if (viewport.width < 640) {
+        await expect(page.getByLabel('재생 속도')).toBeFocused()
+        await page.keyboard.press('Tab')
+        await expect(page.getByLabel('음량 (master gain)')).toBeFocused()
+        await page.keyboard.press('Tab')
+      }
+      await expect(seek).toBeFocused()
       await seek.focus()
       await expect(seek).toBeFocused()
       // A pause can happen after playback has advanced on a slower runner.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -237,3 +237,15 @@ body.playback-rotated {
   .compact-playback-volume { grid-column: 5; grid-row: 1; width: 56px; }
   .compact-playback-seek { grid-column: 1 / -1; grid-row: 2; }
 }
+
+/* At 320 CSS pixels, speed needs its full value/arrow width. Move volume below
+   with seek, allowing 8px more toolbar height rather than hiding a control. */
+@media (max-width: 375px) and (pointer: fine) {
+  .compact-playback-bar {
+    height: 64px;
+    grid-template-columns: 40px max-content 40px minmax(56px, 1fr);
+    grid-template-rows: 40px 16px;
+  }
+  .compact-playback-volume { grid-column: 1 / 3; grid-row: 2; width: 100%; }
+  .compact-playback-seek { grid-column: 3 / -1; grid-row: 2; }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -213,3 +213,27 @@ body.playback-rotated {
 .tab-navigation button:hover {
   background: var(--ck-surface);
 }
+
+/* Narrow desktop windows need a separate seek row inside the existing 56px bar.
+   Touch devices keep their existing landscape/rotation layout. */
+@media (max-width: 639px) and (pointer: fine) {
+  .compact-playback-bar {
+    display: grid;
+    grid-template-columns: 40px max-content 40px minmax(0, 1fr) 56px;
+    grid-template-rows: 40px 8px;
+    gap: 4px;
+    padding-block: 2px;
+  }
+  .compact-playback-transport { grid-column: 1; grid-row: 1; }
+  .compact-playback-loop { grid-column: 2; grid-row: 1; }
+  .compact-playback-stop { grid-column: 3; grid-row: 1; }
+  .compact-playback-speed {
+    grid-column: 4;
+    grid-row: 1;
+    min-width: 0;
+    width: 100%;
+    padding-inline: 4px;
+  }
+  .compact-playback-volume { grid-column: 5; grid-row: 1; width: 56px; }
+  .compact-playback-seek { grid-column: 1 / -1; grid-row: 2; }
+}

--- a/src/components/playback/CompactPlaybackBar.tsx
+++ b/src/components/playback/CompactPlaybackBar.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useSyncExternalStore } from 'react'
 import { Button } from '@/components/ui'
 
 /**
@@ -43,6 +44,17 @@ export interface CompactPlaybackBarProps {
   className?: string
 }
 
+const NARROW_DESKTOP_QUERY = '(max-width: 639px) and (pointer: fine)'
+const isNarrowDesktop = () => typeof window !== 'undefined' &&
+  typeof window.matchMedia === 'function' && window.matchMedia(NARROW_DESKTOP_QUERY).matches
+const serverSnapshot = () => false
+function subscribeToLayout(onChange: () => void) {
+  if (typeof window.matchMedia !== 'function') return () => {}
+  const query = window.matchMedia(NARROW_DESKTOP_QUERY)
+  query.addEventListener('change', onChange)
+  return () => query.removeEventListener('change', onChange)
+}
+
 const SPEEDS = [0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 2.0]
 const SEEK_STEP_SEC = 5
 
@@ -74,6 +86,7 @@ export default function CompactPlaybackBar({
   onLoopClear,
   className = '',
 }: CompactPlaybackBarProps) {
+  const narrowDesktop = useSyncExternalStore(subscribeToLayout, isNarrowDesktop, serverSnapshot)
   const progress = duration > 0 ? Math.min(100, Math.max(0, (currentTime / duration) * 100)) : 0
 
   const clamp = (time: number) => Math.min(duration, Math.max(0, time))
@@ -105,6 +118,23 @@ export default function CompactPlaybackBar({
     event.preventDefault()
     onSeek(clamp(next()))
   }
+
+  const seekControl = (
+    <div
+      className="compact-playback-seek h-2 min-w-0 flex-1 cursor-pointer rounded-full bg-gray-200 hover:bg-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+      onClick={handleSeek}
+      onKeyDown={handleSeekKey}
+      role="slider"
+      tabIndex={0}
+      aria-label="재생 위치"
+      aria-valuemin={0}
+      aria-valuemax={Math.round(duration)}
+      aria-valuenow={Math.round(currentTime)}
+      aria-valuetext={`${formatTime(currentTime)} / ${formatTime(duration)}`}
+    >
+      <div className="h-2 rounded-full bg-blue-600" style={{ width: `${progress}%` }} />
+    </div>
+  )
 
   return (
     <div
@@ -151,20 +181,7 @@ export default function CompactPlaybackBar({
         {formatTime(currentTime)} / {formatTime(duration)}
       </span>
 
-      <div
-        className="compact-playback-seek h-2 min-w-0 flex-1 cursor-pointer rounded-full bg-gray-200 hover:bg-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
-        onClick={handleSeek}
-        onKeyDown={handleSeekKey}
-        role="slider"
-        tabIndex={0}
-        aria-label="재생 위치"
-        aria-valuemin={0}
-        aria-valuemax={Math.round(duration)}
-        aria-valuenow={Math.round(currentTime)}
-        aria-valuetext={`${formatTime(currentTime)} / ${formatTime(duration)}`}
-      >
-        <div className="h-2 rounded-full bg-blue-600" style={{ width: `${progress}%` }} />
-      </div>
+      {!narrowDesktop && seekControl}
 
       {/* Disabled while the samples load, exactly as the setup screen's speed
           control is. During playback this is always enabled — the status has
@@ -189,6 +206,7 @@ export default function CompactPlaybackBar({
           for choosing DEFAULT_MASTER_GAIN by ear during playback. */}
       <input
         type="range"
+        tabIndex={0}
         min={0}
         max={maxVolume}
         step={0.01}
@@ -200,6 +218,8 @@ export default function CompactPlaybackBar({
       <span className="hidden shrink-0 w-10 text-right text-xs font-mono tabular-nums text-ink-muted sm:inline">
         {volume.toFixed(2)}
       </span>
+      {/* DOM order follows the second seek row only in the matching layout. */}
+      {narrowDesktop && seekControl}
     </div>
   )
 }

--- a/src/components/playback/CompactPlaybackBar.tsx
+++ b/src/components/playback/CompactPlaybackBar.tsx
@@ -3,7 +3,7 @@
 import { Button } from '@/components/ui'
 
 /**
- * One-row transport for a screen that is being watched rather than set up.
+ * Compact transport for an active practice session.
  *
  * `PlaybackControls` stacks three rows and costs 152px, and the player adds an
  * instruction line, a sample-status line and a volume row on top of it — 264px
@@ -109,7 +109,7 @@ export default function CompactPlaybackBar({
   return (
     <div
       data-testid="compact-playback-bar"
-      className={`flex items-center gap-3 h-14 px-1 ${className}`}
+      className={`compact-playback-bar flex items-center gap-3 h-14 px-1 ${className}`}
     >
       {/* One slot, two states. A pause used to replace this bar with the
           three-row setup block, so resuming meant finding the transport
@@ -121,12 +121,12 @@ export default function CompactPlaybackBar({
         aria-label={isPlaying ? '일시정지' : '재생'}
         variant="outline"
         size="md"
-        className="h-10 w-10 shrink-0 p-0 !px-0 !py-0 text-lg leading-none"
+        className="compact-playback-transport h-10 w-10 shrink-0 p-0 !px-0 !py-0 text-lg leading-none"
       >
         {isPlaying ? '⏸️' : '▶️'}
       </Button>
       {onLoopStart && onLoopEnd && onLoopClear && (
-        <div className="flex shrink-0 gap-1" data-testid="compact-loop-controls">
+        <div className="compact-playback-loop flex shrink-0 gap-1" data-testid="compact-loop-controls">
           <Button type="button" onClick={onLoopStart} disabled={!isReady} variant="outline" size="sm" className="h-10 w-10 p-0 !px-0 !py-0 border-hand-left text-xs text-hand-left" title="구간 시작 A 설정" aria-label="구간 시작 A 설정">A</Button>
           <Button type="button" onClick={onLoopEnd} disabled={!isReady || loopStart === null} variant="outline" size="sm" className="h-10 w-10 p-0 !px-0 !py-0 border-hand-right text-xs text-hand-right" title="구간 끝 B 설정" aria-label="구간 끝 B 설정">B</Button>
           <Button type="button" onClick={onLoopClear} disabled={!isReady || loopStart === null} variant={loopEnd !== null ? 'primary' : 'ghost'} size="sm" className="h-10 w-10 p-0 !px-0 !py-0 text-xs" aria-label="A-B 구간 반복 초기화" title="A-B 구간 반복 초기화">↻</Button>
@@ -139,7 +139,7 @@ export default function CompactPlaybackBar({
         aria-label="정지"
         variant="outline"
         size="md"
-        className="h-10 w-10 shrink-0 p-0 text-lg leading-none"
+        className="compact-playback-stop h-10 w-10 shrink-0 p-0 text-lg leading-none"
       >
         ⏹️
       </Button>
@@ -152,7 +152,7 @@ export default function CompactPlaybackBar({
       </span>
 
       <div
-        className="h-2 min-w-0 flex-1 cursor-pointer rounded-full bg-gray-200 hover:bg-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+        className="compact-playback-seek h-2 min-w-0 flex-1 cursor-pointer rounded-full bg-gray-200 hover:bg-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
         onClick={handleSeek}
         onKeyDown={handleSeekKey}
         role="slider"
@@ -176,7 +176,7 @@ export default function CompactPlaybackBar({
         onChange={event => onSpeedChange(parseFloat(event.target.value))}
         disabled={!isReady}
         aria-label="재생 속도"
-        className="h-10 shrink-0 rounded-full border border-rule-strong bg-surface px-3 text-xs text-ink shadow-sm disabled:opacity-50"
+        className="compact-playback-speed h-10 shrink-0 rounded-full border border-rule-strong bg-surface px-3 text-xs text-ink shadow-sm disabled:opacity-50"
       >
         {SPEEDS.map(speed => (
           <option key={speed} value={speed}>
@@ -195,7 +195,7 @@ export default function CompactPlaybackBar({
         value={volume}
         onChange={event => onVolumeChange(parseFloat(event.target.value))}
         aria-label="음량 (master gain)"
-        className="w-20 shrink-0"
+        className="compact-playback-volume w-20 shrink-0"
       />
       <span className="hidden shrink-0 w-10 text-right text-xs font-mono tabular-nums text-ink-muted sm:inline">
         {volume.toFixed(2)}

--- a/src/components/playback/CompactPlaybackBar.tsx
+++ b/src/components/playback/CompactPlaybackBar.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useSyncExternalStore } from 'react'
+import { useCallback, useLayoutEffect, useRef, useSyncExternalStore } from 'react'
 import { Button } from '@/components/ui'
 
 /**
@@ -48,12 +48,6 @@ const NARROW_DESKTOP_QUERY = '(max-width: 639px) and (pointer: fine)'
 const isNarrowDesktop = () => typeof window !== 'undefined' &&
   typeof window.matchMedia === 'function' && window.matchMedia(NARROW_DESKTOP_QUERY).matches
 const serverSnapshot = () => false
-function subscribeToLayout(onChange: () => void) {
-  if (typeof window.matchMedia !== 'function') return () => {}
-  const query = window.matchMedia(NARROW_DESKTOP_QUERY)
-  query.addEventListener('change', onChange)
-  return () => query.removeEventListener('change', onChange)
-}
 
 const SPEEDS = [0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 2.0]
 const SEEK_STEP_SEC = 5
@@ -86,7 +80,24 @@ export default function CompactPlaybackBar({
   onLoopClear,
   className = '',
 }: CompactPlaybackBarProps) {
+  const seekRef = useRef<HTMLDivElement>(null)
+  const restoreSeekFocus = useRef(false)
+  const subscribeToLayout = useCallback((onChange: () => void) => {
+    if (typeof window.matchMedia !== 'function') return () => {}
+    const query = window.matchMedia(NARROW_DESKTOP_QUERY)
+    const handleChange = () => {
+      // Capture focus before React moves the control to its new reading order.
+      restoreSeekFocus.current = document.activeElement === seekRef.current
+      onChange()
+    }
+    query.addEventListener('change', handleChange)
+    return () => query.removeEventListener('change', handleChange)
+  }, [])
   const narrowDesktop = useSyncExternalStore(subscribeToLayout, isNarrowDesktop, serverSnapshot)
+  useLayoutEffect(() => {
+    if (restoreSeekFocus.current) seekRef.current?.focus({ preventScroll: true })
+    restoreSeekFocus.current = false
+  }, [narrowDesktop])
   const progress = duration > 0 ? Math.min(100, Math.max(0, (currentTime / duration) * 100)) : 0
 
   const clamp = (time: number) => Math.min(duration, Math.max(0, time))
@@ -121,6 +132,7 @@ export default function CompactPlaybackBar({
 
   const seekControl = (
     <div
+      ref={seekRef}
       className="compact-playback-seek h-2 min-w-0 flex-1 cursor-pointer rounded-full bg-gray-200 hover:bg-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
       onClick={handleSeek}
       onKeyDown={handleSeekKey}


### PR DESCRIPTION
At narrow desktop widths, compact controls left the seek target at zero width. Seeking now uses a second row below640px for fine-pointer devices, with DOM/Tab order matching the visible order. At320px, volume also moves down so speed remains usable: this smallest layout is64px high, while390px stays56px. Touch layout, session/audio logic and playback-box geometry remain unchanged.

Keyboard seeking retains focus across breakpoint changes. Tests also verify that speed and volume keep their DOM nodes and focus across both resize directions. Regression-first coverage caught zero-width seeking, Tab order,320px speed width and seek focus loss; the incorrect CI assumption of a zero-second pause was corrected explicitly.

Local final UI validation:65 E2E and995 Jest tests, typecheck, lint and production build pass. After incorporating approved PR153, combined-dependency Jest995/type/lint and30 transition cases pass. All hosted checks now pass, including both E2E jobs and both security gates. Review findings are fixed or rejected with executable evidence.

Coverage includes320/390/844/1280/1440 CSS pixels and200% CSS zoom; physical devices and native browser zoom remain unverified. Related to #146. Explore/upload refinements stay outside this slice. Rollback reverts the toolbar commits.
