### PR TITLE
Record the OMR-Q2 page/scale plan and its unpassed runtime gate

### DIFF
--- a/docs/recovery/phases/OMR-Q2-page-scale.md
+++ b/docs/recovery/phases/OMR-Q2-page-scale.md
@@ -1,0 +1,41 @@
+# OMR-Q2 — Prove page/scale recognition improvement before adopting a retry policy
+
+Status: `IN_PROGRESS`
+Depends on: Love Affair, Satie and Always real-API references; D-048/D-049 constraints
+
+## Objective
+
+Find and implement a bounded common recognition improvement for input/page/staff/measure loss. Do not
+replace an explicit conversion failure with a musically corrupted success or claim metadata repair as OMR repair.
+This work is independent of unmerged OMR-Q1 key metadata.
+
+## Experiments before policy
+
+1. Use the unchanged TruongCa PDF and explicitly select its visually verified music pages1–2 with the
+   pinned engine's supported `-sheets 1-2`. This is a diagnostic control, not an automatic page classifier.
+2. Keep everything else equal: baseline300dpi versus400dpi via verified ImageLoading.pdfResolution.
+   Capture engine exit/logs, page/staff/measure coverage, exported events and first3-bar source reference.
+3. Bound runs to one experimental JVM, timeout300s, existing3GB heap. Record cost; do not attempt600dpi
+   until lower-cost evidence and memory headroom justify it. Never modify persisted production constants.
+4. If a candidate improves reference events/coverage, test normal Love solo, Satie300dpi, Satie original
+   and Always controls. No warning-count-only selection, filename-specific logic, or hardcoded source notes.
+5. Investigate missing whole-note events separately in saved graphs versus XML before choosing a repair.
+
+## Runtime implementation gate
+
+Only after measured improvement, record a new decision before implementing source-aware page/scale
+selection and quality/fallback handling. Arbitrary coverage60% or target interline28–40 from a review are
+not accepted thresholds. No-staff detection alone does not prove a page has no music. A poor image must
+not be silently omitted. Retain the existing timeout, concurrency, original-output and source-finger safeguards.
+
+## Completion criteria
+
+- Actual same-source note/measure coverage improves with independently verified reference events.
+- Normal controls do not regress; no unsupported success is silently stored.
+- Source PDFs remain only user-local or bounded VM analysis copies; no source PDF enters Git.
+- Focused/full regression and VM/API checks support a ready PR. Explicit merge/rollout approvals apply.
+
+## Exclusions
+
+Nominal-duration padding/stretching (D-048), ungrounded fingering retuning (D-045), commercial OMR API
+integration, source PDF editing/re-encoding, existing stored-score migration or unrelated deployment changes.

--- a/docs/recovery/phases/OMR-Q2-page-scale.md
+++ b/docs/recovery/phases/OMR-Q2-page-scale.md
@@ -7,7 +7,7 @@ Depends on: Love Affair, Satie and Always real-API references; D-048/D-049 const
 
 Find and implement a bounded common recognition improvement for input/page/staff/measure loss. Do not
 replace an explicit conversion failure with a musically corrupted success or claim metadata repair as OMR repair.
-This work is independent of unmerged OMR-Q1 key metadata.
+This work is independent of OMR-Q1 key metadata, which reached `DONE` in main after this plan was drafted.
 
 ## Experiments before policy
 
@@ -34,6 +34,18 @@ not be silently omitted. Retain the existing timeout, concurrency, original-outp
 - Normal controls do not regress; no unsupported success is silently stored.
 - Source PDFs remain only user-local or bounded VM analysis copies; no source PDF enters Git.
 - Focused/full regression and VM/API checks support a ready PR. Explicit merge/rollout approvals apply.
+
+## Progress
+
+- 2026-09-06: Experiment1 ran on the unchanged TruongCa music pages1-2. Selected300dpi produced37 notes
+  and0 of41 opening reference matches; 400dpi produced441 notes and41 of41, with per-page staff coverage
+  4->10 and raw measure stacks4/5->15/16. Cost rose45.909s->98.242s. This is measured XML improvement on
+  one source, not a global400dpi policy.
+- 2026-09-06: 400dpi still omits the final printed measure31 and exports no whole-note types. A preliminary
+  independent page probe separates the text credit page but undercounts Always staves and fails Satie bbox
+  parsing, so it is not production-ready. Evidence: [page/scale experiments](../validation/2026-09-06-page-scale-experiments.md).
+- The runtime implementation gate below has NOT been passed. No400dpi or page-filter policy was deployed and
+  production recognition constants are unchanged. Normal-control and fallback validation remain outstanding.
 
 ## Exclusions
 


### PR DESCRIPTION
## 목적

`docs/recovery/phases/OMR-Q2-page-scale.md`(페이지·해상도 인식 실험 계획과 런타임 구현 gate)를 `main`에 반영한다. 이 문서는 2026-09-06에 작성된 뒤 이 브랜치에만 남아 있었고, PR이 한 번도 열리지 않았다.

## 왜 지금 필요한가

실험 **근거**는 이미 `main`에 있다 — `docs/recovery/validation/2026-09-06-page-scale-experiments.md`는 검증 기록이라 AGENTS.md의 직접 커밋 예외로 반영됐다. 반면 **계획과 승인 경계**를 담은 phase 문서는 `Objective`·`Work stages`를 정의하므로 그 예외에 해당하지 않아 리뷰가 필요하고, 그래서 브랜치에 갇혔다.

결과적으로 `main`만 읽는 세션은 "300dpi 37음 / 400dpi 441음, 41개 기준 이벤트 전부 일치"라는 **숫자만** 보고, 그 숫자가 무엇을 허가하지 **않는지**는 볼 수 없다. 이 PR은 그 경계를 숫자 옆에 되돌려 놓는다.

## 변경 내용 (문서 1건)

- `Status: IN_PROGRESS` 유지 — 실험 1은 수행됐고 런타임 gate는 통과하지 않았다.
- **낡은 서술 정정:** "independent of unmerged OMR-Q1"이라고 쓰여 있었으나 OMR-Q1은 현재 `main`에서 `DONE`이다.
- **`Progress` 절 신설:** 실측된 300/400dpi 결과, 남은 결함(최종 31마디 누락, whole-note 타입 미출력, 페이지 probe의 Always staff 과소 계수·Satie bbox 파싱 실패), 그리고 **gate 미통과** 사실을 명시.

## 검증

- `main` `49cdc49`로 rebase, 충돌 없음. 변경 파일은 phase 문서 1건뿐 (`git diff --stat`으로 확인).
- 참조한 검증 기록이 `main`에 실재함을 확인.
- **실행하지 않은 것:** OMR 엔진 실행, 인식 측정, 배포. 기재된 수치는 기존 2026-09-06 검증 기록에서 전사한 것이다.

## 범위 경계

코드·설정·인식 상수 변경 0건. 400dpi 정책이나 페이지 필터를 배포하지 않으며, 이 PR 병합이 그 승인을 의미하지 않는다. `D-048` 타이밍 경계는 건드리지 않는다.

Related: #134