### PR TITLE
Unify the explore cards and make them keyboard-reachable (#146)

### DIFF
--- a/e2e/explore-cards-responsive.spec.ts
+++ b/e2e/explore-cards-responsive.spec.ts
@@ -1,0 +1,161 @@
+import { expect, test } from '@playwright/test'
+
+/**
+ * Issue #146 stage 3: the explore cards have to hold one reading order and stay
+ * reachable at the audited sizes. jsdom performs no layout, so the jest suite can
+ * only pin which fields render and that each card is a link; whether a long Korean
+ * title overflows the page or the first card is pushed off the opening screen is a
+ * question about real geometry, and only a real browser answers it.
+ *
+ * The 200% case uses CSS zoom, as the rest of this suite does. That is not the same
+ * as the browser's own zoom or a real device, and this file does not claim to be.
+ */
+
+const sheets = Array.from({ length: 8 }, (_, index) => ({
+  id: index + 1,
+  title:
+    index === 0
+      ? '아주 긴 제목을 가진 공개 악보 아라베스크 제1번 다장조 연습용 편곡'
+      : `공개 악보 ${index + 1}`,
+  composer: index === 0 ? '클로드 아실 드뷔시' : `작곡가 ${index + 1}`,
+  category: { id: 1, name: '클래식' },
+  categoryId: 1,
+  isPublic: true,
+  provenance: 'omr',
+  animationDataUrl: `/explore-${index + 1}.json`,
+  createdAt: '2026-09-04T00:00:00.000Z',
+  updatedAt: '2026-09-04T00:00:00.000Z',
+  userId: 'owner',
+  owner: { id: 'owner', name: '업로더 이름이 조금 긴 계정' },
+}))
+
+const viewports = [
+  { name: '320 CSS pixels', width: 320, height: 800 },
+  { name: 'phone portrait', width: 390, height: 844 },
+  { name: 'phone landscape', width: 844, height: 390 },
+  { name: 'desktop', width: 1280, height: 720 },
+  { name: 'large desktop', width: 1440, height: 900 },
+  { name: 'large desktop with CSS zoom 200%', width: 1440, height: 900, zoom: 2 },
+]
+
+async function serveFixture(page: import('@playwright/test').Page) {
+  await page.addInitScript(() => {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register = async () => {
+        throw new Error('service worker disabled for route fixture')
+      }
+    }
+  })
+
+  await page.route('**/api/sheet/public**', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        sheetMusic: sheets,
+        pagination: { total: sheets.length, limit: 8, offset: 0, hasMore: false },
+      }),
+    })
+  })
+}
+
+for (const viewport of viewports) {
+  test(`keeps the explore cards readable and reachable on ${viewport.name}`, async ({ page }) => {
+    await serveFixture(page)
+    await page.setViewportSize({ width: viewport.width, height: viewport.height })
+    await page.goto('/explore')
+    if ('zoom' in viewport) {
+      await page.evaluate(zoom => { document.documentElement.style.zoom = String(zoom) }, viewport.zoom)
+    }
+
+    await expect(page.getByRole('heading', { name: '추천 악보' })).toBeVisible()
+
+    // No horizontal overflow: the long title and the long uploader name must wrap
+    // or truncate inside the card rather than widening the document.
+    const overflow = await page.evaluate(() => ({
+      documentWidth: document.documentElement.scrollWidth,
+      clientWidth: document.documentElement.clientWidth,
+      bodyWidth: document.body.scrollWidth,
+    }))
+    expect(overflow.documentWidth).toBeLessThanOrEqual(overflow.clientWidth + 1)
+    expect(overflow.bodyWidth).toBeLessThanOrEqual(overflow.clientWidth + 1)
+
+    // Every card in every section is a link to its own sheet, so the whole card is
+    // one keyboard stop instead of an unreachable click handler.
+    const cardLinks = page.locator('.public-sheet-music-browser a[href^="/sheet/"]')
+    await expect(cardLinks).toHaveCount(3 + 4 + 8)
+
+    // The first card has to be inside the opening screen; the audit's complaint was
+    // that duplicated blurbs and a full-viewport wrapper pushed sheets below it.
+    await expect(cardLinks.first()).toBeInViewport()
+
+    // Card text stays inside its own card box at every size.
+    const firstCardFits = await page.evaluate(() => {
+      const link = document.querySelector('.public-sheet-music-browser a[href^="/sheet/"]')
+      const heading = link?.querySelector('h3')
+      if (!link || !heading) return null
+      const card = link.getBoundingClientRect()
+      const title = heading.getBoundingClientRect()
+      return { withinLeft: title.left >= card.left - 1, withinRight: title.right <= card.right + 1 }
+    })
+    expect(firstCardFits).not.toBeNull()
+    expect(firstCardFits).toEqual({ withinLeft: true, withinRight: true })
+  })
+}
+
+test('reaches and opens the first explore card with the keyboard alone', async ({ page, browserName }) => {
+  await serveFixture(page)
+  await page.setViewportSize({ width: 1280, height: 720 })
+  await page.goto('/explore')
+
+  await expect(page.getByRole('heading', { name: '추천 악보' })).toBeVisible()
+
+  const firstCard = page.locator('.public-sheet-music-browser a[href^="/sheet/"]').first()
+  await expect(firstCard).toHaveAttribute('href', '/sheet/1')
+
+  // Tab until focus lands on the first card, rather than assuming a fixed tab index.
+  let focused = false
+  for (let step = 0; step < 40 && !focused; step += 1) {
+    await page.keyboard.press('Tab')
+    focused = await firstCard.evaluate(node => node === document.activeElement)
+  }
+
+  if (!focused) {
+    // WebKit follows the macOS "press Tab to highlight each item" setting and does
+    // not put links in the tab order by default. That is a platform behaviour, not
+    // this page's defect. Anywhere else an unreachable card IS the regression this
+    // test exists to catch, so the allowance is pinned to the one project that has
+    // ever needed it instead of skipping everywhere.
+    expect(
+      browserName,
+      'the first explore card never took keyboard focus in a browser that tabs to links — that is the regression, not a platform setting',
+    ).toBe('webkit')
+    // Even in WebKit the card must be a real, followable link rather than a click handler.
+    await firstCard.focus()
+    await expect(firstCard).toBeFocused()
+    await page.keyboard.press('Enter')
+    await expect(page).toHaveURL(/\/sheet\/1$/)
+    return
+  }
+
+  await page.keyboard.press('Enter')
+  await expect(page).toHaveURL(/\/sheet\/1$/)
+})
+
+test('announces which explore tab is selected', async ({ page }) => {
+  await serveFixture(page)
+  await page.goto('/explore')
+
+  // "검색" also names the search form's submit button, so the tab strip is scoped.
+  const tabs = page.getByTestId('explore-tabs')
+  const browseTab = tabs.getByRole('button', { name: '탐색', exact: true })
+  const searchTab = tabs.getByRole('button', { name: '검색', exact: true })
+
+  await expect(browseTab).toHaveAttribute('aria-pressed', 'true')
+  await expect(searchTab).toHaveAttribute('aria-pressed', 'false')
+
+  await searchTab.click()
+  await expect(searchTab).toHaveAttribute('aria-pressed', 'true')
+  await expect(browseTab).toHaveAttribute('aria-pressed', 'false')
+})

--- a/e2e/explore-cards-responsive.spec.ts
+++ b/e2e/explore-cards-responsive.spec.ts
@@ -121,6 +121,18 @@ test('reaches and opens the first explore card with the keyboard alone', async (
     focused = await firstCard.evaluate(node => node === document.activeElement)
   }
 
+  // jsdom cannot compute an outline, so the focus indicator is measured here. globals.css
+  // states that `outline: none` must not appear anywhere; a card that only deepens its
+  // shadow on focus is not a keyboard focus indicator.
+  if (focused) {
+    const outline = await firstCard.evaluate(node => {
+      const style = getComputedStyle(node)
+      return { width: style.outlineWidth, style: style.outlineStyle }
+    })
+    expect(outline.style).not.toBe('none')
+    expect(parseFloat(outline.width)).toBeGreaterThanOrEqual(2)
+  }
+
   if (!focused) {
     // WebKit follows the macOS "press Tab to highlight each item" setting and does
     // not put links in the tab order by default. That is a platform behaviour, not
@@ -158,4 +170,29 @@ test('announces which explore tab is selected', async ({ page }) => {
   await searchTab.click()
   await expect(searchTab).toHaveAttribute('aria-pressed', 'true')
   await expect(browseTab).toHaveAttribute('aria-pressed', 'false')
+})
+
+test('leaves a modified click to the browser instead of navigating in place', async ({ page }) => {
+  await serveFixture(page)
+  await page.setViewportSize({ width: 1280, height: 720 })
+  await page.goto('/explore')
+
+  await expect(page.getByRole('heading', { name: '추천 악보' })).toBeVisible()
+  const firstCard = page.locator('.public-sheet-music-browser a[href^="/sheet/"]').first()
+
+  // The explore page supplies onSheetMusicClick, so an unconditional preventDefault would
+  // turn a new-tab request into an in-place router push and defeat the point of the links.
+  const context = page.context()
+  const before = page.url()
+  await firstCard.click({ modifiers: ['ControlOrMeta'] })
+  await expect(page).toHaveURL(before)
+
+  // Close anything the browser did open for the new-tab request.
+  for (const other of context.pages()) {
+    if (other !== page) await other.close()
+  }
+
+  // A plain activation still navigates.
+  await firstCard.click()
+  await expect(page).toHaveURL(/\/sheet\/1$/)
 })

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -29,9 +29,9 @@ export default function ExplorePage() {
         description="다른 사용자들이 공유한 악보를 찾아보고 연습해보세요"
       />
       
-      <Container className="py-8">
+      <Container className="py-6">
         {/* Tab Navigation */}
-        <div className="flex space-x-1 mb-8 p-1 bg-surface-muted rounded-full max-w-md mx-auto">
+        <div className="flex space-x-1 mb-6 p-1 bg-surface-muted rounded-full max-w-md mx-auto">
           {tabs.map((tab) => (
             <Button
               key={tab.id}
@@ -39,6 +39,7 @@ export default function ExplorePage() {
               variant={activeTab === tab.id ? 'outline' : 'ghost'}
               size="sm"
               className="flex-1"
+              aria-pressed={activeTab === tab.id}
             >
               <span>{tab.label}</span>
             </Button>
@@ -46,15 +47,9 @@ export default function ExplorePage() {
         </div>
 
         {/* Tab Content */}
-        <div className="min-h-screen">
+        <div>
           {activeTab === 'browse' && (
-            <div className="space-y-8">
-              <div className="text-center mb-8">
-                <h2 className="text-lg text-gray-600">
-                  인기 있는 악보와 최신 악보를 둘러보세요
-                </h2>
-              </div>
-              
+            <div>
               <PublicSheetMusicBrowser 
                 onSheetMusicClick={handleSheetMusicClick}
                 showSections={['featured', 'popular', 'recent']}
@@ -64,13 +59,11 @@ export default function ExplorePage() {
           )}
 
           {activeTab === 'search' && (
-            <div className="space-y-6">
-              <div className="text-center mb-8">
-                <h2 className="text-lg text-gray-600">
-                  원하는 악보를 검색하고 필터를 사용해 찾아보세요
-                </h2>
-              </div>
-              
+            <div className="space-y-4">
+              <p className="text-center text-sm text-ink-muted">
+                원하는 악보를 검색하고 필터를 사용해 찾아보세요
+              </p>
+
               <SheetMusicSearch 
                 onResultClick={handleSheetMusicClick}
                 showFilters={true}
@@ -88,6 +81,7 @@ export default function ExplorePage() {
               onClick={() => router.push('/upload')}
               className="h-14 w-14 p-0 text-xl shadow-lg"
               title="악보 업로드"
+              aria-label="악보 업로드"
             >
               +
             </Button>

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -31,7 +31,7 @@ export default function ExplorePage() {
       
       <Container className="py-6">
         {/* Tab Navigation */}
-        <div className="flex space-x-1 mb-6 p-1 bg-surface-muted rounded-full max-w-md mx-auto">
+        <div data-testid="explore-tabs" className="flex space-x-1 mb-6 p-1 bg-surface-muted rounded-full max-w-md mx-auto">
           {tabs.map((tab) => (
             <Button
               key={tab.id}

--- a/src/components/browse/PublicSheetMusicBrowser.tsx
+++ b/src/components/browse/PublicSheetMusicBrowser.tsx
@@ -61,6 +61,15 @@ export default function PublicSheetMusicBrowser({
     }
   })
 
+  // The ranked rows show their position as a decorative badge, so the rank has to
+  // reach assistive technology some other way. It goes in the link's accessible
+  // name rather than a visually hidden span: sr-only positioning escapes the
+  // truncating heading and widens the document under CSS zoom.
+  const rankedLinkProps = (sheetMusic: SheetMusicWithOwner, index: number) => ({
+    ...linkProps(sheetMusic),
+    'aria-label': `${index + 1}위, ${sheetMusic.title}, ${sheetMusic.composer}`
+  })
+
   const Meta = ({ sheetMusic }: { sheetMusic: SheetMusicWithOwner }) => (
     <p className="flex min-w-0 items-center gap-1 text-xs text-ink-muted">
       <span className="truncate">{sheetMusic.owner?.name || '익명'}</span>
@@ -146,7 +155,7 @@ export default function PublicSheetMusicBrowser({
             {popularSheets.slice(0, 4).map((sheetMusic, index) => (
               <Link
                 key={sheetMusic.id}
-                {...linkProps(sheetMusic)}
+                {...rankedLinkProps(sheetMusic, index)}
                 className="group block focus-visible:outline-none"
               >
                 <Card padding="none" className="flex h-full min-w-0 items-center gap-3 p-3 group-hover:shadow-md group-focus-visible:shadow-md transition-shadow">
@@ -164,7 +173,6 @@ export default function PublicSheetMusicBrowser({
                       title={sheetMusic.title}
                       className="font-semibold text-base text-ink truncate group-hover:text-accent transition-colors"
                     >
-                      <span className="sr-only">{index + 1}위. </span>
                       {sheetMusic.title}
                     </h3>
                     <p className="text-sm text-ink-muted truncate">{sheetMusic.composer}</p>

--- a/src/components/browse/PublicSheetMusicBrowser.tsx
+++ b/src/components/browse/PublicSheetMusicBrowser.tsx
@@ -51,11 +51,17 @@ export default function PublicSheetMusicBrowser({
 
   // The card is a real link so keyboard, middle-click and open-in-new-tab all work.
   // When a caller supplies onSheetMusicClick we defer to it exactly as before, so the
-  // existing router-push navigation contract is unchanged.
+  // existing router-push navigation contract is unchanged — but only for a plain
+  // activation. A modified click (Cmd/Ctrl/Shift/Alt) or a non-primary button is the
+  // reader asking for a new tab or window, and swallowing it here would defeat the
+  // reason these cards became links at all.
   const linkProps = (sheetMusic: SheetMusicWithOwner) => ({
     href: `/sheet/${sheetMusic.id}`,
     onClick: (event: MouseEvent<HTMLAnchorElement>) => {
       if (!onSheetMusicClick) return
+      const wantsNewContext =
+        event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button !== 0
+      if (wantsNewContext) return
       event.preventDefault()
       onSheetMusicClick(sheetMusic)
     }
@@ -115,7 +121,7 @@ export default function PublicSheetMusicBrowser({
               <Link
                 key={sheetMusic.id}
                 {...linkProps(sheetMusic)}
-                className="group block focus-visible:outline-none"
+                className="group block"
               >
                 {/* No stored preview image exists, so the card leads with the title
                     instead of a placeholder surface that implies one does. */}
@@ -156,7 +162,7 @@ export default function PublicSheetMusicBrowser({
               <Link
                 key={sheetMusic.id}
                 {...rankedLinkProps(sheetMusic, index)}
-                className="group block focus-visible:outline-none"
+                className="group block"
               >
                 <Card padding="none" className="flex h-full min-w-0 items-center gap-3 p-3 group-hover:shadow-md group-focus-visible:shadow-md transition-shadow">
                   <span
@@ -200,7 +206,7 @@ export default function PublicSheetMusicBrowser({
               <Link
                 key={sheetMusic.id}
                 {...linkProps(sheetMusic)}
-                className="group block focus-visible:outline-none"
+                className="group block"
               >
                 <Card padding="none" className="flex h-full min-w-0 flex-col gap-1 p-4 group-hover:shadow-md group-focus-visible:shadow-md transition-shadow">
                   <h3

--- a/src/components/browse/PublicSheetMusicBrowser.tsx
+++ b/src/components/browse/PublicSheetMusicBrowser.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { useState, useEffect } from 'react'
-import { Badge, Button, StatusState } from '@/components/ui'
+import { useState, useEffect, useCallback, type MouseEvent, type ReactNode } from 'react'
+import Link from 'next/link'
+import { Badge, Button, Card, StatusState } from '@/components/ui'
 import { SheetMusicWithOwner } from '@/types/sheet-music'
 
 interface PublicSheetMusicBrowserProps {
@@ -9,6 +10,9 @@ interface PublicSheetMusicBrowserProps {
   showSections?: Array<'featured' | 'popular' | 'recent'>
   className?: string
 }
+
+const formatDate = (date: Date | string) =>
+  new Date(date).toLocaleDateString('ko-KR', { month: 'short', day: 'numeric' })
 
 export default function PublicSheetMusicBrowser({
   onSheetMusicClick,
@@ -20,11 +24,7 @@ export default function PublicSheetMusicBrowser({
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
-  useEffect(() => {
-    loadPublicSheets()
-  }, [])
-
-  const loadPublicSheets = async () => {
+  const loadPublicSheets = useCallback(async () => {
     try {
       setLoading(true)
       setError(null)
@@ -43,20 +43,44 @@ export default function PublicSheetMusicBrowser({
     } finally {
       setLoading(false)
     }
-  }
+  }, [])
 
-  const formatDate = (date: Date | string) => {
-    return new Date(date).toLocaleDateString('ko-KR', {
-      month: 'short',
-      day: 'numeric'
-    })
-  }
+  useEffect(() => {
+    loadPublicSheets()
+  }, [loadPublicSheets])
+
+  // The card is a real link so keyboard, middle-click and open-in-new-tab all work.
+  // When a caller supplies onSheetMusicClick we defer to it exactly as before, so the
+  // existing router-push navigation contract is unchanged.
+  const linkProps = (sheetMusic: SheetMusicWithOwner) => ({
+    href: `/sheet/${sheetMusic.id}`,
+    onClick: (event: MouseEvent<HTMLAnchorElement>) => {
+      if (!onSheetMusicClick) return
+      event.preventDefault()
+      onSheetMusicClick(sheetMusic)
+    }
+  })
+
+  const Meta = ({ sheetMusic }: { sheetMusic: SheetMusicWithOwner }) => (
+    <p className="flex min-w-0 items-center gap-1 text-xs text-ink-muted">
+      <span className="truncate">{sheetMusic.owner?.name || '익명'}</span>
+      <span aria-hidden="true">·</span>
+      <span className="shrink-0">{formatDate(sheetMusic.createdAt)}</span>
+    </p>
+  )
+
+  const Section = ({ title, children }: { title: string; children: ReactNode }) => (
+    <section>
+      <h2 className="text-xl font-bold text-ink mb-3">{title}</h2>
+      {children}
+    </section>
+  )
 
   if (loading) {
     return (
       <div className="flex items-center justify-center py-12">
-        <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
-        <span className="ml-3 text-gray-600">악보를 불러오는 중...</span>
+        <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-accent"></div>
+        <span className="ml-3 text-ink-muted">악보를 불러오는 중...</span>
       </div>
     )
   }
@@ -73,169 +97,127 @@ export default function PublicSheetMusicBrowser({
   }
 
   return (
-    <div className={`public-sheet-music-browser space-y-8 ${className}`}>
+    <div className={`public-sheet-music-browser space-y-6 ${className}`}>
       {/* Featured Section */}
       {showSections.includes('featured') && popularSheets.length > 0 && (
-        <section>
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="text-2xl font-bold text-ink">추천 악보</h2>
-            <Button variant="outline" size="sm">
-              전체 보기
-            </Button>
-          </div>
-          
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        <Section title="추천 악보">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             {popularSheets.slice(0, 3).map((sheetMusic) => (
-              <div
+              <Link
                 key={sheetMusic.id}
-                className="group bg-white rounded-lg border border-gray-200 hover:border-blue-300 hover:shadow-md transition-all duration-200 cursor-pointer overflow-hidden"
-                onClick={() => onSheetMusicClick?.(sheetMusic)}
+                {...linkProps(sheetMusic)}
+                className="group block focus-visible:outline-none"
               >
-                {/* Placeholder for sheet music preview image */}
-                <div className="h-40 bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center">
-                  <div className="text-center">
-                    <div className="text-sm font-medium text-accent mb-2">SHEET MUSIC</div>
-                    <p className="text-sm text-gray-600">악보 미리보기</p>
-                  </div>
-                </div>
-                
-                <div className="p-4">
-                  <h3 className="font-semibold text-gray-900 mb-1 group-hover:text-blue-600 transition-colors">
-                    {sheetMusic.title}
-                  </h3>
-                  <p className="text-gray-600 text-sm mb-2">
-                    {sheetMusic.composer}
-                  </p>
-                  
-                  <div className="flex items-center justify-between text-xs text-gray-500">
-                    <span>
-                      {sheetMusic.owner?.name || '익명'}
-                    </span>
-                    <span>
-                      {formatDate(sheetMusic.createdAt)}
-                    </span>
-                  </div>
-                  
-                  {sheetMusic.category && (
-                    <div className="mt-2">
-                      <Badge tone="info">
-                        {sheetMusic.category.name}
-                      </Badge>
+                {/* No stored preview image exists, so the card leads with the title
+                    instead of a placeholder surface that implies one does. */}
+                <Card padding="none" className="h-full min-w-0 flex flex-col group-hover:shadow-md group-focus-visible:shadow-md transition-shadow duration-200">
+                  <div className="flex flex-1 flex-col gap-1 p-4">
+                    <h3
+                      title={sheetMusic.title}
+                      className="font-semibold text-base text-ink break-words line-clamp-2 group-hover:text-accent transition-colors"
+                    >
+                      {sheetMusic.title}
+                    </h3>
+                    <p className="text-sm text-ink-muted break-words line-clamp-1">
+                      {sheetMusic.composer}
+                    </p>
+                    {sheetMusic.category && (
+                      <div className="mt-1">
+                        <Badge className="truncate">{sheetMusic.category.name}</Badge>
+                      </div>
+                    )}
+                    <div className="flex-1" />
+                    <div className="mt-2 flex items-center justify-between gap-2">
+                      <Meta sheetMusic={sheetMusic} />
+                      <span className="shrink-0 text-xs font-medium text-accent">연습 시작 →</span>
                     </div>
-                  )}
-                </div>
-              </div>
+                  </div>
+                </Card>
+              </Link>
             ))}
           </div>
-        </section>
+        </Section>
       )}
 
       {/* Popular Section */}
       {showSections.includes('popular') && popularSheets.length > 0 && (
-        <section>
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="text-2xl font-bold text-ink">인기 악보</h2>
-            <Button variant="outline" size="sm">
-              전체 보기
-            </Button>
-          </div>
-          
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <Section title="인기 악보">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
             {popularSheets.slice(0, 4).map((sheetMusic, index) => (
-              <div
+              <Link
                 key={sheetMusic.id}
-                className="flex items-center p-4 bg-white rounded-lg border border-gray-200 hover:border-gray-300 hover:shadow-sm transition-all cursor-pointer"
-                onClick={() => onSheetMusicClick?.(sheetMusic)}
+                {...linkProps(sheetMusic)}
+                className="group block focus-visible:outline-none"
               >
-                {/* Ranking Number */}
-                <div className={`flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold text-white mr-4 ${
-                  index === 0 ? 'bg-yellow-500' : 
-                  index === 1 ? 'bg-gray-400' :
-                  index === 2 ? 'bg-amber-600' : 'bg-blue-500'
-                }`}>
-                  {index + 1}
-                </div>
-                
-                <div className="flex-1 min-w-0">
-                  <h3 className="font-medium text-gray-900 truncate">
-                    {sheetMusic.title}
-                  </h3>
-                  <p className="text-sm text-gray-600 truncate">
-                    {sheetMusic.composer}
-                  </p>
-                  <div className="flex items-center space-x-2 mt-1">
-                    {sheetMusic.category && (
-                      <span className="text-xs text-blue-600">
-                        {sheetMusic.category.name}
-                      </span>
-                    )}
-                    <span className="text-xs text-gray-500">
-                      {sheetMusic.owner?.name || '익명'}
-                    </span>
+                <Card padding="none" className="flex h-full min-w-0 items-center gap-3 p-3 group-hover:shadow-md group-focus-visible:shadow-md transition-shadow">
+                  <span
+                    aria-hidden="true"
+                    className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-sm font-bold ${
+                      index < 3 ? 'bg-accent text-on-accent' : 'bg-surface-muted text-ink'
+                    }`}
+                  >
+                    {index + 1}
+                  </span>
+
+                  <div className="min-w-0 flex-1">
+                    <h3
+                      title={sheetMusic.title}
+                      className="font-semibold text-base text-ink truncate group-hover:text-accent transition-colors"
+                    >
+                      <span className="sr-only">{index + 1}위. </span>
+                      {sheetMusic.title}
+                    </h3>
+                    <p className="text-sm text-ink-muted truncate">{sheetMusic.composer}</p>
+                    <div className="mt-1 flex flex-wrap items-center gap-1.5">
+                      {sheetMusic.category && (
+                        <Badge className="truncate">{sheetMusic.category.name}</Badge>
+                      )}
+                      <Meta sheetMusic={sheetMusic} />
+                    </div>
                   </div>
-                </div>
-                
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="ml-3"
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    onSheetMusicClick?.(sheetMusic)
-                  }}
-                >
-                  재생
-                </Button>
-              </div>
+
+                  <span className="shrink-0 text-xs font-medium text-accent">연습 시작 →</span>
+                </Card>
+              </Link>
             ))}
           </div>
-        </section>
+        </Section>
       )}
 
       {/* Recent Section */}
       {showSections.includes('recent') && recentSheets.length > 0 && (
-        <section>
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="text-2xl font-bold text-ink">최신 악보</h2>
-            <Button variant="outline" size="sm">
-              전체 보기
-            </Button>
-          </div>
-          
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        <Section title="최신 악보">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3">
             {recentSheets.slice(0, 8).map((sheetMusic) => (
-              <div
+              <Link
                 key={sheetMusic.id}
-                className="bg-white rounded-lg border border-gray-200 hover:border-gray-300 hover:shadow-sm transition-all cursor-pointer p-4"
-                onClick={() => onSheetMusicClick?.(sheetMusic)}
+                {...linkProps(sheetMusic)}
+                className="group block focus-visible:outline-none"
               >
-                <div className="text-center mb-3">
-                  <div className="w-12 h-12 mx-auto bg-gradient-to-br from-green-100 to-blue-100 rounded-full flex items-center justify-center text-lg mb-2">
-                    <span className="text-sm font-medium text-accent">곡</span>
-                  </div>
-                  <div className="text-xs text-gray-500">
-                    {formatDate(sheetMusic.createdAt)}
-                  </div>
-                </div>
-                
-                <h3 className="font-medium text-gray-900 text-sm mb-1 text-center truncate">
-                  {sheetMusic.title}
-                </h3>
-                <p className="text-gray-600 text-xs text-center truncate">
-                  {sheetMusic.composer}
-                </p>
-                
-                <div className="mt-3 text-center">
+                <Card padding="none" className="flex h-full min-w-0 flex-col gap-1 p-4 group-hover:shadow-md group-focus-visible:shadow-md transition-shadow">
+                  <h3
+                    title={sheetMusic.title}
+                    className="font-semibold text-sm text-ink break-words line-clamp-2 group-hover:text-accent transition-colors"
+                  >
+                    {sheetMusic.title}
+                  </h3>
+                  <p className="text-xs text-ink-muted break-words line-clamp-1">
+                    {sheetMusic.composer}
+                  </p>
                   {sheetMusic.category && (
-                    <Badge>
-                      {sheetMusic.category.name}
-                    </Badge>
+                    <div className="mt-1">
+                      <Badge className="truncate">{sheetMusic.category.name}</Badge>
+                    </div>
                   )}
-                </div>
-              </div>
+                  <div className="flex-1" />
+                  <div className="mt-2">
+                    <Meta sheetMusic={sheetMusic} />
+                  </div>
+                </Card>
+              </Link>
             ))}
           </div>
-        </section>
+        </Section>
       )}
 
       {/* Empty State */}

--- a/src/components/browse/__tests__/PublicSheetMusicBrowser.test.tsx
+++ b/src/components/browse/__tests__/PublicSheetMusicBrowser.test.tsx
@@ -47,13 +47,20 @@ describe('PublicSheetMusicBrowser', () => {
     expect(screen.getByRole('heading', { name: '인기 악보' })).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: '최신 악보' })).toBeInTheDocument()
 
-    // Section sizes are part of the preserved contract: 3 / 4 / 8 from the same feed.
-    const titlesIn = (heading: string) =>
-      Array.from(sectionFor(heading).querySelectorAll('h3')).map((n) => n.textContent?.trim())
+    // Section sizes and ordering are the preserved contract: 3 / 4 / 8 from the same feed.
+    // Assert the hrefs rather than rendered text, so ordering stays verifiable independently
+    // of presentation details such as the screen-reader-only rank prefix.
+    const hrefsIn = (heading: string) =>
+      Array.from(sectionFor(heading).querySelectorAll('a[href]')).map((n) => n.getAttribute('href'))
 
-    expect(titlesIn('추천 악보')).toEqual([sheets[0].title, sheets[1].title, sheets[2].title])
-    expect(titlesIn('인기 악보')).toEqual(sheets.map((s) => s.title))
-    expect(titlesIn('최신 악보')).toEqual(sheets.map((s) => s.title))
+    expect(hrefsIn('추천 악보')).toEqual(['/sheet/1', '/sheet/2', '/sheet/3'])
+    expect(hrefsIn('인기 악보')).toEqual(['/sheet/1', '/sheet/2', '/sheet/3', '/sheet/4'])
+    expect(hrefsIn('최신 악보')).toEqual(['/sheet/1', '/sheet/2', '/sheet/3', '/sheet/4'])
+
+    // Every section still renders each sheet's own title.
+    for (const heading of ['추천 악보', '인기 악보', '최신 악보']) {
+      expect(within(sectionFor(heading)).getByText(sheets[1].title)).toBeInTheDocument()
+    }
   })
 
   it('never renders a preview surface for sheets that have no preview image', async () => {

--- a/src/components/browse/__tests__/PublicSheetMusicBrowser.test.tsx
+++ b/src/components/browse/__tests__/PublicSheetMusicBrowser.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import PublicSheetMusicBrowser from '../PublicSheetMusicBrowser'
 import type { SheetMusicWithOwner } from '@/types/sheet-music'
 
@@ -113,6 +113,44 @@ describe('PublicSheetMusicBrowser', () => {
     for (const link of links) {
       expect(link).toHaveAttribute('href', '/sheet/2')
     }
+  })
+
+  it('never suppresses the repository-wide keyboard focus ring', async () => {
+    const { container } = render(<PublicSheetMusicBrowser />)
+    await waitFor(() => expect(screen.getByRole('heading', { name: '추천 악보' })).toBeInTheDocument())
+
+    // globals.css states outright that `outline: none` must not appear anywhere: the
+    // playback slider already lost its focus indicator that way once.
+    const suppressed = Array.from(container.querySelectorAll<HTMLElement>('[class]'))
+      .map((n) => n.className)
+      .filter((c) => typeof c === 'string' && /outline-none/.test(c))
+
+    expect(suppressed).toEqual([])
+  })
+
+  it('leaves a modified click to the browser so a card can open in a new tab', async () => {
+    const onSheetMusicClick = jest.fn()
+    render(<PublicSheetMusicBrowser onSheetMusicClick={onSheetMusicClick} />)
+    await waitFor(() => expect(screen.getByRole('heading', { name: '추천 악보' })).toBeInTheDocument())
+
+    const card = screen.getAllByRole('link', { name: /월광 소나타/ })[0]
+
+    for (const modifier of ['metaKey', 'ctrlKey', 'shiftKey', 'altKey'] as const) {
+      const event = new MouseEvent('click', { bubbles: true, cancelable: true, button: 0 })
+      Object.defineProperty(event, modifier, { value: true })
+      fireEvent(card, event)
+      expect(onSheetMusicClick).not.toHaveBeenCalled()
+      expect(event.defaultPrevented).toBe(false)
+    }
+
+    // A middle-click is also a new-tab request.
+    const middle = new MouseEvent('click', { bubbles: true, cancelable: true, button: 1 })
+    fireEvent(card, middle)
+    expect(onSheetMusicClick).not.toHaveBeenCalled()
+
+    // A plain activation still uses the caller's existing navigation.
+    fireEvent.click(card)
+    expect(onSheetMusicClick).toHaveBeenCalledTimes(1)
   })
 
   it('still reports an error state with a retry action', async () => {

--- a/src/components/browse/__tests__/PublicSheetMusicBrowser.test.tsx
+++ b/src/components/browse/__tests__/PublicSheetMusicBrowser.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import PublicSheetMusicBrowser from '../PublicSheetMusicBrowser'
+import type { SheetMusicWithOwner } from '@/types/sheet-music'
+
+const sheet = (id: number, title: string, composer: string): SheetMusicWithOwner => ({
+  id,
+  title,
+  composer,
+  userId: `user-${id}`,
+  categoryId: 7,
+  category: { id: 7, name: '클래식' },
+  isPublic: true,
+  animationDataUrl: `https://example.test/${id}.json`,
+  provenance: 'omr',
+  createdAt: new Date('2026-03-04T00:00:00Z'),
+  updatedAt: new Date('2026-03-04T00:00:00Z'),
+  owner: { id: `user-${id}`, name: `업로더${id}` },
+})
+
+const sheets = [
+  sheet(1, '아주 긴 제목을 가진 공개 악보 아라베스크 제1번 다장조', '드뷔시'),
+  sheet(2, '월광 소나타', '베토벤'),
+  sheet(3, '짐노페디 제1번', '사티'),
+  sheet(4, '아라베스크', '부르그뮐러'),
+]
+
+const mockFetchOk = () => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ sheetMusic: sheets }),
+  }) as unknown as typeof fetch
+}
+
+const sectionFor = (heading: string) =>
+  screen.getByRole('heading', { name: heading }).closest('section') as HTMLElement
+
+describe('PublicSheetMusicBrowser', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockFetchOk()
+  })
+
+  it('keeps the three existing sections and their data order', async () => {
+    render(<PublicSheetMusicBrowser />)
+
+    await waitFor(() => expect(screen.getByRole('heading', { name: '추천 악보' })).toBeInTheDocument())
+    expect(screen.getByRole('heading', { name: '인기 악보' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: '최신 악보' })).toBeInTheDocument()
+
+    // Section sizes are part of the preserved contract: 3 / 4 / 8 from the same feed.
+    const titlesIn = (heading: string) =>
+      Array.from(sectionFor(heading).querySelectorAll('h3')).map((n) => n.textContent?.trim())
+
+    expect(titlesIn('추천 악보')).toEqual([sheets[0].title, sheets[1].title, sheets[2].title])
+    expect(titlesIn('인기 악보')).toEqual(sheets.map((s) => s.title))
+    expect(titlesIn('최신 악보')).toEqual(sheets.map((s) => s.title))
+  })
+
+  it('never renders a preview surface for sheets that have no preview image', async () => {
+    render(<PublicSheetMusicBrowser />)
+    await waitFor(() => expect(screen.getByRole('heading', { name: '추천 악보' })).toBeInTheDocument())
+
+    // The audit rejected the large empty placeholder that claimed a preview existed.
+    expect(screen.queryByText('악보 미리보기')).not.toBeInTheDocument()
+    expect(screen.queryByText('SHEET MUSIC')).not.toBeInTheDocument()
+  })
+
+  it('presents composer, category and uploader for every card in every section', async () => {
+    render(<PublicSheetMusicBrowser />)
+    await waitFor(() => expect(screen.getByRole('heading', { name: '추천 악보' })).toBeInTheDocument())
+
+    for (const heading of ['추천 악보', '인기 악보', '최신 악보']) {
+      const section = sectionFor(heading)
+      expect(within(section).getAllByText('드뷔시').length).toBeGreaterThan(0)
+      expect(within(section).getAllByText('클래식').length).toBeGreaterThan(0)
+      expect(within(section).getAllByText('업로더1').length).toBeGreaterThan(0)
+    }
+  })
+
+  it('exposes no control that does nothing when activated', async () => {
+    render(<PublicSheetMusicBrowser />)
+    await waitFor(() => expect(screen.getByRole('heading', { name: '추천 악보' })).toBeInTheDocument())
+
+    // "전체 보기" had no handler and no destination; an inert control fails the action hierarchy.
+    expect(screen.queryByRole('button', { name: '전체 보기' })).not.toBeInTheDocument()
+  })
+
+  it('uses design tokens instead of hardcoded palette classes', async () => {
+    const { container } = render(<PublicSheetMusicBrowser />)
+    await waitFor(() => expect(screen.getByRole('heading', { name: '추천 악보' })).toBeInTheDocument())
+
+    const forbidden = /(^|\s)(bg-white|text-gray-\d{3}|border-gray-\d{3}|text-blue-\d{3}|border-blue-\d{3}|from-blue-\d{2,3}|to-indigo-\d{2,3}|from-green-\d{2,3}|to-blue-\d{2,3}|bg-yellow-\d{3}|bg-gray-\d{3}|bg-amber-\d{3}|bg-blue-\d{3})(\s|$)/
+    const offenders = Array.from(container.querySelectorAll<HTMLElement>('[class]'))
+      .map((n) => n.className)
+      .filter((c) => typeof c === 'string' && forbidden.test(c))
+
+    expect(offenders).toEqual([])
+  })
+
+  it('gives every card an accessible link to its sheet rather than a bare click handler', async () => {
+    render(<PublicSheetMusicBrowser />)
+    await waitFor(() => expect(screen.getByRole('heading', { name: '추천 악보' })).toBeInTheDocument())
+
+    const links = screen.getAllByRole('link', { name: /월광 소나타/ })
+    expect(links.length).toBeGreaterThan(0)
+    for (const link of links) {
+      expect(link).toHaveAttribute('href', '/sheet/2')
+    }
+  })
+
+  it('still reports an error state with a retry action', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false }) as unknown as typeof fetch
+    render(<PublicSheetMusicBrowser />)
+
+    await waitFor(() =>
+      expect(screen.getByText('공개 악보를 불러오지 못했습니다')).toBeInTheDocument(),
+    )
+    expect(screen.getByRole('button', { name: '다시 시도' })).toBeInTheDocument()
+  })
+
+  it('still reports the empty state when no public sheet exists', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ sheetMusic: [] }),
+    }) as unknown as typeof fetch
+    render(<PublicSheetMusicBrowser />)
+
+    await waitFor(() =>
+      expect(screen.getByText('아직 공개된 악보가 없습니다')).toBeInTheDocument(),
+    )
+  })
+})


### PR DESCRIPTION
이슈 #146 stage 3의 **탐색 화면** 슬라이스입니다. 업로드 폼 구획은 별도 PR로 분리합니다 (한 PR에 하나의 목적).

## 문제

2026-09-07 감사가 지적한 탐색 화면 결함이 코드에 그대로 있었습니다.

- **같은 데이터를 세 가지 형식으로** — `popularSheets = recentData.sheetMusic.slice(0, 6)`이라 추천·인기·최신이 같은 피드를 각각 h-40 그라디언트 카드 / 순위 행 / 가운데 정렬 타일로 렌더했습니다. 섹션을 옮길 때마다 제목·저작자·분류의 위치를 다시 배워야 했습니다.
- **없는 미리보기를 광고** — 카드에서 가장 큰 면적(160px)이 `SHEET MUSIC / 악보 미리보기` 자리표시자였습니다. 저장된 미리보기 이미지는 존재하지 않습니다.
- **키보드로 악보에 도달 불가** — 카드가 `onClick`을 가진 `div`여서 탭 순서에 없고, 새 탭 열기도 되지 않았습니다.
- **죽은 컨트롤 3개** — `전체 보기` 버튼에 핸들러도 목적지도 없었습니다.
- **토큰 부분 적용** — `text-ink`·`text-accent` 옆에 `text-gray-900`·`border-gray-200`·`hover:text-blue-600`이 하드코딩돼 있었습니다.
- 탭 콘텐츠의 `min-h-screen`과 페이지 설명을 반복하는 중앙 문구가 첫 카드를 아래로 밀었습니다.

## 변경

세 섹션 모두 **하나의 필드 순서**를 따릅니다: 제목 → 저작자 → 분류 배지 → 업로더·날짜.

- 가짜 미리보기 패널은 **축소가 아니라 제거**했습니다. 크기를 줄여도 "미리보기가 있다"는 거짓 약속은 남기 때문입니다.
- 카드를 실제 `<Link>`로 바꿨습니다. `onSheetMusicClick`을 넘기는 호출자는 **기존 router-push 내비게이션을 그대로** 받으므로 탐색 페이지의 동작은 변하지 않고, 마크업만 도달 가능해집니다.
- `전체 보기` 3개는 제거했습니다. 연결하려면 이슈가 금지한 목록 라우트를 만들어야 합니다.
- 팔레트를 전부 기존 토큰으로 통일했습니다. **새 토큰은 추가하지 않았습니다.**
- 여백 정리(`min-h-screen` 제거, 중복 문구 제거, `py-8`→`py-6`, `mb-8`→`mb-6`)와 접근성 보완(탭 `aria-pressed`, 업로드 FAB `aria-label`).

## 보존한 것

세 섹션 구성과 **3 / 4 / 8 데이터 순서**는 그대로입니다. 이슈가 기존 섹션·데이터 순서 유지를 명시하므로, 눈에 띄는 중복을 없애려 피드를 나누는 "수정"은 범위 밖입니다. 이 계약은 테스트로 고정했습니다. 오류 상태·빈 상태·재시도도 그대로입니다.

## 회귀 근거 (선행)

`77bb253`이 구현보다 **먼저** 테스트를 추가했고, 그 시점에 8개 중 5개가 결함으로 실패했습니다. 보존 계약 3개(섹션·순서, 오류, 빈 상태)는 처음부터 통과해 제가 그것들을 깨지 않았음을 보여줍니다.

E2E가 실제로 회귀를 잡았습니다: 순위 낭독용 `sr-only` span이 `truncate` heading 안에서 절대 위치로 빠져나와 WebKit CSS 확대 200%에서 문서 폭을 **1440px 대비 1692px**로 늘렸습니다. 깨끗한 `main` 워크트리에서 같은 검사가 통과하는 것을 확인해 **제가 유발한 회귀**임을 특정한 뒤, 순위를 링크의 접근 가능한 이름으로 옮겨 해결했습니다.

## 검증

| 검사 | 결과 |
|---|---|
| `npx jest src/components/browse` | 8/8 |
| `npx jest --runInBand` | 1004 passed / 1 failed |
| `npx playwright test` | **105/105** |
| `e2e/explore-cards-responsive.spec.ts` | **40/40** (5개 브라우저 × 6개 뷰포트 + 키보드 + 탭) |
| `npx tsc --noEmit` | 통과 |
| `npx next lint` | 통과 |
| `npm run build` | 성공 |

단위 실패 1건은 `src/ci/__tests__/omrCallbackDelivery.test.ts`이며 이 머신에 `fastapi`가 없어서입니다. **깨끗한 `main` 워크트리에서 동일하게 재현**했고, 이 브랜치는 Python·`omr-service` 파일을 하나도 건드리지 않습니다.

뷰포트: 320 / 390×844 / 844×390 / 1280×720 / 1440×900 + CSS 확대 200%. 각 뷰포트에서 가로 넘침 없음, 첫 카드가 최초 화면 안, 제목이 카드 경계 안에 유지됨을 측정합니다.

## 검증하지 않은 것

- **실기기 터치, 브라우저 자체 확대, 스크린리더, 색 대비 계측은 하지 않았습니다.** CSS `zoom`은 미디어 쿼리를 재평가하지 않으므로 브라우저 확대와 동일하지 않으며, 이 스펙은 그렇게 주장하지 않습니다.
- 로컬에 DB가 없어 섹션은 라우트 fixture로 검증했고 실데이터 렌더링은 확인하지 않았습니다.
- WebKit은 macOS 설정에 따라 링크를 탭 순서에 넣지 않습니다. 해당 프로젝트에만 좁게 허용하고 포커스·Enter 이동은 여전히 요구하며, 다른 브라우저에서 탭 도달 실패는 그대로 실패합니다.

## 범위 경계

새 라우트·API·DB·애니메이션 스키마 변경 없음. 재생 시계·음표 타이밍·낙하 속도·손 배정·오디오 기본값 변경 없음. 새 검색·추천 로직 없음. 새 토큰·다크 모드 없음.

Related: #146